### PR TITLE
[Feat/BE] modify meeting API

### DIFF
--- a/geulnamu-backend/src/docs/asciidoc/meeting-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/meeting-api-guide.adoc
@@ -62,6 +62,25 @@ include::{snippets}/meeting/view/response-fields.adoc[]
 
 ---
 
+=== 운영진 목록 조회 - 필터링용
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/meeting/list/staff/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/meeting/list/staff/request-headers.adoc[]
+
+==== response
+include::{snippets}/meeting/list/staff/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/meeting/list/staff/response-fields.adoc[]
+
+==== Error case
+
+---
+
 === 모임 목록 조회
 접근 가능 권한 레벨: MEMBER
 
@@ -108,8 +127,8 @@ include::{snippets}/meeting/list/admin/response-fields.adoc[]
 
 == PATCH
 
-=== 모임 수정
-접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 미래 시간으로만 수정 가능
+=== 모임 수정 - 기본 정보
+접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)
 
 ==== request
 include::{snippets}/meeting/modify/http-request.adoc[]
@@ -128,6 +147,32 @@ include::{snippets}/meeting/modify/http-response.adoc[]
 
 ==== response-fields
 include::{snippets}/meeting/modify/response-fields.adoc[]
+
+==== Error case
+
+
+---
+
+=== 모임 수정 - 조별 활동 관련
+접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)
+
+==== request
+include::{snippets}/meeting/modify/discussion/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/meeting/modify/discussion/request-headers.adoc[]
+
+==== path-parameters
+include::{snippets}/meeting/modify/discussion/path-parameters.adoc[]
+
+==== request-fields
+include::{snippets}/meeting/modify/discussion/request-fields.adoc[]
+
+==== response
+include::{snippets}/meeting/modify/discussion/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/meeting/modify/discussion/response-fields.adoc[]
 
 ==== Error case
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -1,9 +1,11 @@
 package com.geulnamu.controller.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingCreateRequest;
+import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
+import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.domain.shared.enums.Role;
@@ -19,6 +21,8 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/meeting")
@@ -31,7 +35,7 @@ public class MeetingController {
     @PostMapping(name = "모임 생성")
     public BaseResponse<Void> createMeeting(@AuthMemberId Long memberId, @Valid @RequestBody MeetingCreateRequest request) {
         meetingService.createMeeting(memberId, request.getMeetingName(), request.getMeetingType(),
-            request.getMeetingDate(), request.getDescription());
+            request.getMeetingDate(), request.getMeetingPlace(), request.getDescription());
         return BaseResponse.ofSuccess();
     }
 
@@ -40,6 +44,13 @@ public class MeetingController {
     public BaseResponse<MeetingInfoResponse> findMeeting(@PathVariable @Min(value = 1) Long meetingId) {
         MeetingInfoResponse meetingInfoResponse = meetingService.findMeeting(meetingId);
         return BaseResponse.ofSuccess(meetingInfoResponse);
+    }
+
+    @AccessLevel(Level.MEMBER)
+    @GetMapping(value = "/list/staff", name = "운영진 목록 조회 - 필터링용")
+    public BaseResponse<List<StaffResponse>> getStaffList() {
+        List<StaffResponse> staffResponseList = meetingService.getStaffList();
+        return BaseResponse.ofSuccess(staffResponseList);
     }
 
     @AccessLevel(Level.MEMBER)
@@ -58,11 +69,20 @@ public class MeetingController {
 
     @LogAction(value = ActionType.MEETING_UPDATE, actionDomain = "meeting")
     @AccessLevel(Level.STAFF)
-    @PatchMapping(value = "/{meetingId}", name = "모임 수정")
+    @PatchMapping(value = "/{meetingId}", name = "모임 수정 - 기본 정보")
     public BaseResponse<Void> updateMeeting(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId,
                                             @AuthRole Role role, @Valid @RequestBody MeetingUpdateRequest request) {
-        meetingService.updateMeeting(meetingId, memberId, role, request.getMeetingName(), request.getMeetingType(),
-            request.getMeetingDate(), request.getDescription());
+        meetingService.updateMeeting(meetingId, memberId, request.getMeetingName(), request.getMeetingType(),
+            request.getMeetingDate(), request.getMeetingPlace(), request.getDescription());
+        return BaseResponse.ofSuccess();
+    }
+
+    @LogAction(value = ActionType.MEETING_UPDATE_DISCUSSION, actionDomain = "meeting")
+    @AccessLevel(Level.STAFF)
+    @PatchMapping(value = "/{meetingId}/discussion", name = "모임 수정 - 조별 활동 관련")
+    public BaseResponse<Void> updateMeetingForDiscussion(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId,
+                                                         @AuthRole Role role, @Valid @RequestBody MeetingGroupUpdateRequest request) {
+        meetingService.updateMeetingForDiscussion(meetingId, memberId, request.getDiscussionTime(), request.getAlarmMessage());
         return BaseResponse.ofSuccess();
     }
 
@@ -84,7 +104,7 @@ public class MeetingController {
     @AccessLevel(Level.STAFF)
     @DeleteMapping(value = "/{meetingId}", name = "개설한 모임 삭제 - 모임 시작 6시간 전까지만 가능")
     public BaseResponse<Void> removeMeeting(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId, @AuthRole Role role) {
-        meetingService.removeMeeting(meetingId, memberId, role);
+        meetingService.removeMeeting(meetingId, memberId);
         return BaseResponse.ofSuccess();
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -2,6 +2,7 @@ package com.geulnamu.controller.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingCreateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
+import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
@@ -14,7 +15,6 @@ import com.geulnamu.infrastructure.annotation.AuthMemberId;
 import com.geulnamu.infrastructure.annotation.AuthRole;
 import com.geulnamu.infrastructure.annotation.LogAction;
 import com.geulnamu.infrastructure.response.BaseResponse;
-import com.geulnamu.infrastructure.response.paging.PagingRequest;
 import com.geulnamu.service.meeting.MeetingService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
@@ -55,15 +55,15 @@ public class MeetingController {
 
     @AccessLevel(Level.MEMBER)
     @GetMapping(value = "/list", name = "모임 목록 조회")
-    public BaseResponse<MeetingListResponse> getMeetingList(@Valid PagingRequest pagingRequest) {
-        MeetingListResponse meetingListResponse = meetingService.getMeetingList(pagingRequest);
+    public BaseResponse<MeetingListResponse> getMeetingList(@Valid MeetingListRequest request) {
+        MeetingListResponse meetingListResponse = meetingService.getMeetingList(request);
         return BaseResponse.ofSuccess(meetingListResponse);
     }
 
     @AccessLevel(Level.ADMIN)
     @GetMapping(value = "/list/admin", name = "모임 목록 조회(관리자용)")
-    public BaseResponse<MeetingListResponse> getMeetingListForAdminLevel(@Valid PagingRequest pagingRequest) {
-        MeetingListResponse meetingListResponse = meetingService.getMeetingListForAdmin(pagingRequest);
+    public BaseResponse<MeetingListResponse> getMeetingListForAdminLevel(@Valid MeetingListRequest request) {
+        MeetingListResponse meetingListResponse = meetingService.getMeetingListForAdmin(request);
         return BaseResponse.ofSuccess(meetingListResponse);
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
@@ -29,7 +29,13 @@ public class MeetingCreateRequest {
     @JsonFormat(pattern = "yyyyMMdd HH:mm")
     private LocalDateTime meetingDate;    // 모임 개최일자
 
+    @NotNull(message = "모임 장소 필수 입력")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
+        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+    private String meetingPlace;
+
     private String description;    // 상세 내용
+
 
     public MeetingType getMeetingType() {
         return MeetingType.valueOf(meetingType);

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingGroupUpdateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingGroupUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.geulnamu.controller.meeting.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingGroupUpdateRequest {
+
+    @Future(message = "토론 시간은 미래의 시간이어야 합니다.")
+    @JsonFormat(pattern = "yyyyMMdd HH:mm")
+    private LocalDateTime discussionTime;
+
+    private String alarmMessage; // 모임 알람용 메세지 내용
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingListRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingListRequest.java
@@ -1,0 +1,53 @@
+package com.geulnamu.controller.meeting.dto.request;
+
+import com.geulnamu.domain.meeting.MeetingType;
+import com.geulnamu.infrastructure.response.paging.PagingRequest;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+
+public class MeetingListRequest extends PagingRequest {
+
+    @Pattern(regexp = "REGULAR|FLASH|SPECIAL", message = "모임 유형은 'REGULAR', 'FLASH', 'SPECIAL' 중 하나만 가능합니다.")
+    private final String meetingType;
+
+    @Getter
+    private final Long meetingCreatorId;
+
+    @Pattern(regexp = "true|false", message = "모임 비공개 여부 값은 'true' 또는 'false' 만 가능합니다.")
+    private final String isPrivate; // 관리자용 목록 조회에서만 사용되는 값
+
+//    @Getter
+//    @Pattern(regexp = "true|true_late|false", message = "본인 참석 여부 값은 'true', 'true_late', 'false' 중 하나만 가능합니다.")
+//    private final String isAttend; // 본인 참석 여부 (true는 지각한 것 포함해서 보여주고, true_late는 지각한 참석만 보여주기로 할 것)
+    // 일반 목록 조회에서만 사용되는 값
+
+    @Getter
+    @Pattern(regexp = "meetingDate|meetingId|createdAt", message = "정렬 기준 값은 'meetingDate', 'meetingId', 'createdAt' 중 하나만 가능합니다.")
+    private final String sortBy;
+
+    @Pattern(regexp = "true|false", message = "오름차순 여부 값은 'true' 또는 'false' 만 가능합니다.")
+    private final String isAsc;
+
+
+    public MeetingType getMeetingType() {
+        return meetingType != null ? MeetingType.valueOf(meetingType) : null;
+    }
+
+    public Boolean getIsPrivate() {
+        return isPrivate != null ? Boolean.valueOf(isPrivate) : null;
+    }
+
+    public Boolean getIsAsc() {
+        return isAsc != null ? Boolean.valueOf(isAsc) : null;
+    }
+
+    public MeetingListRequest(String meetingType, Long meetingCreatorId, String isPrivate,
+                              String sortBy, String isAsc, Integer page, Integer size) {
+        super(page, size);
+        this.meetingType = meetingType;
+        this.meetingCreatorId = meetingCreatorId;
+        this.isPrivate = isPrivate;
+        this.sortBy = sortBy;
+        this.isAsc = isAsc;
+    }
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
@@ -24,6 +24,10 @@ public class MeetingUpdateRequest {
     @JsonFormat(pattern = "yyyyMMdd HH:mm")
     private LocalDateTime meetingDate;    // 모임 개최일자
 
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
+        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+    private String meetingPlace;
+
     private String description;    // 상세 내용
 
     public MeetingType getMeetingType() {

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoResponse.java
@@ -18,15 +18,19 @@ public class MeetingInfoResponse {
     private String meetingName;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime meetingDateTime;
+    private String meetingPlace;
     private String description;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime discussionTime;
+    private String alarmMessage;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime createdAt;
     private Boolean isPrivateMeeting;
 
     public static MeetingInfoResponse of(Meeting meeting) {
-        return new MeetingInfoResponse(meeting.getId(), meeting.getMember().getName(),
-            meeting.getMeetingType(), meeting.getMeetingName(), meeting.getMeetingDate(),
-            meeting.getDescription(), meeting.getCreatedAt(), meeting.getPrivateAt() != null);
+        return new MeetingInfoResponse(meeting.getId(), meeting.getMember().getName(), meeting.getMeetingType(),
+            meeting.getMeetingName(), meeting.getMeetingDate(), meeting.getMeetingPlace(), meeting.getDescription(),
+            meeting.getDiscussionTime(), meeting.getAlarmMessage(), meeting.getCreatedAt(), meeting.getPrivateAt() != null);
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/StaffResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/StaffResponse.java
@@ -1,0 +1,13 @@
+package com.geulnamu.controller.meeting.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class StaffResponse {
+
+    private Long memberId;
+    private String memberName;
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/member/dto/request/MemberListRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/member/dto/request/MemberListRequest.java
@@ -24,6 +24,7 @@ public class MemberListRequest extends PagingRequest {
     @Pattern(regexp = "true|false", message = "오름차순 여부 값은 'true' 또는 'false' 만 가능합니다.")
     private final String isAsc;
 
+
     public Gender getGender() {
         return gender != null ? Gender.valueOf(gender) : null;
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
@@ -6,7 +6,6 @@ import com.geulnamu.domain.shared.DateColumn;
 import com.geulnamu.domain.shared.converter.MeetingTypeConverter;
 import com.geulnamu.infrastructure.exception.BadRequestException;
 import com.geulnamu.infrastructure.exception.ExistDataException;
-import com.geulnamu.infrastructure.exception.ForbiddenException;
 import com.geulnamu.infrastructure.response.ResponseMessage;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,17 +31,26 @@ public class Meeting extends DateColumn {
     private Member member;
 
     @Convert(converter = MeetingTypeConverter.class)
-    @Column(name = "meeting_type", length = 7)
+    @Column(name = "meeting_type", length = 7, nullable = false)
     private MeetingType meetingType;
 
-    @Column(name = "meeting_name", length = 70)
+    @Column(name = "meeting_name", length = 70, nullable = false)
     private String meetingName;
 
-    @Column(name = "meeting_date")
+    @Column(name = "meeting_date", nullable = false)
     private LocalDateTime meetingDate;
+
+    @Column(name = "meeting_place", nullable = false)
+    private String meetingPlace;
 
     @Column(name = "description")
     private String description;
+
+    @Column(name = "discussion_time")
+    private LocalDateTime discussionTime;
+
+    @Column(name = "alarm_message")
+    private String alarmMessage;
 
     @OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
     private List<MeetingAttendance> meetingAttendances;
@@ -51,14 +59,27 @@ public class Meeting extends DateColumn {
     private LocalDateTime privateAt;
 
 
-    public static Meeting createMeeting(Member member, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String description) {
+    public static Meeting createMeeting(Member member, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
         return Meeting.builder()
             .member(member)
             .meetingType(meetingType)
             .meetingName(meetingName)
             .meetingDate(meetingDate)
+            .meetingPlace(meetingPlace)
             .description(description)
             .build();
+    }
+
+    public void checkTimeCanUpdateMeeting() {
+        if(LocalDateTime.now().isAfter(this.meetingDate)) {
+            throw new BadRequestException(ResponseMessage.MEETING_INFO_UPDATE_TIME_RESTRICTION);
+        }
+    }
+
+    public void checkTimeCanUpdateMeetingForDiscussion() {
+        if(this.discussionTime != null && LocalDateTime.now().isAfter(this.discussionTime)) {
+            throw new BadRequestException(ResponseMessage.MEETING_DISCUSSION_INFO_UPDATE_TIME_RESTRICTION);
+        }
     }
 
     public void updateMeetingName(String meetingName) {
@@ -79,8 +100,33 @@ public class Meeting extends DateColumn {
         this.meetingDate = targetMeetingDate;
     }
 
+    public void updateMeetingPlace(String meetingPlace) {
+        if(this.meetingPlace.equals(meetingPlace)) {
+            throw new ExistDataException();
+        }
+        this.meetingPlace = meetingPlace;
+    }
+
     public void updateMeetingDescription(String description) {
         this.description = description;
+    }
+
+    public void updateDiscussionTime(LocalDateTime discussionTime) {
+        // 이전에 입력한 시간과 동일한지 확인
+        if(this.discussionTime != null && this.discussionTime.equals(discussionTime)) {
+            throw new ExistDataException();
+        }
+        // 토론 시간은 모임 일정의 날짜와 같은 날 안에서만 모임 이후로 가능
+        if(discussionTime != null && (!discussionTime.isAfter(this.meetingDate) ||
+            discussionTime.getYear() != this.meetingDate.getYear() ||
+            discussionTime.getDayOfYear() != this.meetingDate.getDayOfYear())) {
+            throw new BadRequestException(ResponseMessage.MEETING_DISCUSSION_TIME_RESTRICTION);
+        }
+        this.discussionTime = discussionTime;
+    }
+
+    public void updateAlarmMessage(String alarmMessage) {
+        this.alarmMessage = alarmMessage;
     }
 
     public void makeMeetingPrivate() {

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
@@ -17,6 +17,7 @@ public enum ActionType {
     // 모임 관리
     MEETING_CREATE("모임 생성"),
     MEETING_UPDATE("모임 수정"),
+    MEETING_UPDATE_DISCUSSION("모임 토론 정보 수정"),
     MEETING_DELETE("모임 삭제");
 
     private final String description;

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/RoleResolver.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/RoleResolver.java
@@ -1,6 +1,5 @@
 package com.geulnamu.infrastructure.config.security;
 
-import com.geulnamu.domain.shared.enums.Role;
 import com.geulnamu.infrastructure.annotation.AuthRole;
 import com.geulnamu.infrastructure.exception.TokenException;
 import com.geulnamu.infrastructure.response.ResponseMessage;

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -14,6 +14,9 @@ public class ResponseMessage {
 
     public static final String DATE_NOT_VALIDATE = "날짜값이 유효한 형식의 값이 아닙니다.";
 
+    public static final String MEETING_INFO_UPDATE_TIME_RESTRICTION = "모임이 이뤄진 이후에는 모임 개최 관련 정보를 수정할 수 없습니다.";
+    public static final String MEETING_DISCUSSION_INFO_UPDATE_TIME_RESTRICTION = "토론 활동이 시작된 이후에는 토론 관련 정보를 수정할 수 없습니다.";
+    public static final String MEETING_DISCUSSION_TIME_RESTRICTION = "토론 시간은 모임 당일 내에서만, 모임 시간 이후로 가능합니다.";
     public static final String MEETING_PRIVACY_TIME_RESTRICTION  = "모임이 이뤄진 당일까지는 비공개 처리할 수 없습니다.";
     public static final String MEETING_DELETION_TIME_EXPIRED = "모임 시작 6시간 전부터는 삭제할 수 없습니다.";
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -1,15 +1,15 @@
 package com.geulnamu.repository.meeting;
 
+import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface MeetingQueryRepositoryCustom {
     List<StaffResponse> findStaffList();
-    Page<MeetingInfoResponse> findMeetingsWithPaging(Pageable pageable);
-    Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(Pageable pageable);
+    Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request);
+    Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(MeetingListRequest request);
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -1,10 +1,14 @@
 package com.geulnamu.repository.meeting;
 
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
+import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface MeetingQueryRepositoryCustom {
+    List<StaffResponse> findStaffList();
     Page<MeetingInfoResponse> findMeetingsWithPaging(Pageable pageable);
     Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(Pageable pageable);
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -1,10 +1,16 @@
 package com.geulnamu.repository.meeting;
 
+import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.meeting.QMeeting;
 import com.geulnamu.domain.member.QMember;
+import com.geulnamu.infrastructure.util.QueryDslUtil;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,7 +33,8 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     public List<StaffResponse> findStaffList() {
         return queryFactory
             .select(Projections.constructor(StaffResponse.class,
-                member.id, member.name))
+                member.id, member.name)
+            )
             .from(meeting)
             .join(member).on(meeting.member.id.eq(member.id))
             .distinct()
@@ -35,21 +42,31 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     }
 
     @Override
-    public Page<MeetingInfoResponse> findMeetingsWithPaging(Pageable pageable) {
+    public Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request) {
+        Pageable pageable = request.toPageable();
+
         List<Long> count = queryFactory
             .select(meeting.count())
             .from(meeting)
-            .where(meeting.privateAt.isNull())
+            .where(meeting.privateAt.isNull(),
+                filterByMeetingType(request.getMeetingType()),
+                filterByMemberId(request.getMeetingCreatorId())
+            )
             .fetch();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
                 meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
-                meeting.createdAt, meeting.privateAt.isNotNull()))
+                meeting.createdAt, meeting.privateAt.isNotNull())
+            )
             .from(meeting)
-            .where(meeting.privateAt.isNull())
-            .orderBy(meeting.id.desc())
+            .where(meeting.privateAt.isNull(),
+                filterByMeetingType(request.getMeetingType()),
+                filterByMemberId(request.getMeetingCreatorId())
+            )
+            .orderBy(customSorting(request.getSortBy(), request.getIsAsc()),
+                meeting.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
@@ -58,24 +75,79 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     }
 
     @Override
-    public Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(Pageable pageable) {
+    public Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(MeetingListRequest request) {
+        Pageable pageable = request.toPageable();
+
         List<Long> count = queryFactory
             .select(meeting.count())
             .from(meeting)
+            .where(
+                filterByMeetingType(request.getMeetingType()),
+                filterByMemberId(request.getMeetingCreatorId()),
+                filterByIsPrivateOrNot(request.getIsPrivate())
+            )
             .fetch();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
                 meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
-                meeting.createdAt, meeting.privateAt.isNotNull()))
+                meeting.createdAt, meeting.privateAt.isNotNull())
+            )
             .from(meeting)
-            .orderBy(meeting.id.desc())
+            .where(
+                filterByMeetingType(request.getMeetingType()),
+                filterByMemberId(request.getMeetingCreatorId()),
+                filterByIsPrivateOrNot(request.getIsPrivate())
+            )
+            .orderBy(customSorting(request.getSortBy(), request.getIsAsc()),
+                meeting.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
 
         return PageableExecutionUtils.getPage(content, pageable, count::size);
+    }
+
+
+    BooleanExpression filterByMeetingType(MeetingType meetingType) {
+        if(meetingType == null) return meeting.meetingType.isNotNull();
+        return switch(meetingType) {
+            case REGULAR -> meeting.meetingType.eq(MeetingType.REGULAR);
+            case FLASH -> meeting.meetingType.eq(MeetingType.FLASH);
+            case SPECIAL -> meeting.meetingType.eq(MeetingType.SPECIAL);
+        };
+    }
+
+    BooleanExpression filterByMemberId(Long memberId) {
+        if(memberId == null) return meeting.member.id.isNotNull();
+        else return meeting.member.id.eq(memberId);
+    }
+
+    BooleanExpression filterByIsPrivateOrNot(Boolean isPrivate) {
+        if(isPrivate == null) return null;
+        else if(isPrivate.equals(false)) return meeting.privateAt.isNull();
+        else return meeting.privateAt.isNotNull();
+    }
+
+    // 기본 정렬 기준은 이름 오름차순, 다른 정렬 기준을 사용하더라도 2차 정렬 기준은 다시 이름 오름차순
+    OrderSpecifier<?> customSorting(String sortBy, Boolean isAsc) {
+        if(sortBy == null) return QueryDslUtil.getSortedColumn(Order.DESC, meeting, "id");
+        if(isAsc == null) isAsc = false;
+
+        return switch(sortBy) {
+            case "meetingDate" ->
+                (isAsc) ? QueryDslUtil.getSortedColumn(Order.ASC, meeting, "meetingDate")
+                    : QueryDslUtil.getSortedColumn(Order.DESC, meeting, "meetingDate");
+            case "meetingId" ->
+                (isAsc) ? QueryDslUtil.getSortedColumn(Order.ASC, meeting, "id")
+                    : QueryDslUtil.getSortedColumn(Order.DESC, meeting, "id");
+            case "createdAt" ->
+                (isAsc) ? QueryDslUtil.getSortedColumn(Order.ASC, meeting, "createdAt")
+                    : QueryDslUtil.getSortedColumn(Order.DESC, meeting, "createdAt");
+            default ->
+                QueryDslUtil.getSortedColumn(Order.DESC, meeting, "id");
+        };
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -1,9 +1,10 @@
 package com.geulnamu.repository.meeting;
 
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
+import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import com.geulnamu.domain.meeting.QMeeting;
+import com.geulnamu.domain.member.QMember;
 import com.querydsl.core.types.Projections;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,18 +20,33 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
 
     private final JPAQueryFactory queryFactory;
     private final QMeeting meeting = QMeeting.meeting;
+    private final QMember member = QMember.member;
+
+
+    @Override
+    public List<StaffResponse> findStaffList() {
+        return queryFactory
+            .select(Projections.constructor(StaffResponse.class,
+                member.id, member.name))
+            .from(meeting)
+            .join(member).on(meeting.member.id.eq(member.id))
+            .distinct()
+            .fetch();
+    }
 
     @Override
     public Page<MeetingInfoResponse> findMeetingsWithPaging(Pageable pageable) {
-        JPAQuery<Long> count = queryFactory
+        List<Long> count = queryFactory
             .select(meeting.count())
             .from(meeting)
-            .where(meeting.privateAt.isNull());
+            .where(meeting.privateAt.isNull())
+            .fetch();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
-                meeting.description, meeting.createdAt, meeting.privateAt.isNotNull()))
+                meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
+                meeting.createdAt, meeting.privateAt.isNotNull()))
             .from(meeting)
             .where(meeting.privateAt.isNull())
             .orderBy(meeting.id.desc())
@@ -38,25 +54,28 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable, count::size);
     }
 
     @Override
     public Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(Pageable pageable) {
-        JPAQuery<Long> count = queryFactory
+        List<Long> count = queryFactory
             .select(meeting.count())
-            .from(meeting);
+            .from(meeting)
+            .fetch();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
-                meeting.description, meeting.createdAt, meeting.privateAt.isNotNull()))
+                meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
+                meeting.createdAt, meeting.privateAt.isNotNull()))
             .from(meeting)
             .orderBy(meeting.id.desc())
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::fetchOne);
+        return PageableExecutionUtils.getPage(content, pageable, count::size);
     }
+
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -1,16 +1,15 @@
 package com.geulnamu.service.meeting;
 
+import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
 import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.member.Member;
-import com.geulnamu.domain.shared.enums.Role;
 import com.geulnamu.infrastructure.exception.BadRequestException;
 import com.geulnamu.infrastructure.exception.NotFoundDataException;
 import com.geulnamu.infrastructure.response.ResponseMessage;
-import com.geulnamu.infrastructure.response.paging.PagingRequest;
 import com.geulnamu.infrastructure.response.paging.PagingResponse;
 import com.geulnamu.repository.meeting.MeetingQueryRepository;
 import com.geulnamu.repository.meeting.MeetingCommandRepository;
@@ -18,7 +17,6 @@ import com.geulnamu.repository.member.MemberQueryRepository;
 import com.geulnamu.service.authorization.MeetingAuthorizationService;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,9 +52,8 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingListResponse getMeetingList(PagingRequest pagingRequest) {
-        Pageable pageable = pagingRequest.toPageable();
-        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(pageable);
+    public MeetingListResponse getMeetingList(MeetingListRequest request) {
+        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(request);
 
         PagingResponse pagingResponse = PagingResponse.from(meetingDslList);
         List<MeetingInfoResponse> meetingList = meetingDslList.getContent();
@@ -64,9 +61,8 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingListResponse getMeetingListForAdmin(PagingRequest pagingRequest) {
-        Pageable pageable = pagingRequest.toPageable();
-        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsForAdminWithPaging(pageable);
+    public MeetingListResponse getMeetingListForAdmin(MeetingListRequest request) {
+        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsForAdminWithPaging(request);
 
         PagingResponse pagingResponse = PagingResponse.from(meetingDslList);
         List<MeetingInfoResponse> meetingList = meetingDslList.getContent();

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -2,6 +2,7 @@ package com.geulnamu.service.meeting;
 
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
+import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.member.Member;
@@ -35,9 +36,9 @@ public class MeetingService {
 
 
     @Transactional(rollbackFor = Exception.class)
-    public void createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String description) {
+    public void createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
-        Meeting meeting = Meeting.createMeeting(member, meetingName, meetingType, meetingDate, description);
+        Meeting meeting = Meeting.createMeeting(member, meetingName, meetingType, meetingDate, meetingPlace, description);
         meetingCommandRepository.save(meeting);
     }
 
@@ -45,6 +46,11 @@ public class MeetingService {
     public MeetingInfoResponse findMeeting(Long meetingId) {
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         return MeetingInfoResponse.of(meeting);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StaffResponse> getStaffList() {
+        return meetingQueryRepository.findStaffList();
     }
 
     @Transactional(readOnly = true)
@@ -68,20 +74,46 @@ public class MeetingService {
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public void updateMeeting(Long meetingId, Long memberId, Role memberRole, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String description) {
-        // 모임 수정 가능 여부 권한 검사
+    public void updateMeeting(Long meetingId, Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
+        // 모임 정보 수정 가능 권한 검사
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
         authorizationService.validateModificationBy(meeting, member);
 
+        // 수정 가능 시간 확인(모임 시작 이후, 수정 불가) - 관리자급의 경우, 시간이 넘었더라도 수정 가능
+        if(!authorizationService.hasAdminPrivileges(member)) {
+            meeting.checkTimeCanUpdateMeeting();
+        }
+
         // 수정 필요 부분 적용
-        if(meetingName == null && meetingType == null && meetingDate == null && description == null) {
+        if(meetingName == null && meetingType == null && meetingDate == null && meetingPlace == null && description == null) {
             throw new BadRequestException(ResponseMessage.NO_CHANGE_DETECTED);
         }
         if(meetingName != null) meeting.updateMeetingName(meetingName);
         if(meetingType != null) meeting.updateMeetingType(meetingType);
         if(meetingDate != null) meeting.updateMeetingDate(meetingDate);
+        if(meetingPlace != null) meeting.updateMeetingPlace(meetingPlace);
         if(description != null) meeting.updateMeetingDescription(description);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void updateMeetingForDiscussion(Long meetingId, Long memberId, LocalDateTime discussionTime, String alarmMessage) {
+        // 모임 정보 수정 가능 권한 검사
+        Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
+        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+        authorizationService.validateModificationBy(meeting, member);
+
+        // 수정 가능 시간 확인(토론 시작 이후, 수정 불가) - 관리자급의 경우, 시간이 넘었더라도 수정 가능
+        if(!authorizationService.hasAdminPrivileges(member)) {
+            meeting.checkTimeCanUpdateMeetingForDiscussion();
+        }
+
+        // 수정 필요 부분 적용
+        if(discussionTime == null && alarmMessage == null) {
+            throw new BadRequestException(ResponseMessage.NO_CHANGE_DETECTED);
+        }
+        if(discussionTime != null) meeting.updateDiscussionTime(discussionTime);
+        if(alarmMessage != null) meeting.updateAlarmMessage(alarmMessage);
     }
 
     // 모임일 익일부터 비공개 처리 가능
@@ -100,7 +132,7 @@ public class MeetingService {
 
     // 모임 시작 6시간 전까지만 삭제 가능
     @Transactional(rollbackFor = Exception.class)
-    public void removeMeeting(Long meetingId, Long memberId, Role memberRole) {
+    public void removeMeeting(Long meetingId, Long memberId) {
         // 모임 삭제 가능 여부 검사
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 06:52:45 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 16:11:10 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 06:52:45 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 16:11:09 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
@@ -456,13 +456,15 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_get">GET</a>
 <ul class="sectlevel2">
 <li><a href="#_모임_단일_조회">모임 단일 조회</a></li>
+<li><a href="#_운영진_목록_조회_필터링용">운영진 목록 조회 - 필터링용</a></li>
 <li><a href="#_모임_목록_조회">모임 목록 조회</a></li>
 <li><a href="#_모임_목록_조회_관리자용">모임 목록 조회 (관리자용)</a></li>
 </ul>
 </li>
 <li><a href="#_patch">PATCH</a>
 <ul class="sectlevel2">
-<li><a href="#_모임_수정">모임 수정</a></li>
+<li><a href="#_모임_수정_기본_정보">모임 수정 - 기본 정보</a></li>
+<li><a href="#_모임_수정_조별_활동_관련">모임 수정 - 조별 활동 관련</a></li>
 <li><a href="#_지난_모임_비공개_처리">지난 모임 비공개 처리</a></li>
 <li><a href="#_비공개_모임_공개_처리">비공개 모임 공개 처리</a></li>
 </ul>
@@ -498,13 +500,14 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 163
+Content-Length: 233
 Host: docs.api.com
 
 {
   "meetingType" : "REGULAR",
   "meetingName" : "제 200회 정기모임",
   "meetingDate" : "21260614 10:30",
+  "meetingPlace" : "추후 공지 예정 (합정역 주변 카페)",
   "description" : "늦지 않게 오세요~"
 }</code></pre>
 </div>
@@ -571,6 +574,13 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
@@ -732,7 +742,10 @@ Content-Type: application/json;charset=UTF-8
     "meetingType" : "REGULAR",
     "meetingName" : "1회 정기모임",
     "meetingDateTime" : "2025.05.31 10:45",
+    "meetingPlace" : "추후 공지 예정 (합정역 주변 카페)",
     "description" : "~~",
+    "discussionTime" : "2025.05.31 12:00",
+    "alarmMessage" : null,
     "createdAt" : "2025.05.01 12:30",
     "isPrivateMeeting" : false
   }
@@ -810,11 +823,32 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.discussionTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.alarmMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시작 알림 메세지</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
@@ -839,7 +873,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_모임_목록_조회"><a class="link" href="#_모임_목록_조회">모임 목록 조회</a></h3>
+<h3 id="_운영진_목록_조회_필터링용"><a class="link" href="#_운영진_목록_조회_필터링용">운영진 목록 조회 - 필터링용</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -847,7 +881,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /meeting/list?page=1&amp;size=10 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /meeting/list/staff HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -857,6 +891,121 @@ Host: docs.api.com</code></pre>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_3"><a class="link" href="#_request_headers_3">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_3"><a class="link" href="#_response_3">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : [ {
+    "memberId" : 1,
+    "memberName" : "나뭉모임장"
+  }, {
+    "memberId" : 2,
+    "memberName" : "나순부모임장"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_3"><a class="link" href="#_response_fields_3">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설자 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_3"><a class="link" href="#_error_case_3">Error case</a></h4>
+<hr>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_모임_목록_조회"><a class="link" href="#_모임_목록_조회">모임 목록 조회</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: MEMBER</p>
+</div>
+<div class="sect3">
+<h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /meeting/list?meetingType=REGULAR&amp;meetingCreatorId=1&amp;page=1&amp;size=10 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_4"><a class="link" href="#_request_headers_4">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -897,253 +1046,19 @@ Host: docs.api.com</code></pre>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">사이즈</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_3"><a class="link" href="#_response_3">response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "code" : 200,
-  "message" : "API 호출에 성공했습니다.",
-  "data" : {
-    "pagingResponse" : {
-      "pageNumber" : 1,
-      "totalPages" : 3,
-      "totalElements" : 6
-    },
-    "meetingList" : [ {
-      "meetingId" : 1,
-      "meetingCreatorName" : "나뭉이",
-      "meetingType" : "REGULAR",
-      "meetingName" : "1회 정기모임",
-      "meetingDateTime" : "2025.05.31 10:45",
-      "description" : "~~",
-      "createdAt" : "2025.05.01 12:30",
-      "isPrivateMeeting" : false
-    }, {
-      "meetingId" : 2,
-      "meetingCreatorName" : "나뭉이",
-      "meetingType" : "FLASH",
-      "meetingName" : "금요 독서벙",
-      "meetingDateTime" : "2025.06.03 18:30",
-      "description" : "~~",
-      "createdAt" : "2025.05.01 12:31",
-      "isPrivateMeeting" : false
-    } ]
-  }
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_3"><a class="link" href="#_response_fields_3">response-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 정보</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.pageNumber</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.totalPages</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.totalElements</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전체 데이터 수</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[]</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">데이터 정보</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingCreatorName</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설자 이름</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingType</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 유형</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingName</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 제목</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingDateTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].description</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 종류</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].createdAt</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingCreatorId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설일자</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(운영진의) 모임원 고유번호</p></td>
 </tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].isPrivateMeeting</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비공개 여부</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_error_case_3"><a class="link" href="#_error_case_3">Error case</a></h4>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_모임_목록_조회_관리자용"><a class="link" href="#_모임_목록_조회_관리자용">모임 목록 조회 (관리자용)</a></h3>
-<div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
-</div>
-<div class="sect3">
-<h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /meeting/list/admin?page=1&amp;size=10 HTTP/2.0
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access_token
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_headers_4"><a class="link" href="#_request_headers_4">request-headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">query-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
@@ -1183,7 +1098,10 @@ Content-Type: application/json;charset=UTF-8
       "meetingType" : "REGULAR",
       "meetingName" : "1회 정기모임",
       "meetingDateTime" : "2025.05.31 10:45",
+      "meetingPlace" : "합정 빌리프커피로스터리스",
       "description" : "~~",
+      "discussionTime" : "2025.05.31 12:00",
+      "alarmMessage" : null,
       "createdAt" : "2025.05.01 12:30",
       "isPrivateMeeting" : false
     }, {
@@ -1192,8 +1110,11 @@ Content-Type: application/json;charset=UTF-8
       "meetingType" : "FLASH",
       "meetingName" : "금요 독서벙",
       "meetingDateTime" : "2025.06.03 18:30",
+      "meetingPlace" : "합정 저스티나",
       "description" : "~~",
-      "createdAt" : "2025.05.01 12:31",
+      "discussionTime" : "2025.05.01 12:31",
+      "alarmMessage" : null,
+      "createdAt" : "2025.05.01 12:30",
       "isPrivateMeeting" : false
     } ]
   }
@@ -1306,11 +1227,32 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].discussionTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].alarmMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시작 알림 메세지</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].createdAt</code></p></td>
@@ -1331,6 +1273,302 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div class="sect3">
 <h4 id="_error_case_4"><a class="link" href="#_error_case_4">Error case</a></h4>
+<hr>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_모임_목록_조회_관리자용"><a class="link" href="#_모임_목록_조회_관리자용">모임 목록 조회 (관리자용)</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN</p>
+</div>
+<div class="sect3">
+<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /meeting/list/admin?meetingType=REGULAR&amp;meetingCreatorId=1&amp;isPrivate=true&amp;page=1&amp;size=10 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 종류</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingCreatorId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">(운영진의) 모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>isPrivate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Boolean</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">'true', 'false' 중 하나의 값</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 비공개 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">사이즈</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : {
+    "pagingResponse" : {
+      "pageNumber" : 1,
+      "totalPages" : 3,
+      "totalElements" : 6
+    },
+    "meetingList" : [ {
+      "meetingId" : 1,
+      "meetingCreatorName" : "나뭉이",
+      "meetingType" : "REGULAR",
+      "meetingName" : "1회 정기모임",
+      "meetingDateTime" : "2025.05.31 10:45",
+      "meetingPlace" : "합정 빌리프커피로스터리스",
+      "description" : "~~",
+      "discussionTime" : "2025.05.31 12:00",
+      "alarmMessage" : null,
+      "createdAt" : "2025.05.01 12:30",
+      "isPrivateMeeting" : false
+    }, {
+      "meetingId" : 2,
+      "meetingCreatorName" : "나뭉이",
+      "meetingType" : "FLASH",
+      "meetingName" : "금요 독서벙",
+      "meetingDateTime" : "2025.06.03 18:30",
+      "meetingPlace" : "합정 저스티나",
+      "description" : "~~",
+      "discussionTime" : "2025.05.01 12:31",
+      "alarmMessage" : null,
+      "createdAt" : "2025.05.01 12:30",
+      "isPrivateMeeting" : false
+    } ]
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.pageNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.totalPages</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 페이지 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pagingResponse.totalElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 데이터 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">데이터 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingCreatorName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설자 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 유형</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].discussionTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].alarmMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시작 알림 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].isPrivateMeeting</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비공개 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_5"><a class="link" href="#_error_case_5">Error case</a></h4>
 
 </div>
 </div>
@@ -1340,32 +1578,33 @@ Content-Type: application/json;charset=UTF-8
 <h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_모임_수정"><a class="link" href="#_모임_수정">모임 수정</a></h3>
+<h3 id="_모임_수정_기본_정보"><a class="link" href="#_모임_수정_기본_정보">모임 수정 - 기본 정보</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 미래 시간으로만 수정 가능</p>
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)</p>
 </div>
 <div class="sect3">
-<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
+<h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 125
+Content-Length: 168
 Host: docs.api.com
 
 {
   "meetingType" : null,
   "meetingName" : null,
   "meetingDate" : null,
+  "meetingPlace" : "합정 저스티나",
   "description" : "늦지 않게 오세요~"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
+<h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1454,140 +1693,18 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>description</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">형식, 길이 제한 없는 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">상세 내용</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "code" : 200,
-  "message" : "API 호출에 성공했습니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">response-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_error_case_5"><a class="link" href="#_error_case_5">Error case</a></h4>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_지난_모임_비공개_처리"><a class="link" href="#_지난_모임_비공개_처리">지난 모임 비공개 처리</a></h3>
-<div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 모임 익일부터 처리 가능</p>
-</div>
-<div class="sect3">
-<h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1/private HTTP/2.0
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access_token
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">meetingId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -1657,19 +1774,25 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_비공개_모임_공개_처리"><a class="link" href="#_비공개_모임_공개_처리">비공개 모임 공개 처리</a></h3>
+<h3 id="_모임_수정_조별_활동_관련"><a class="link" href="#_모임_수정_조별_활동_관련">모임 수정 - 조별 활동 관련</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)</p>
 </div>
 <div class="sect3">
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1/public HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1/discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 93
+Host: docs.api.com
+
+{
+  "discussionTime" : "20260501 12:30",
+  "alarmMessage" : "모두 올라와주세요~"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1695,7 +1818,7 @@ Host: docs.api.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_4"><a class="link" href="#_path_parameters_4">path-parameters</a></h4>
+<h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1717,6 +1840,43 @@ Host: docs.api.com</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>discussionTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>alarmMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">형식제한 없는 최대 255자 이하의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시작 알림용 메세지</p></td>
 </tr>
 </tbody>
 </table>
@@ -1782,24 +1942,19 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div class="sect3">
 <h4 id="_error_case_7"><a class="link" href="#_error_case_7">Error case</a></h4>
-
+<hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_개설한_모임_삭제"><a class="link" href="#_개설한_모임_삭제">개설한 모임 삭제</a></h3>
+<h3 id="_지난_모임_비공개_처리"><a class="link" href="#_지난_모임_비공개_처리">지난 모임 비공개 처리</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 6시간 전까지만 가능</p>
+<p>접근 가능 권한 레벨: ADMIN / 모임 익일부터 처리 가능</p>
 </div>
 <div class="sect3">
 <h4 id="_request_8"><a class="link" href="#_request_8">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /meeting/1 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1/private HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1829,7 +1984,7 @@ Host: docs.api.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
+<h4 id="_path_parameters_4"><a class="link" href="#_path_parameters_4">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1919,13 +2074,276 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_비공개_모임_공개_처리"><a class="link" href="#_비공개_모임_공개_처리">비공개 모임 공개 처리</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN</p>
+</div>
+<div class="sect3">
+<h4 id="_request_9"><a class="link" href="#_request_9">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /meeting/1/public HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_9"><a class="link" href="#_request_headers_9">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">meetingId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_9"><a class="link" href="#_response_9">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_9"><a class="link" href="#_error_case_9">Error case</a></h4>
+
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_개설한_모임_삭제"><a class="link" href="#_개설한_모임_삭제">개설한 모임 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 6시간 전까지만 가능</p>
+</div>
+<div class="sect3">
+<h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /meeting/1 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_10"><a class="link" href="#_request_headers_10">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">meetingId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_10"><a class="link" href="#_response_10">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_10"><a class="link" href="#_error_case_10">Error case</a></h4>
+<hr>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-09 10:05:32 +0900
+Last updated 2025-06-19 19:30:27 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -226,6 +226,8 @@ public class MeetingControllerTest extends ControllerTest {
         ResultActions actions =
             mockMvc.perform(
                 get("/meeting/list")
+                    .param("meetingType", "REGULAR")
+                    .param("meetingCreatorId", "1")
                     .param("page", "1")
                     .param("size", "10")
                     .header("Authorization", accessToken)
@@ -246,6 +248,8 @@ public class MeetingControllerTest extends ControllerTest {
                     headerWithName("Authorization").description("액세스 토큰")
                 ),
                 queryParameters(
+                    parameterWithName("meetingType").attributes(key("type").value(JsonFieldType.STRING)).attributes(setAttributes("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
+                    parameterWithName("meetingCreatorId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("(운영진의) 모임원 고유번호").optional(),
                     parameterWithName("page").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("페이지"),
                     parameterWithName("size").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("사이즈")
                 ),
@@ -303,6 +307,9 @@ public class MeetingControllerTest extends ControllerTest {
         ResultActions actions =
             mockMvc.perform(
                 get("/meeting/list/admin")
+                    .param("meetingType", "REGULAR")
+                    .param("meetingCreatorId", "1")
+                    .param("isPrivate", "true")
                     .param("page", "1")
                     .param("size", "10")
                     .header("Authorization", accessToken)
@@ -323,6 +330,9 @@ public class MeetingControllerTest extends ControllerTest {
                     headerWithName("Authorization").description("액세스 토큰")
                 ),
                 queryParameters(
+                    parameterWithName("meetingType").attributes(key("type").value(JsonFieldType.STRING)).attributes(setAttributes("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
+                    parameterWithName("meetingCreatorId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("(운영진의) 모임원 고유번호").optional(),
+                    parameterWithName("isPrivate").attributes(key("type").value(JsonFieldType.BOOLEAN)).attributes(setAttributes("'true', 'false' 중 하나의 값")).description("모임 비공개 여부").optional(),
                     parameterWithName("page").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("페이지"),
                     parameterWithName("size").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("사이즈")
                 ),

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -1,9 +1,11 @@
 package com.geulnamu.controller.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingCreateRequest;
+import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
+import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import com.geulnamu.controller.shared.ControllerTest;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
@@ -51,9 +53,9 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
         MeetingCreateRequest request = new MeetingCreateRequest(
-            "REGULAR", "제 200회 정기모임", LocalDateTime.of(2126, 6, 14, 10, 30), "늦지 않게 오세요~");
+            "REGULAR", "제 200회 정기모임", LocalDateTime.of(2126, 6, 14, 10, 30), "추후 공지 예정 (합정역 주변 카페)", "늦지 않게 오세요~");
 
-        doNothing().when(meetingService).createMeeting(any(), any(), any(), any(), any());
+        doNothing().when(meetingService).createMeeting(any(), any(), any(), any(), any(), any());
 
         // when
         ResultActions actions =
@@ -82,6 +84,7 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류"),
                     fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목"),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자"),
+                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소"),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),
                 responseFields(
@@ -100,7 +103,9 @@ public class MeetingControllerTest extends ControllerTest {
 
         MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
             1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "~~", LocalDateTime.of(2025, 5, 1, 12, 30), false);
+            "추후 공지 예정 (합정역 주변 카페)", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30), false
+        );
 
         given(meetingService.findMeeting(any())).willReturn(meetingInfoResponse_01);
 
@@ -136,9 +141,56 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingType").type(JsonFieldType.STRING).description("모임 유형"),
                     fieldWithPath("data.meetingName").type(JsonFieldType.STRING).description("모임 제목"),
                     fieldWithPath("data.meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
+                    fieldWithPath("data.discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
+                    fieldWithPath("data.alarmMessage").type(JsonFieldType.STRING).description("토론 시작 알림 메세지").optional(),
                     fieldWithPath("data.createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자"),
                     fieldWithPath("data.isPrivateMeeting").type(JsonFieldType.BOOLEAN).description("비공개 여부")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void getStaffListTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        StaffResponse staffResponse_01 = new StaffResponse(1L, "나뭉모임장");
+        StaffResponse staffResponse_02 = new StaffResponse(2L, "나순부모임장");
+        List<StaffResponse> staffResponseList = new ArrayList<>();
+        staffResponseList.add(staffResponse_01);
+        staffResponseList.add(staffResponse_02);
+
+        given(meetingService.getStaffList()).willReturn(staffResponseList);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                get("/meeting/list/staff")
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/meeting/list/staff",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
+                    fieldWithPath("data[].memberName").type(JsonFieldType.STRING).description("모임 개설자 이름")
                 )
             ));
     }
@@ -151,10 +203,14 @@ public class MeetingControllerTest extends ControllerTest {
 
         MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
             1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "~~", LocalDateTime.of(2025, 5, 1, 12, 30), false);
+            "합정 빌리프커피로스터리스", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30), false
+        );
         MeetingInfoResponse meetingInfoResponse_02 = new MeetingInfoResponse(
             2L, "나뭉이", MeetingType.FLASH, "금요 독서벙", LocalDateTime.of(2025, 6, 3, 18, 30),
-            "~~", LocalDateTime.of(2025, 5, 1, 12, 31), false);
+            "합정 저스티나", "~~", LocalDateTime.of(2025, 5, 1, 12, 31), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30), false
+        );
         List<MeetingInfoResponse> meetingInfoResponseList = new ArrayList<>();
         meetingInfoResponseList.add(meetingInfoResponse_01);
         meetingInfoResponseList.add(meetingInfoResponse_02);
@@ -206,7 +262,10 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingList[].meetingType").type(JsonFieldType.STRING).description("모임 유형"),
                     fieldWithPath("data.meetingList[].meetingName").type(JsonFieldType.STRING).description("모임 제목"),
                     fieldWithPath("data.meetingList[].meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.meetingList[].meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.meetingList[].description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
+                    fieldWithPath("data.meetingList[].discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
+                    fieldWithPath("data.meetingList[].alarmMessage").type(JsonFieldType.STRING).description("토론 시작 알림 메세지").optional(),
                     fieldWithPath("data.meetingList[].createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자"),
                     fieldWithPath("data.meetingList[].isPrivateMeeting").type(JsonFieldType.BOOLEAN).description("비공개 여부")
                 )
@@ -221,10 +280,14 @@ public class MeetingControllerTest extends ControllerTest {
 
         MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
             1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "~~", LocalDateTime.of(2025, 5, 1, 12, 30), false);
+            "합정 빌리프커피로스터리스", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30), false
+        );
         MeetingInfoResponse meetingInfoResponse_02 = new MeetingInfoResponse(
             2L, "나뭉이", MeetingType.FLASH, "금요 독서벙", LocalDateTime.of(2025, 6, 3, 18, 30),
-            "~~", LocalDateTime.of(2025, 5, 1, 12, 31), false);
+            "합정 저스티나", "~~", LocalDateTime.of(2025, 5, 1, 12, 31), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30), false
+        );
         List<MeetingInfoResponse> meetingInfoResponseList = new ArrayList<>();
         meetingInfoResponseList.add(meetingInfoResponse_01);
         meetingInfoResponseList.add(meetingInfoResponse_02);
@@ -276,7 +339,10 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingList[].meetingType").type(JsonFieldType.STRING).description("모임 유형"),
                     fieldWithPath("data.meetingList[].meetingName").type(JsonFieldType.STRING).description("모임 제목"),
                     fieldWithPath("data.meetingList[].meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.meetingList[].meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.meetingList[].description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
+                    fieldWithPath("data.meetingList[].discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
+                    fieldWithPath("data.meetingList[].alarmMessage").type(JsonFieldType.STRING).description("토론 시작 알림 메세지").optional(),
                     fieldWithPath("data.meetingList[].createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자"),
                     fieldWithPath("data.meetingList[].isPrivateMeeting").type(JsonFieldType.BOOLEAN).description("비공개 여부")
                 )
@@ -289,7 +355,8 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
         MeetingUpdateRequest request = new MeetingUpdateRequest(
-            null, null, null, "늦지 않게 오세요~");
+            null, null, null, "합정 저스티나", "늦지 않게 오세요~"
+        );
 
         doNothing().when(meetingService).updateMeeting(any(), any(), any(), any(), any(), any(), any());
 
@@ -323,7 +390,57 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
                     fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목").optional(),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자").optional(),
+                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소").optional(),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "STAFF")
+    public void updateMeetingForDiscussionTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+        MeetingGroupUpdateRequest request = new MeetingGroupUpdateRequest(
+            LocalDateTime.of(2026, 5, 1, 12, 30), "모두 올라와주세요~"
+        );
+
+        doNothing().when(meetingService).updateMeetingForDiscussion(any(), any(), any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.patch("/meeting/{meetingId}/discussion", 1L)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "meeting/modify/discussion",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("meetingId").attributes(key("format").value("1 이상의 정수")).description("모임 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("discussionTime").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("토론 시간").optional(),
+                    fieldWithPath("alarmMessage").type(JsonFieldType.STRING).attributes(key("format").value("형식제한 없는 최대 255자 이하의 문자열")).description("토론 시작 알림용 메세지").optional()
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
@@ -421,7 +538,7 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
 
-        doNothing().when(meetingService).removeMeeting(any(), any(), any());
+        doNothing().when(meetingService).removeMeeting(any(), any());
 
         // when
         ResultActions actions =


### PR DESCRIPTION
## 변경 내역
### 모임 도메인 수정
- Meeting 엔티티 meetingPlace(모임 장소), discussionTime(토론 시간), alarmMessage(알림 메세지) 필드 추가
  - 관련 내용 DB 반영
  - 관련 내용 기존 API에 반영


### 기존 API 수정
- 모임 수정 기능 수정
  - 모임 시작 시간 지난 후에 모임 수정을 할 수 없도록 제한하는 기능 추가
- 모임 목록 조회 (관리자용 조회 포함) 기능 수정
  - 페이지네이션 및 소팅, 필터링 기능 추가 (관리자용과 일반용에서의 필터 가능 목록이 다르나 내부 구현으로 잘 못 처리되지 않도록 로직 설계함)


### API 추가
- 모임 개설 가능자 목록 조회 기능 구현
  - 모임 목록 조회시, filtering을 위한 가능 목록을 제공하기 위한 기능
- 토론을 위한 모임 정보 수정 기능 구현
  - 토론 관련 정보 (discussionTime, alarmMessage) 수정을 위한 기능 추가
  - 기존 모임 수정과 나눠서 따로 만든 이유는 두 개의 기능이 수정 가능 제한 시간이 다르기에 이를 위해 개별 API로 만듦


### 테스트 코드 및 API 문서 작성
- 수정 내역 및 추가 구현 사항 테스트 코드 작성 및 API 문서 반영