### PR TITLE
[Feat/BE] attendance domain api

### DIFF
--- a/geulnamu-backend/src/docs/asciidoc/_backup-template.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/_backup-template.adoc
@@ -27,14 +27,14 @@ endif::[]
 // ==== request
 // include::{snippets}/login/oauth/kakao/http-request.adoc[]
 
+// ==== path-parameters
+// include::{snippets}/login/oauth/kakao/path-parameters.adoc[]
+
 // ==== request-cookies
 // include::{snippets}/login/oauth/kakao/request-cookies.adoc[]
 
 // ==== request-headers
 // include::{snippets}/login/oauth/kakao/request-headers.adoc[]
-
-// ==== path-parameters
-// include::{snippets}/login/oauth/kakao/path-parameters.adoc[]
 
 // ==== query-parameters
 // include::{snippets}/login/oauth/kakao/query-parameters.adoc[]

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -40,29 +40,50 @@ include::{snippets}/attendance/create/response-fields.adoc[]
 
 == GET
 
-=== 출석 정보 조회
+=== 본인 출석 정보 조회
 접근 가능 권한 레벨: MEMBER
 
 ==== request
-include::{snippets}/attendance/view/http-request.adoc[]
+include::{snippets}/attendance/view/myInfo/http-request.adoc[]
 
 ==== path-parameters
-include::{snippets}/attendance/view/path-parameters.adoc[]
+include::{snippets}/attendance/view/myInfo/path-parameters.adoc[]
 
 ==== request-headers
-include::{snippets}/attendance/view/request-headers.adoc[]
+include::{snippets}/attendance/view/myInfo/request-headers.adoc[]
 
 ==== response
-include::{snippets}/attendance/view/http-response.adoc[]
+include::{snippets}/attendance/view/myInfo/http-response.adoc[]
 
 ==== response-fields
-include::{snippets}/attendance/view/response-fields.adoc[]
+include::{snippets}/attendance/view/myInfo/response-fields.adoc[]
+
+==== Error case
+
+---
+
+=== 모임별 참석 현황 조회
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/view/list/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/view/list/path-parameters.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/view/list/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/view/list/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/view/list/response-fields.adoc[]
 
 ==== Error case
 
 
 ---
-
 
 == PATCH
 

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -110,17 +110,39 @@ include::{snippets}/attendance/discussion/response-fields.adoc[]
 ==== request
 include::{snippets}/attendance/discussion/view/my-group/http-request.adoc[]
 
+==== path-parameters
+include::{snippets}/attendance/discussion/view/my-group/path-parameters.adoc[]
+
 ==== request-headers
 include::{snippets}/attendance/discussion/view/my-group/request-headers.adoc[]
-
-==== query-parameters
-include::{snippets}/attendance/discussion/view/my-group/query-parameters.adoc[]
 
 ==== response
 include::{snippets}/attendance/discussion/view/my-group/http-response.adoc[]
 
 ==== response-fields
 include::{snippets}/attendance/discussion/view/my-group/response-fields.adoc[]
+
+==== Error case
+
+---
+
+=== 전체 토론 그룹 명단 조회
+접근 가능 권한 레벨: STAFF
+
+==== request
+include::{snippets}/attendance/discussion/view/all-group/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/discussion/view/all-group/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/discussion/view/all-group/query-parameters.adoc[]
+
+==== response
+include::{snippets}/attendance/discussion/view/all-group/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/discussion/view/all-group/response-fields.adoc[]
 
 ==== Error case
 

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -1,0 +1,37 @@
+ifndef::snippets[]
+:snippets: ../../../build/generated-snippets
+endif::[]
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+// 코드 하이라이팅
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+
+[[title]]
+= Attendance API Guide
+
+== link:index.html[Index 페이지로 이동]
+
+== POST
+
+=== 모임 출석
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/create/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/create/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/create/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/create/response-fields.adoc[]
+
+==== Error case
+
+---

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -23,11 +23,11 @@ endif::[]
 ==== request
 include::{snippets}/attendance/create/http-request.adoc[]
 
-==== path-parameters
-include::{snippets}/attendance/create/path-parameters.adoc[]
-
 ==== request-headers
 include::{snippets}/attendance/create/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/create/query-parameters.adoc[]
 
 ==== response
 include::{snippets}/attendance/create/http-response.adoc[]
@@ -68,11 +68,11 @@ include::{snippets}/attendance/view/myInfo/response-fields.adoc[]
 ==== request
 include::{snippets}/attendance/view/list/http-request.adoc[]
 
-==== path-parameters
-include::{snippets}/attendance/view/list/path-parameters.adoc[]
-
 ==== request-headers
 include::{snippets}/attendance/view/list/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/view/list/query-parameters.adoc[]
 
 ==== response
 include::{snippets}/attendance/view/list/http-response.adoc[]
@@ -177,7 +177,7 @@ include::{snippets}/attendance/modify/want-discussion/response-fields.adoc[]
 ---
 
 === 토론 그룹 구성 - 수동
-접근 가능 권한 레벨: STAFF
+접근 가능 권한 레벨: STAFF / 로그 생성
 
 ==== request
 include::{snippets}/attendance/group/assign/http-request.adoc[]
@@ -203,7 +203,7 @@ include::{snippets}/attendance/group/assign/response-fields.adoc[]
 
 
 === 토론 그룹 할당 - 개인
-접근 가능 권한 레벨: ADMIN
+접근 가능 권한 레벨: ADMIN / 로그 생성
 
 ==== request
 include::{snippets}/attendance/group/assign/solo/http-request.adoc[]

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -23,6 +23,9 @@ endif::[]
 ==== request
 include::{snippets}/attendance/create/http-request.adoc[]
 
+==== path-parameters
+include::{snippets}/attendance/create/path-parameters.adoc[]
+
 ==== request-headers
 include::{snippets}/attendance/create/request-headers.adoc[]
 
@@ -36,6 +39,51 @@ include::{snippets}/attendance/create/response-fields.adoc[]
 
 ---
 
+== PATCH
+
+=== 독서만 할래요
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/modify/just-read/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/modify/just-read/path-parameters.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/modify/just-read/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/modify/just-read/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/modify/just-read/response-fields.adoc[]
+
+==== Error case
+
+---
+
+=== 토론할래요
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/modify/want-discussion/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/modify/want-discussion/path-parameters.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/modify/want-discussion/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/modify/want-discussion/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/modify/want-discussion/response-fields.adoc[]
+
+==== Error case
+
+---
 
 == DELETE
 
@@ -44,6 +92,9 @@ include::{snippets}/attendance/create/response-fields.adoc[]
 
 ==== request
 include::{snippets}/attendance/delete/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/delete/path-parameters.adoc[]
 
 ==== request-headers
 include::{snippets}/attendance/delete/request-headers.adoc[]

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -41,6 +41,31 @@ include::{snippets}/attendance/create/response-fields.adoc[]
 
 == PATCH
 
+=== 비고 작성
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/modify/note/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/modify/note/path-parameters.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/modify/note/request-headers.adoc[]
+
+==== request-fields
+include::{snippets}/attendance/modify/note/request-fields.adoc[]
+
+==== response
+include::{snippets}/attendance/modify/note/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/modify/note/response-fields.adoc[]
+
+==== Error case
+
+---
+
 === 독서만 할래요
 접근 가능 권한 레벨: MEMBER
 

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -102,8 +102,30 @@ include::{snippets}/attendance/discussion/response-fields.adoc[]
 
 ==== Error case
 
+---
+
+=== 본인 토론 그룹 명단 조회
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/discussion/view/my-group/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/discussion/view/my-group/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/discussion/view/my-group/query-parameters.adoc[]
+
+==== response
+include::{snippets}/attendance/discussion/view/my-group/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/discussion/view/my-group/response-fields.adoc[]
+
+==== Error case
 
 ---
+
 
 == PATCH
 

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -18,7 +18,7 @@ endif::[]
 == POST
 
 === 모임 출석
-접근 가능 권한 레벨: MEMBER
+접근 가능 권한 레벨: MEMBER / 로그 생성
 
 ==== request
 include::{snippets}/attendance/create/http-request.adoc[]
@@ -33,5 +33,28 @@ include::{snippets}/attendance/create/http-response.adoc[]
 include::{snippets}/attendance/create/response-fields.adoc[]
 
 ==== Error case
+
+---
+
+
+== DELETE
+
+=== 출석 삭제
+접근 가능 권한 레벨: ADMIN / 로그 생성
+
+==== request
+include::{snippets}/attendance/delete/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/delete/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/delete/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/delete/response-fields.adoc[]
+
+==== Error case
+
 
 ---

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -82,6 +82,26 @@ include::{snippets}/attendance/view/list/response-fields.adoc[]
 
 ==== Error case
 
+=== 모임 토론 참여 희망 명단 조회
+접근 가능 권한 레벨: STAFF
+
+==== request
+include::{snippets}/attendance/discussion/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/discussion/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/discussion/query-parameters.adoc[]
+
+==== response
+include::{snippets}/attendance/discussion/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/discussion/response-fields.adoc[]
+
+==== Error case
+
 
 ---
 
@@ -155,6 +175,55 @@ include::{snippets}/attendance/modify/want-discussion/response-fields.adoc[]
 ==== Error case
 
 ---
+
+=== 토론 그룹 구성 - 수동
+접근 가능 권한 레벨: STAFF
+
+==== request
+include::{snippets}/attendance/group/assign/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/group/assign/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/group/assign/query-parameters.adoc[]
+
+==== request-fields
+include::{snippets}/attendance/group/assign/request-fields.adoc[]
+
+==== response
+include::{snippets}/attendance/group/assign/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/group/assign/response-fields.adoc[]
+
+==== Error case
+
+---
+
+
+=== 토론 그룹 할당 - 개인
+접근 가능 권한 레벨: ADMIN
+
+==== request
+include::{snippets}/attendance/group/assign/solo/http-request.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/group/assign/solo/request-headers.adoc[]
+
+==== query-parameters
+include::{snippets}/attendance/group/assign/solo/query-parameters.adoc[]
+
+==== response
+include::{snippets}/attendance/group/assign/solo/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/group/assign/solo/response-fields.adoc[]
+
+==== Error case
+
+---
+
 
 == DELETE
 

--- a/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/attendance-api-guide.adoc
@@ -37,7 +37,32 @@ include::{snippets}/attendance/create/response-fields.adoc[]
 
 ==== Error case
 
+
+== GET
+
+=== 출석 정보 조회
+접근 가능 권한 레벨: MEMBER
+
+==== request
+include::{snippets}/attendance/view/http-request.adoc[]
+
+==== path-parameters
+include::{snippets}/attendance/view/path-parameters.adoc[]
+
+==== request-headers
+include::{snippets}/attendance/view/request-headers.adoc[]
+
+==== response
+include::{snippets}/attendance/view/http-response.adoc[]
+
+==== response-fields
+include::{snippets}/attendance/view/response-fields.adoc[]
+
+==== Error case
+
+
 ---
+
 
 == PATCH
 

--- a/geulnamu-backend/src/docs/asciidoc/index.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/index.adoc
@@ -93,7 +93,7 @@
 
 // 추후 수정할 것
 === ✅ 출석 관리
-==== link:meeting-attendance-api-guide.html[출석 API]
+==== link:attendance-api-guide.html[출석 API]
 - **출석 처리**: QR 코드 또는 GPS 기반 출석
 - **출석 현황 조회**: 개인별/모임별 출석 이력
 - **지각자 조회**: 운영진 전용 지각자 명단

--- a/geulnamu-backend/src/docs/asciidoc/login-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/login-api-guide.adoc
@@ -60,7 +60,7 @@ include::{snippets}/login/logout/response-fields.adoc[]
 == GET
 
 === 카카오 OAuth 로그인
-접근 가능 권한 레벨: PUBLIC
+접근 가능 권한 레벨: PUBLIC / 로그 생성
 
 ==== request
 include::{snippets}/login/oauth/kakao/http-request.adoc[]

--- a/geulnamu-backend/src/docs/asciidoc/meeting-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/meeting-api-guide.adoc
@@ -18,7 +18,7 @@ endif::[]
 == POST
 
 === 모임 생성
-접근 가능 권한 레벨: STAFF / 미래 시간만 생성 가능
+접근 가능 권한 레벨: STAFF / 로그 생성 / 미래 시간만 생성 가능
 
 ==== request
 include::{snippets}/meeting/open/http-request.adoc[]
@@ -128,7 +128,7 @@ include::{snippets}/meeting/list/admin/response-fields.adoc[]
 == PATCH
 
 === 모임 수정 - 기본 정보
-접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)
+접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)
 
 ==== request
 include::{snippets}/meeting/modify/http-request.adoc[]
@@ -154,7 +154,7 @@ include::{snippets}/meeting/modify/response-fields.adoc[]
 ---
 
 === 모임 수정 - 조별 활동 관련
-접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)
+접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)
 
 ==== request
 include::{snippets}/meeting/modify/discussion/http-request.adoc[]
@@ -226,7 +226,7 @@ include::{snippets}/meeting/public/response-fields.adoc[]
 == DELETE
 
 === 개설한 모임 삭제
-접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 6시간 전까지만 가능
+접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 모임 시작 6시간 전까지만 가능
 
 ==== request
 include::{snippets}/meeting/remove/http-request.adoc[]

--- a/geulnamu-backend/src/docs/asciidoc/member-api-guide.adoc
+++ b/geulnamu-backend/src/docs/asciidoc/member-api-guide.adoc
@@ -61,7 +61,7 @@ include::{snippets}/member/list/response-fields.adoc[]
 == PATCH
 
 === 개인 정보 수정
-접근 가능 권한 레벨: MEMBER
+접근 가능 권한 레벨: MEMBER / 로그 생성
 
 ==== request
 include::{snippets}/member/info/modify/http-request.adoc[]
@@ -84,7 +84,7 @@ include::{snippets}/member/info/modify/response-fields.adoc[]
 ---
 
 === 모임원 등급 변경
-접근 가능 권한 레벨: ADMIN / 해당 모임원 재로그인 필요
+접근 가능 권한 레벨: ADMIN / 로그 생성 / 해당 모임원 재로그인 필요
 
 ==== request
 include::{snippets}/member/role/modify/http-request.adoc[]
@@ -109,7 +109,7 @@ include::{snippets}/member/role/modify/response-fields.adoc[]
 ---
 
 === 모임원 이름 변경
-접근 가능 권한 레벨: ADMIN
+접근 가능 권한 레벨: ADMIN / 로그 생성
 
 ==== request
 include::{snippets}/member/name/modify/http-request.adoc[]
@@ -134,7 +134,7 @@ include::{snippets}/member/name/modify/response-fields.adoc[]
 ---
 
 === 모임원 활성화
-접근 가능 권한 레벨: ADMIN
+접근 가능 권한 레벨: ADMIN / 로그 생성
 
 ==== request
 include::{snippets}/member/activate/http-request.adoc[]
@@ -156,7 +156,7 @@ include::{snippets}/member/activate/response-fields.adoc[]
 ---
 
 === 모임원 비활성화
-접근 가능 권한 레벨: ADMIN
+접근 가능 권한 레벨: ADMIN / 로그 생성
 
 ==== request
 include::{snippets}/member/deactivate/http-request.adoc[]

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -1,6 +1,7 @@
 package com.geulnamu.controller.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
+import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.infrastructure.annotation.AccessLevel;
@@ -27,6 +28,13 @@ public class AttendanceController {
     public BaseResponse<Long> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
         Long attendanceId = attendanceService.createAttendance(meetingId, memberId);
         return BaseResponse.ofSuccess(attendanceId);
+    }
+
+    @AccessLevel(Level.MEMBER)
+    @GetMapping(value = "/{attendanceId}", name = "출석 정보 조회")
+    public BaseResponse<AttendanceInfoResponse> getAttendanceInfo(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
+        AttendanceInfoResponse attendanceInfoResponse = attendanceService.getAttendanceInfo(attendanceId, memberId);
+        return BaseResponse.ofSuccess(attendanceInfoResponse);
     }
 
     @AccessLevel(Level.MEMBER)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -3,8 +3,9 @@ package com.geulnamu.controller.attendance;
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
 import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.DiscussionGroupResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.infrastructure.annotation.AccessLevel;
@@ -14,6 +15,7 @@ import com.geulnamu.infrastructure.response.BaseResponse;
 import com.geulnamu.service.attendance.AttendanceService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -63,6 +65,13 @@ public class AttendanceController {
                                                                                       @AuthMemberId Long memberId) {
         List<MemberIdAndNameResponse> memberIdAndNameResponsesList = attendanceService.getMyDiscussionMemberList(attendanceId, memberId);
         return BaseResponse.ofSuccess(memberIdAndNameResponsesList);
+    }
+
+    @AccessLevel(Level.STAFF)
+    @GetMapping(value = "/discussion/all", name = "전체 토론 그룹 명단 조회")
+    public BaseResponse<List<DiscussionGroupResponse>> getAllDiscussionGroupMemberList(@NotNull(message = "모임 고유번호 필수 입력") @Min(value = 1) Long meetingId) {
+        List<DiscussionGroupResponse> discussionGroupResponseList = attendanceService.getAllDiscussionGroupMemberList(meetingId);
+        return BaseResponse.ofSuccess(discussionGroupResponseList);
     }
 
     @AccessLevel(Level.MEMBER)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -1,5 +1,6 @@
 package com.geulnamu.controller.attendance;
 
+import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.infrastructure.annotation.AccessLevel;
@@ -7,6 +8,7 @@ import com.geulnamu.infrastructure.annotation.AuthMemberId;
 import com.geulnamu.infrastructure.annotation.LogAction;
 import com.geulnamu.infrastructure.response.BaseResponse;
 import com.geulnamu.service.attendance.AttendanceService;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -25,6 +27,13 @@ public class AttendanceController {
     public BaseResponse<Long> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
         Long attendanceId = attendanceService.createAttendance(meetingId, memberId);
         return BaseResponse.ofSuccess(attendanceId);
+    }
+
+    @AccessLevel(Level.MEMBER)
+    @PatchMapping(value = "/{attendanceId}/note", name = "비고 작성")
+    public BaseResponse<Void> writeNote(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId, @Valid @RequestBody AttendanceNoteRequest request) {
+        attendanceService.writeNote(attendanceId, memberId, request.getNote());
+        return BaseResponse.ofSuccess();
     }
 
     @AccessLevel(Level.MEMBER)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -58,6 +58,14 @@ public class AttendanceController {
     }
 
     @AccessLevel(Level.MEMBER)
+    @GetMapping(value = "/discussion/{attendanceId}", name = "본인 토론 그룹 명단 조회")
+    public BaseResponse<List<MemberIdAndNameResponse>> getMyDiscussionGroupMemberList(@PathVariable @Min(value = 1) Long attendanceId,
+                                                                                      @AuthMemberId Long memberId) {
+        List<MemberIdAndNameResponse> memberIdAndNameResponsesList = attendanceService.getMyDiscussionMemberList(attendanceId, memberId);
+        return BaseResponse.ofSuccess(memberIdAndNameResponsesList);
+    }
+
+    @AccessLevel(Level.MEMBER)
     @PatchMapping(value = "/{attendanceId}/note", name = "비고 작성")
     public BaseResponse<Void> writeNote(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId,
                                         @Valid @RequestBody AttendanceNoteRequest request) {

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -1,0 +1,33 @@
+package com.geulnamu.controller.attendance;
+
+import com.geulnamu.domain.shared.enums.ActionType;
+import com.geulnamu.domain.shared.enums.Level;
+import com.geulnamu.infrastructure.annotation.AccessLevel;
+import com.geulnamu.infrastructure.annotation.AuthMemberId;
+import com.geulnamu.infrastructure.annotation.LogAction;
+import com.geulnamu.infrastructure.response.BaseResponse;
+import com.geulnamu.service.attendance.AttendanceService;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/attendance")
+public class AttendanceController {
+
+    private final AttendanceService attendanceService;
+
+    @LogAction(value = ActionType.ATTENDANCE_CREATE, actionDomain = "attendance")
+    @AccessLevel(Level.MEMBER)
+    @PostMapping(value = "/{meetingId}", name = "출석")
+    public BaseResponse<Void> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
+        attendanceService.createAttendance(meetingId, memberId);
+        return BaseResponse.ofSuccess();
+    }
+
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -2,6 +2,7 @@ package com.geulnamu.controller.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.infrastructure.annotation.AccessLevel;
@@ -13,6 +14,8 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,10 +34,17 @@ public class AttendanceController {
     }
 
     @AccessLevel(Level.MEMBER)
-    @GetMapping(value = "/{attendanceId}", name = "출석 정보 조회")
-    public BaseResponse<AttendanceInfoResponse> getAttendanceInfo(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
-        AttendanceInfoResponse attendanceInfoResponse = attendanceService.getAttendanceInfo(attendanceId, memberId);
+    @GetMapping(value = "/{attendanceId}/my", name = "개인 출석 정보 조회")
+    public BaseResponse<AttendanceInfoResponse> getMyAttendanceInfo(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
+        AttendanceInfoResponse attendanceInfoResponse = attendanceService.getMyAttendanceInfo(attendanceId, memberId);
         return BaseResponse.ofSuccess(attendanceInfoResponse);
+    }
+
+    @AccessLevel(Level.MEMBER)
+    @GetMapping(value = "/{meetingId}", name = "모임별 참석 현황 조회")
+    public BaseResponse<MeetingAttendanceDetailsResponse> getMeetingAttendanceStatus(@PathVariable @Min(value = 1) Long meetingId) {
+        MeetingAttendanceDetailsResponse meetingAttendanceStatusResponseList = attendanceService.getMeetingAttendanceStatus(meetingId);
+        return BaseResponse.ofSuccess(meetingAttendanceStatusResponseList);
     }
 
     @AccessLevel(Level.MEMBER)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -9,10 +9,7 @@ import com.geulnamu.infrastructure.response.BaseResponse;
 import com.geulnamu.service.attendance.AttendanceService;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,13 +18,21 @@ public class AttendanceController {
 
     private final AttendanceService attendanceService;
 
+
     @LogAction(value = ActionType.ATTENDANCE_CREATE, actionDomain = "attendance")
     @AccessLevel(Level.MEMBER)
     @PostMapping(value = "/{meetingId}", name = "출석")
-    public BaseResponse<Void> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
-        attendanceService.createAttendance(meetingId, memberId);
-        return BaseResponse.ofSuccess();
+    public BaseResponse<Long> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
+        Long attendanceId = attendanceService.createAttendance(meetingId, memberId);
+        return BaseResponse.ofSuccess(attendanceId);
     }
 
+    @LogAction(value = ActionType.ATTENDANCE_DELETE, actionDomain = "attendance")
+    @AccessLevel(Level.ADMIN)
+    @DeleteMapping(value = "/{attendanceId}/delete", name = "출석 삭제")
+    public BaseResponse<Void> DeleteMeetingAttend(@PathVariable @Min(value = 1) Long attendanceId) {
+        attendanceService.deleteAttendance(attendanceId);
+        return BaseResponse.ofSuccess();
+    }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -1,8 +1,10 @@
 package com.geulnamu.controller.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
+import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.infrastructure.annotation.AccessLevel;
@@ -27,29 +29,38 @@ public class AttendanceController {
 
     @LogAction(value = ActionType.ATTENDANCE_CREATE, actionDomain = "attendance")
     @AccessLevel(Level.MEMBER)
-    @PostMapping(value = "/{meetingId}", name = "출석")
-    public BaseResponse<Long> meetingAttend(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
+    @PostMapping(name = "출석")
+    public BaseResponse<Long> meetingAttend(@RequestParam @Min(value = 1) Long meetingId, @AuthMemberId Long memberId) {
         Long attendanceId = attendanceService.createAttendance(meetingId, memberId);
         return BaseResponse.ofSuccess(attendanceId);
     }
 
     @AccessLevel(Level.MEMBER)
     @GetMapping(value = "/{attendanceId}/my", name = "개인 출석 정보 조회")
-    public BaseResponse<AttendanceInfoResponse> getMyAttendanceInfo(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
+    public BaseResponse<AttendanceInfoResponse> getMyAttendanceInfo(@PathVariable @Min(value = 1) Long attendanceId,
+                                                                    @AuthMemberId Long memberId) {
         AttendanceInfoResponse attendanceInfoResponse = attendanceService.getMyAttendanceInfo(attendanceId, memberId);
         return BaseResponse.ofSuccess(attendanceInfoResponse);
     }
 
     @AccessLevel(Level.MEMBER)
-    @GetMapping(value = "/{meetingId}", name = "모임별 참석 현황 조회")
-    public BaseResponse<MeetingAttendanceDetailsResponse> getMeetingAttendanceStatus(@PathVariable @Min(value = 1) Long meetingId) {
+    @GetMapping(name = "모임별 참석 현황 조회")
+    public BaseResponse<MeetingAttendanceDetailsResponse> getMeetingAttendanceStatus(@RequestParam @Min(value = 1) Long meetingId) {
         MeetingAttendanceDetailsResponse meetingAttendanceStatusResponseList = attendanceService.getMeetingAttendanceStatus(meetingId);
         return BaseResponse.ofSuccess(meetingAttendanceStatusResponseList);
     }
 
+    @AccessLevel(Level.STAFF)
+    @GetMapping(value = "/discussion", name = "모임 토론 참여 희망 명단 조회")
+    public BaseResponse<List<MemberIdAndNameResponse>> getWantDiscussionMemberList(@RequestParam @Min(value = 1) Long meetingId) {
+        List<MemberIdAndNameResponse> memberIdAndNameResponsesList = attendanceService.getWantDiscussionMemberList(meetingId);
+        return BaseResponse.ofSuccess(memberIdAndNameResponsesList);
+    }
+
     @AccessLevel(Level.MEMBER)
     @PatchMapping(value = "/{attendanceId}/note", name = "비고 작성")
-    public BaseResponse<Void> writeNote(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId, @Valid @RequestBody AttendanceNoteRequest request) {
+    public BaseResponse<Void> writeNote(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId,
+                                        @Valid @RequestBody AttendanceNoteRequest request) {
         attendanceService.writeNote(attendanceId, memberId, request.getNote());
         return BaseResponse.ofSuccess();
     }
@@ -65,6 +76,25 @@ public class AttendanceController {
     @PatchMapping(value = "/{attendanceId}/want-discussion", name = "토론할래요")
     public BaseResponse<Void> wantDiscussion(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
         attendanceService.wantDiscussion(attendanceId, memberId);
+        return BaseResponse.ofSuccess();
+    }
+
+    @LogAction(value = ActionType.DISCUSSION_GROUP_ORGANIZE, actionDomain = "attendance")
+    @AccessLevel(Level.STAFF)
+    @PatchMapping(value = "/group", name = "토론 그룹 구성 - 수동")
+    public BaseResponse<Void> manuallyAssignDiscussionGroups(@RequestParam @Min(value = 1) Long meetingId,
+                                                             @Valid @RequestBody AssignDiscussionGroupsRequest request) {
+        attendanceService.manuallyAssignDiscussionGroups(meetingId, request);
+        return BaseResponse.ofSuccess();
+    }
+
+    @LogAction(value = ActionType.DISCUSSION_GROUP_ORGANIZE_SOLO, actionDomain = "attendance")
+    @AccessLevel(Level.ADMIN)
+    @PatchMapping(value = "/group/solo", name = "토론 그룹 할당 - 개인")
+    public BaseResponse<Void> manuallyAssignDiscussionGroup(@RequestParam @Min(value = 1) Long meetingId,
+                                                            @RequestParam @Min(value = 1) Long memberId,
+                                                            @RequestParam @Min(value = 1) Integer groupNumber) {
+        attendanceService.assignMemberToDiscussionGroup(meetingId, memberId, groupNumber-1);
         return BaseResponse.ofSuccess();
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/AttendanceController.java
@@ -27,6 +27,20 @@ public class AttendanceController {
         return BaseResponse.ofSuccess(attendanceId);
     }
 
+    @AccessLevel(Level.MEMBER)
+    @PatchMapping(value = "/{attendanceId}/just-read", name = "독서만 할래요")
+    public BaseResponse<Void> notWantDiscussion(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
+        attendanceService.notWantDiscussion(attendanceId, memberId);
+        return BaseResponse.ofSuccess();
+    }
+
+    @AccessLevel(Level.MEMBER)
+    @PatchMapping(value = "/{attendanceId}/want-discussion", name = "토론할래요")
+    public BaseResponse<Void> wantDiscussion(@PathVariable @Min(value = 1) Long attendanceId, @AuthMemberId Long memberId) {
+        attendanceService.wantDiscussion(attendanceId, memberId);
+        return BaseResponse.ofSuccess();
+    }
+
     @LogAction(value = ActionType.ATTENDANCE_DELETE, actionDomain = "attendance")
     @AccessLevel(Level.ADMIN)
     @DeleteMapping(value = "/{attendanceId}/delete", name = "출석 삭제")

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AssignDiscussionGroupsRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AssignDiscussionGroupsRequest.java
@@ -1,0 +1,17 @@
+package com.geulnamu.controller.attendance.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AssignDiscussionGroupsRequest {
+
+    @NotEmpty(message = "토론 그룹 정보는 필수입니다.")
+    List<@Valid DiscussionGroupRequest> groups;
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AttendanceNoteRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AttendanceNoteRequest.java
@@ -1,0 +1,17 @@
+package com.geulnamu.controller.attendance.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class AttendanceNoteRequest {
+
+    @NotBlank(message = "비고 필수 입력")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_!?.,;-]{1,255}$",
+        message = "비고는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+    private String note;
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/DiscussionGroupRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/request/DiscussionGroupRequest.java
@@ -1,0 +1,15 @@
+package com.geulnamu.controller.attendance.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DiscussionGroupRequest {
+    @NotEmpty(message = "토론 그룹에는 1명 이상이 반드시 들어가야 합니다.")
+    private List<@Min(1) Long> memberIdList;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
@@ -1,11 +1,14 @@
 package com.geulnamu.controller.attendance.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.MeetingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -23,15 +26,24 @@ public class AttendanceInfoResponse {
     private String note;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime discussionTime;
-    private String groupMemberList;
-//    private List<GroupMember> groupMemberList;
+    private List<MemberIdAndNameResponse> groupMemberList;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime createdAt;
     // TODO: 발제문 내용을 여기다가 적을지 어떻게 할지 고민해 볼 것 (근데 따로 빼는 게 나을 것 같음..;)
 
-    static class GroupMember {
-        Long memberId;
-        String Name;
+
+    public AttendanceInfoResponse(Attendance attendance, List<MemberIdAndNameResponse> memberIdAndNameResponseList) {
+        this.attendanceId = attendance.getId();
+        this.meetingType = attendance.getMeeting().getMeetingType();
+        this.meetingDateTime = attendance.getMeeting().getMeetingDate();
+        this.lateThresholdTime = attendance.getMeeting().getLateThresholdTime();
+        this.meetingName = attendance.getMeeting().getMeetingName();
+        this.meetingPlace = attendance.getMeeting().getMeetingPlace();
+        this.description = attendance.getMeeting().getDescription();
+        this.note = attendance.getNote();
+        this.discussionTime = attendance.getMeeting().getDiscussionTime();
+        this.groupMemberList = memberIdAndNameResponseList;
+        this.createdAt = attendance.getCreatedAt();
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
@@ -1,0 +1,37 @@
+package com.geulnamu.controller.attendance.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.geulnamu.domain.meeting.MeetingType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class AttendanceInfoResponse {
+
+    private Long attendanceId;
+    private MeetingType meetingType;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime meetingDateTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime lateThresholdTime;
+    private String meetingName;
+    private String meetingPlace;
+    private String description;
+    private String note;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime discussionTime;
+    private String groupMemberList;
+//    private List<GroupMember> groupMemberList;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime createdAt;
+    // TODO: 발제문 내용을 여기다가 적을지 어떻게 할지 고민해 볼 것 (근데 따로 빼는 게 나을 것 같음..;)
+
+    static class GroupMember {
+        Long memberId;
+        String Name;
+    }
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/DiscussionGroupResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/DiscussionGroupResponse.java
@@ -1,0 +1,13 @@
+package com.geulnamu.controller.attendance.dto.response;
+
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DiscussionGroupResponse {
+    private List<MemberIdAndNameResponse> memberIdAndNameResponseList;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceDetailsResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceDetailsResponse.java
@@ -1,0 +1,13 @@
+package com.geulnamu.controller.attendance.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingAttendanceDetailsResponse {
+    private MeetingAttendanceSummaryResponse meetingAttendanceSummaryResponse;
+    private List<MeetingAttendanceStatusResponse> meetingAttendanceStatusResponseList;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceStatusResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceStatusResponse.java
@@ -1,0 +1,17 @@
+package com.geulnamu.controller.attendance.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingAttendanceStatusResponse {
+    private Long memberId;
+    private String name;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime attendanceTime;
+    private Boolean isLate;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
@@ -1,0 +1,19 @@
+package com.geulnamu.controller.attendance.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingAttendanceSummaryResponse {
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime meetingDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    private LocalDateTime lateThresholdTime;
+    private Long totalAttendCount;
+    private Long attendCount;
+    private Long lateAttendCount;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/login/dto/response/LoginResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/login/dto/response/LoginResponse.java
@@ -1,7 +1,7 @@
 package com.geulnamu.controller.login.dto.response;
 
-public record LoginResponse(String accessToken, boolean newMember) {
-    public static LoginResponse of(String accessToken, boolean newMember) {
-        return new LoginResponse(accessToken, newMember);
+public record LoginResponse(Long memberId, String accessToken, boolean newMember) {
+    public static LoginResponse of(Long memberId, String accessToken, boolean newMember) {
+        return new LoginResponse(memberId, accessToken, newMember);
     }
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -33,10 +33,10 @@ public class MeetingController {
     @LogAction(value = ActionType.MEETING_CREATE, actionDomain = "meeting")
     @AccessLevel(Level.STAFF)
     @PostMapping(name = "모임 생성")
-    public BaseResponse<Void> createMeeting(@AuthMemberId Long memberId, @Valid @RequestBody MeetingCreateRequest request) {
-        meetingService.createMeeting(memberId, request.getMeetingName(), request.getMeetingType(),
+    public BaseResponse<Long> createMeeting(@AuthMemberId Long memberId, @Valid @RequestBody MeetingCreateRequest request) {
+        Long meetingId = meetingService.createMeeting(memberId, request.getMeetingName(), request.getMeetingType(),
             request.getMeetingDate(), request.getMeetingPlace(), request.getDescription());
-        return BaseResponse.ofSuccess();
+        return BaseResponse.ofSuccess(meetingId);
     }
 
     @AccessLevel(Level.STAFF)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -46,9 +46,9 @@ public class MeetingController {
 
     @AccessLevel(Level.MEMBER)
     @GetMapping(value = "/list/staff", name = "운영진 목록 조회 - 필터링용")
-    public BaseResponse<List<StaffResponse>> getStaffList() {
-        List<StaffResponse> staffResponseList = meetingService.getStaffList();
-        return BaseResponse.ofSuccess(staffResponseList);
+    public BaseResponse<List<MemberIdAndNameResponse>> getStaffList() {
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList = meetingService.getStaffList();
+        return BaseResponse.ofSuccess(memberIdAndNameResponseList);
     }
 
     @AccessLevel(Level.MEMBER)

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -4,9 +4,7 @@ import com.geulnamu.controller.meeting.dto.request.MeetingCreateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
-import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
-import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.domain.shared.enums.Role;
@@ -35,14 +33,14 @@ public class MeetingController {
     @PostMapping(name = "모임 생성")
     public BaseResponse<Long> createMeeting(@AuthMemberId Long memberId, @Valid @RequestBody MeetingCreateRequest request) {
         Long meetingId = meetingService.createMeeting(memberId, request.getMeetingName(), request.getMeetingType(),
-            request.getMeetingDate(), request.getMeetingPlace(), request.getDescription());
+            request.getMeetingDate(), request.getLateThresholdTime(), request.getMeetingPlace(), request.getDescription());
         return BaseResponse.ofSuccess(meetingId);
     }
 
     @AccessLevel(Level.STAFF)
     @GetMapping(value = "/{meetingId}", name = "모임 단일 조회")
-    public BaseResponse<MeetingInfoResponse> findMeeting(@PathVariable @Min(value = 1) Long meetingId) {
-        MeetingInfoResponse meetingInfoResponse = meetingService.findMeeting(meetingId);
+    public BaseResponse<MeetingInfoForAdminResponse> findMeeting(@PathVariable @Min(value = 1) Long meetingId) {
+        MeetingInfoForAdminResponse meetingInfoResponse = meetingService.findMeeting(meetingId);
         return BaseResponse.ofSuccess(meetingInfoResponse);
     }
 
@@ -55,15 +53,15 @@ public class MeetingController {
 
     @AccessLevel(Level.MEMBER)
     @GetMapping(value = "/list", name = "모임 목록 조회")
-    public BaseResponse<MeetingListResponse> getMeetingList(@Valid MeetingListRequest request) {
-        MeetingListResponse meetingListResponse = meetingService.getMeetingList(request);
+    public BaseResponse<MeetingListResponse> getMeetingList(@Valid MeetingListRequest request, @AuthMemberId Long memberId) {
+        MeetingListResponse meetingListResponse = meetingService.getMeetingList(request, memberId);
         return BaseResponse.ofSuccess(meetingListResponse);
     }
 
     @AccessLevel(Level.ADMIN)
     @GetMapping(value = "/list/admin", name = "모임 목록 조회(관리자용)")
-    public BaseResponse<MeetingListResponse> getMeetingListForAdminLevel(@Valid MeetingListRequest request) {
-        MeetingListResponse meetingListResponse = meetingService.getMeetingListForAdmin(request);
+    public BaseResponse<MeetingListForAdminResponse> getMeetingListForAdminLevel(@Valid MeetingListRequest request) {
+        MeetingListForAdminResponse meetingListResponse = meetingService.getMeetingListForAdmin(request);
         return BaseResponse.ofSuccess(meetingListResponse);
     }
 
@@ -73,7 +71,7 @@ public class MeetingController {
     public BaseResponse<Void> updateMeeting(@PathVariable @Min(value = 1) Long meetingId, @AuthMemberId Long memberId,
                                             @AuthRole Role role, @Valid @RequestBody MeetingUpdateRequest request) {
         meetingService.updateMeeting(meetingId, memberId, request.getMeetingName(), request.getMeetingType(),
-            request.getMeetingDate(), request.getMeetingPlace(), request.getDescription());
+            request.getMeetingDate(), request.getLateThresholdTime(), request.getMeetingPlace(), request.getDescription());
         return BaseResponse.ofSuccess();
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/MeetingController.java
@@ -5,6 +5,7 @@ import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.meeting.dto.response.*;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.shared.enums.ActionType;
 import com.geulnamu.domain.shared.enums.Level;
 import com.geulnamu.domain.shared.enums.Role;

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
@@ -20,7 +20,7 @@ public class MeetingCreateRequest {
     private String meetingType;    // 모임 종류
 
     @NotBlank(message = "모임 제목 필수 입력")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,70}$",
         message = "모임 제목은 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 70자 이하로 입력해주세요.")
     private String meetingName;    // 모임 제목
 
@@ -29,8 +29,8 @@ public class MeetingCreateRequest {
     @JsonFormat(pattern = "yyyyMMdd HH:mm")
     private LocalDateTime meetingDate;    // 모임 개최일자
 
-    @NotNull(message = "모임 장소 필수 입력")
-    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
+    @NotBlank(message = "모임 장소 필수 입력")
+    @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,255}$",
         message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
     private String meetingPlace;
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
@@ -29,6 +29,10 @@ public class MeetingCreateRequest {
     @JsonFormat(pattern = "yyyyMMdd HH:mm")
     private LocalDateTime meetingDate;    // 모임 개최일자
 
+    @Future(message = "지각 기준 시간은 미래의 시간이어야 합니다.")
+    @JsonFormat(pattern = "yyyyMMdd HH:mm")
+    private LocalDateTime lateThresholdTime;    // 지각 기준 시간
+
     @NotBlank(message = "모임 장소 필수 입력")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,255}$",
         message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingListRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingListRequest.java
@@ -16,10 +16,9 @@ public class MeetingListRequest extends PagingRequest {
     @Pattern(regexp = "true|false", message = "모임 비공개 여부 값은 'true' 또는 'false' 만 가능합니다.")
     private final String isPrivate; // 관리자용 목록 조회에서만 사용되는 값
 
-//    @Getter
-//    @Pattern(regexp = "true|true_late|false", message = "본인 참석 여부 값은 'true', 'true_late', 'false' 중 하나만 가능합니다.")
-//    private final String isAttend; // 본인 참석 여부 (true는 지각한 것 포함해서 보여주고, true_late는 지각한 참석만 보여주기로 할 것)
-    // 일반 목록 조회에서만 사용되는 값
+    @Getter
+    @Pattern(regexp = "ATTEND|ATTEND_LATE|NOT_ATTEND", message = "참석 상태 값은 'ATTEND', 'ATTEND_LATE', 'NOT_ATTEND' 중 하나만 가능합니다.")
+    private final String attendanceStatus; // 참석 상태 (일반 목록 조회에서만 사용되는 값)
 
     @Getter
     @Pattern(regexp = "meetingDate|meetingId|createdAt", message = "정렬 기준 값은 'meetingDate', 'meetingId', 'createdAt' 중 하나만 가능합니다.")
@@ -42,11 +41,12 @@ public class MeetingListRequest extends PagingRequest {
     }
 
     public MeetingListRequest(String meetingType, Long meetingCreatorId, String isPrivate,
-                              String sortBy, String isAsc, Integer page, Integer size) {
+                              String attendanceStatus, String sortBy, String isAsc, Integer page, Integer size) {
         super(page, size);
         this.meetingType = meetingType;
         this.meetingCreatorId = meetingCreatorId;
         this.isPrivate = isPrivate;
+        this.attendanceStatus = attendanceStatus;
         this.sortBy = sortBy;
         this.isAsc = isAsc;
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
@@ -24,6 +24,10 @@ public class MeetingUpdateRequest {
     @JsonFormat(pattern = "yyyyMMdd HH:mm")
     private LocalDateTime meetingDate;    // 모임 개최일자
 
+    @Future(message = "지각 기준 시간은 미래의 시간이어야 합니다.")
+    @JsonFormat(pattern = "yyyyMMdd HH:mm")
+    private LocalDateTime lateThresholdTime;    // 지각 기준 시간
+
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
         message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
     private String meetingPlace;

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoForAdminResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoForAdminResponse.java
@@ -1,7 +1,7 @@
 package com.geulnamu.controller.meeting.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.geulnamu.domain.attendance.DiscussionGroup;
+import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.meeting.MeetingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class MeetingInfoResponse {
+public class MeetingInfoForAdminResponse {
 
     private Long meetingId;
     private String meetingCreatorName;
@@ -18,14 +18,23 @@ public class MeetingInfoResponse {
     private String meetingName;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime meetingDateTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
+    private LocalDateTime lateThresholdTime;
     private String meetingPlace;
     private String description;
-    private String attendanceStatus;
-    private DiscussionGroup discussionGroup;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime discussionTime;
     private String alarmMessage;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime createdAt;
+    private Boolean isPrivateMeeting;
+
+
+    public static MeetingInfoForAdminResponse of(Meeting meeting) {
+        return new MeetingInfoForAdminResponse(meeting.getId(), meeting.getMember().getName(), meeting.getMeetingType(),
+            meeting.getMeetingName(), meeting.getMeetingDate(), meeting.getLateThresholdTime(), meeting.getMeetingPlace(),
+            meeting.getDescription(), meeting.getDiscussionTime(), meeting.getAlarmMessage(), meeting.getCreatedAt(),
+            meeting.getPrivateAt() != null);
+    }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingListForAdminResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingListForAdminResponse.java
@@ -1,0 +1,14 @@
+package com.geulnamu.controller.meeting.dto.response;
+
+import com.geulnamu.infrastructure.response.paging.PagingResponse;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingListForAdminResponse {
+    private PagingResponse pagingResponse;
+    private List<MeetingInfoForAdminResponse> meetingList;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MemberIdAndNameResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MemberIdAndNameResponse.java
@@ -5,9 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class StaffResponse {
-
+public class MemberIdAndNameResponse {
     private Long memberId;
     private String memberName;
-
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/controller/shared/dto/response/MemberIdAndNameResponse.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/controller/shared/dto/response/MemberIdAndNameResponse.java
@@ -1,4 +1,4 @@
-package com.geulnamu.controller.meeting.dto.response;
+package com.geulnamu.controller.shared.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -68,6 +68,12 @@ public class Attendance extends DateColumn {
         }
     }
 
+    public void validateDiscussionGroupMemberListRequestedPerson(Long memberId) {
+        if(!this.getMember().getId().equals(memberId)) {
+            throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
+        }
+    }
+
     public void updateNote(String note) {
         this.note = note;
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -1,4 +1,4 @@
-package com.geulnamu.domain.meetingAttendance;
+package com.geulnamu.domain.attendance;
 
 import com.geulnamu.domain.bookQuestion.BookQuestion;
 import com.geulnamu.domain.meeting.Meeting;
@@ -6,19 +6,19 @@ import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.DateColumn;
 import com.geulnamu.domain.shared.converter.DiscussionGroupConverter;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
-@Entity(name = "meeting_attendances")
+@Builder
+@Entity(name = "attendances")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MeetingAttendance extends DateColumn {
+public class Attendance extends DateColumn {
 
     @Id
-    @Column(name = "meeting_attendance_id", updatable = false)
+    @Column(name = "attendance_id", updatable = false)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -37,7 +37,15 @@ public class MeetingAttendance extends DateColumn {
     @Column(name = "discussion_group", length = 1)
     private DiscussionGroup discussionGroup;
 
-    @OneToMany(mappedBy = "meetingAttendance", fetch = FetchType.LAZY)
+    @OneToMany(mappedBy = "attendance", fetch = FetchType.LAZY)
     private List<BookQuestion> bookQuestions;
+
+
+    public static Attendance createAttendance(Meeting meeting, Member member) {
+        return Attendance.builder()
+            .meeting(meeting)
+            .member(member)
+            .build();
+    }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -33,6 +33,9 @@ public class Attendance extends DateColumn {
     @Column(name = "note", length = 1)
     private String note; // 비고 (출석 관련 특이사항이 적는 곳)
 
+    @Column(name = "not_want_discussion", columnDefinition = "TINYINT(1)", nullable = false)
+    private boolean notWantDiscussion; // 토론 미참여 희망
+
     @Convert(converter = DiscussionGroupConverter.class)
     @Column(name = "discussion_group", length = 1)
     private DiscussionGroup discussionGroup;
@@ -45,6 +48,7 @@ public class Attendance extends DateColumn {
         return Attendance.builder()
             .meeting(meeting)
             .member(member)
+            .notWantDiscussion(false)
             .build();
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -80,4 +80,8 @@ public class Attendance extends DateColumn {
         this.notWantDiscussion = false;
     }
 
+    public void updateDiscussionGroup(DiscussionGroup discussionGroup) {
+        this.discussionGroup = discussionGroup;
+    }
+
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -5,6 +5,8 @@ import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.DateColumn;
 import com.geulnamu.domain.shared.converter.DiscussionGroupConverter;
+import com.geulnamu.infrastructure.exception.BadRequestException;
+import com.geulnamu.infrastructure.response.ResponseMessage;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -50,6 +52,28 @@ public class Attendance extends DateColumn {
             .member(member)
             .notWantDiscussion(false)
             .build();
+    }
+
+    // 불참 의사를 비친 모임원과 해당 모임의 출석한 모임원 정보가 동일하지 않을 경우, 에러 발생
+    public void checkRequestedMemberAndAttendanceMember(Member member) {
+        if(!this.member.equals(member)) {
+            throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
+        }
+    }
+
+    // 아직 토론 시간이 셋팅되지 않았다면 에러 발생
+    public void checkSettingDiscussionTime() {
+        if(this.meeting.getDiscussionTime() == null) {
+            throw new BadRequestException(ResponseMessage.NOT_YET_SETTING_DISCUSSION_TIME);
+        }
+    }
+
+    public void updateNotWantDiscussion() {
+        this.notWantDiscussion = true;
+    }
+
+    public void updateWantDiscussion() {
+        this.notWantDiscussion = false;
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -54,13 +54,6 @@ public class Attendance extends DateColumn {
             .build();
     }
 
-    // 요청한 모임원과 해당 모임에 출석한 모임원 정보가 동일하지 않을 경우, 에러 발생
-    public void checkRequestedMemberAndAttendanceMember(Member member) {
-        if(!this.member.equals(member)) {
-            throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
-        }
-    }
-
     // 아직 토론 시간이 셋팅되지 않았다면 에러 발생
     public void checkSettingDiscussionTime() {
         if(this.meeting.getDiscussionTime() == null) {
@@ -68,7 +61,7 @@ public class Attendance extends DateColumn {
         }
     }
 
-    public void validateDiscussionGroupMemberListRequestedPerson(Long memberId) {
+    public void validateRequestedPerson(Long memberId) {
         if(!this.getMember().getId().equals(memberId)) {
             throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
         }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/Attendance.java
@@ -54,7 +54,7 @@ public class Attendance extends DateColumn {
             .build();
     }
 
-    // 불참 의사를 비친 모임원과 해당 모임의 출석한 모임원 정보가 동일하지 않을 경우, 에러 발생
+    // 요청한 모임원과 해당 모임에 출석한 모임원 정보가 동일하지 않을 경우, 에러 발생
     public void checkRequestedMemberAndAttendanceMember(Member member) {
         if(!this.member.equals(member)) {
             throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
@@ -66,6 +66,10 @@ public class Attendance extends DateColumn {
         if(this.meeting.getDiscussionTime() == null) {
             throw new BadRequestException(ResponseMessage.NOT_YET_SETTING_DISCUSSION_TIME);
         }
+    }
+
+    public void updateNote(String note) {
+        this.note = note;
     }
 
     public void updateNotWantDiscussion() {

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/AttendanceStatus.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/AttendanceStatus.java
@@ -1,0 +1,14 @@
+package com.geulnamu.domain.attendance;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AttendanceStatus {
+    ATTENDED("ATTEND"),
+    ATTENDED_LATE("ATTEND_LATE"),
+    NOT_ATTENDED("NOT_ATTEND");
+
+    private final String value;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/DiscussionGroup.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/attendance/DiscussionGroup.java
@@ -1,4 +1,4 @@
-package com.geulnamu.domain.meetingAttendance;
+package com.geulnamu.domain.attendance;
 
 
 public enum DiscussionGroup {

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/bookQuestion/BookQuestion.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/bookQuestion/BookQuestion.java
@@ -1,6 +1,6 @@
 package com.geulnamu.domain.bookQuestion;
 
-import com.geulnamu.domain.meetingAttendance.MeetingAttendance;
+import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.shared.DateColumn;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -18,8 +18,8 @@ public class BookQuestion extends DateColumn {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "meeting_attendance_id")
-    private MeetingAttendance meetingAttendance;
+    @JoinColumn(name = "attendance_id")
+    private Attendance attendance;
 
     @Column(name = "content", length = 255) // 향후 테스트해보고 길이 조정할 것
     private String content;

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
@@ -82,11 +82,19 @@ public class Meeting extends DateColumn {
         }
     }
 
+    // 모임 출석 가능 시간 확인
     public void checkTimeCanAttendMeeting() {
         if(LocalDateTime.now().getYear() != this.meetingDate.getYear()
             || LocalDateTime.now().getDayOfYear() != this.meetingDate.getDayOfYear()
             || !LocalDateTime.now().isAfter(this.meetingDate.minusHours(1))) {
             throw new BadRequestException(ResponseMessage.MEETING_ATTEND_TIME_RESTRICTION);
+        }
+    }
+
+    // 토론 참여 의사는 토론 시작 30분 전까지만 설정 가능   TODO: 해당 기능은 실 운영해보면서 수정 가능 시간이나 기능 수정 권한 조율해 볼 것
+    public void checkTimeCanSwitchAboutDiscussionAttendance() {
+        if(LocalDateTime.now().isAfter(this.discussionTime.minusMinutes(30))) {
+            throw new BadRequestException(ResponseMessage.DISCUSSION_INTENTION_SETTING_TIME_RESTRICTION);
         }
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
@@ -1,6 +1,6 @@
 package com.geulnamu.domain.meeting;
 
-import com.geulnamu.domain.meetingAttendance.MeetingAttendance;
+import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.DateColumn;
 import com.geulnamu.domain.shared.converter.MeetingTypeConverter;
@@ -53,7 +53,7 @@ public class Meeting extends DateColumn {
     private String alarmMessage;
 
     @OneToMany(mappedBy = "meeting", fetch = FetchType.LAZY)
-    private List<MeetingAttendance> meetingAttendances;
+    private List<Attendance> attendances;
 
     @Column(name = "private_at")
     private LocalDateTime privateAt;
@@ -79,6 +79,14 @@ public class Meeting extends DateColumn {
     public void checkTimeCanUpdateMeetingForDiscussion() {
         if(this.discussionTime != null && LocalDateTime.now().isAfter(this.discussionTime)) {
             throw new BadRequestException(ResponseMessage.MEETING_DISCUSSION_INFO_UPDATE_TIME_RESTRICTION);
+        }
+    }
+
+    public void checkTimeCanAttendMeeting() {
+        if(LocalDateTime.now().getYear() != this.meetingDate.getYear()
+            || LocalDateTime.now().getDayOfYear() != this.meetingDate.getDayOfYear()
+            || !LocalDateTime.now().isAfter(this.meetingDate.minusHours(1))) {
+            throw new BadRequestException(ResponseMessage.MEETING_ATTEND_TIME_RESTRICTION);
         }
     }
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
@@ -112,6 +112,12 @@ public class Meeting extends DateColumn {
         }
     }
 
+    public void validateRequestedMember(Long memberId) {
+        if(!this.getMember().getId().equals(memberId)) {
+            throw new BadRequestException(ResponseMessage.NOT_SUITABLE_MEMBER);
+        }
+    }
+
     public void updateMeetingName(String meetingName) {
         this.meetingName = meetingName;
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meeting/Meeting.java
@@ -40,6 +40,9 @@ public class Meeting extends DateColumn {
     @Column(name = "meeting_date", nullable = false)
     private LocalDateTime meetingDate;
 
+    @Column(name = "late_threshold_time", nullable = false)
+    private LocalDateTime lateThresholdTime;
+
     @Column(name = "meeting_place", nullable = false)
     private String meetingPlace;
 
@@ -59,12 +62,14 @@ public class Meeting extends DateColumn {
     private LocalDateTime privateAt;
 
 
-    public static Meeting createMeeting(Member member, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
+    public static Meeting createMeeting(Member member, String meetingName, MeetingType meetingType, LocalDateTime meetingDate,
+                                        LocalDateTime lateThresholdTime, String meetingPlace, String description) {
         return Meeting.builder()
             .member(member)
             .meetingType(meetingType)
             .meetingName(meetingName)
             .meetingDate(meetingDate)
+            .lateThresholdTime(lateThresholdTime == null ? meetingDate : lateThresholdTime) // 해당 값 입력 안 해줄 경우, 모임 시간과 동일한 시간을 가져가도록 함.
             .meetingPlace(meetingPlace)
             .description(description)
             .build();
@@ -82,12 +87,21 @@ public class Meeting extends DateColumn {
         }
     }
 
-    // 모임 출석 가능 시간 확인
+    // 모임 출석 가능 시간 확인 (모임 당일, 모임 시작 1시간 전부터 출석 가능)
     public void checkTimeCanAttendMeeting() {
         if(LocalDateTime.now().getYear() != this.meetingDate.getYear()
             || LocalDateTime.now().getDayOfYear() != this.meetingDate.getDayOfYear()
             || !LocalDateTime.now().isAfter(this.meetingDate.minusHours(1))) {
             throw new BadRequestException(ResponseMessage.MEETING_ATTEND_TIME_RESTRICTION);
+        }
+    }
+
+    // 지각 기준 시간 확인 (모임 당일, 모임 시간보다 빠르지 않아야 함)
+    public void checkLateThresholdTimeBeforeMeetingTime() {
+        if(this.lateThresholdTime.getYear() != this.meetingDate.getYear()
+            || this.lateThresholdTime.getDayOfYear() != this.meetingDate.getDayOfYear()
+            || this.lateThresholdTime.isBefore(this.meetingDate)) {
+            throw new BadRequestException(ResponseMessage.LATE_THRESHOLD_TIME_RESTRICTION);
         }
     }
 
@@ -104,21 +118,29 @@ public class Meeting extends DateColumn {
 
     public void updateMeetingType(MeetingType targetMeetingType) {
         if(this.meetingType.equals(targetMeetingType)) {
-            throw new ExistDataException();
+            throw new ExistDataException("targetMeetingType");
         }
         this.meetingType = targetMeetingType;
     }
 
     public void updateMeetingDate(LocalDateTime targetMeetingDate) {
         if(this.meetingDate.equals(targetMeetingDate)) {
-            throw new ExistDataException();
+            throw new ExistDataException("targetMeetingDate");
         }
         this.meetingDate = targetMeetingDate;
     }
 
+    public void updateLateThresholdTime(LocalDateTime lateThresholdTime) {
+        if(this.lateThresholdTime.equals(lateThresholdTime)) {
+            throw new ExistDataException("lateThresholdTime");
+        }
+        this.lateThresholdTime = lateThresholdTime;
+        checkLateThresholdTimeBeforeMeetingTime();
+    }
+
     public void updateMeetingPlace(String meetingPlace) {
         if(this.meetingPlace.equals(meetingPlace)) {
-            throw new ExistDataException();
+            throw new ExistDataException("meetingPlace");
         }
         this.meetingPlace = meetingPlace;
     }
@@ -130,7 +152,7 @@ public class Meeting extends DateColumn {
     public void updateDiscussionTime(LocalDateTime discussionTime) {
         // 이전에 입력한 시간과 동일한지 확인
         if(this.discussionTime != null && this.discussionTime.equals(discussionTime)) {
-            throw new ExistDataException();
+            throw new ExistDataException("discussionTime");
         }
         // 토론 시간은 모임 일정의 날짜와 같은 날 안에서만 모임 이후로 가능
         if(discussionTime != null && (!discussionTime.isAfter(this.meetingDate) ||
@@ -147,14 +169,14 @@ public class Meeting extends DateColumn {
 
     public void makeMeetingPrivate() {
         if(this.privateAt != null) {
-            throw new ExistDataException();
+            throw new ExistDataException("privateAt");
         }
         this.privateAt = LocalDateTime.now();
     }
 
     public void makeMeetingPublic() {
         if(this.privateAt == null) {
-            throw new ExistDataException();
+            throw new ExistDataException("privateAt");
         }
         this.privateAt = null;
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/meetingAttendance/MeetingAttendance.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/meetingAttendance/MeetingAttendance.java
@@ -30,6 +30,9 @@ public class MeetingAttendance extends DateColumn {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @Column(name = "note", length = 1)
+    private String note; // 비고 (출석 관련 특이사항이 적는 곳)
+
     @Convert(converter = DiscussionGroupConverter.class)
     @Column(name = "discussion_group", length = 1)
     private DiscussionGroup discussionGroup;

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/member/Member.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/member/Member.java
@@ -1,7 +1,7 @@
 package com.geulnamu.domain.member;
 
+import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.Meeting;
-import com.geulnamu.domain.meetingAttendance.MeetingAttendance;
 import com.geulnamu.domain.shared.*;
 import com.geulnamu.domain.shared.converter.GenderConverter;
 import com.geulnamu.domain.shared.enums.Role;
@@ -49,7 +49,7 @@ public class Member extends DateColumn {
     private List<Meeting> meetings;
 
     @OneToMany(mappedBy = "member", fetch = FetchType.LAZY)
-    private List<MeetingAttendance> meetingAttendances;
+    private List<Attendance> attendances;
 
     @Column(name = "kakao_user_id", nullable = false, length = 50)
     private String kakaoUserId;

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/member/Member.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/member/Member.java
@@ -71,14 +71,14 @@ public class Member extends DateColumn {
 
     public void updateMemberName(String newName) {
         if(this.name != null && this.name.equals(newName)) {
-            throw new ExistDataException();
+            throw new ExistDataException("name");
         }
         this.name = newName;
     }
 
     public void updateMemberRole(Role newRole) {
         if(this.role.equals(newRole)) {
-            throw new ExistDataException();
+            throw new ExistDataException("role");
         }
         this.role = newRole;
         this.refreshToken = null; // 역할에 따라 권한이 다르기에 재접속을 강제하기 위해 리프레시 토큰 말소시킴
@@ -98,14 +98,14 @@ public class Member extends DateColumn {
 
     public void activate() {
         if(this.deletedAt == null) {
-            throw new ExistDataException();
+            throw new ExistDataException("deletedAt");
         }
         this.deletedAt = null;
     }
 
     public void deactivate() {
         if(this.deletedAt != null) {
-            throw new ExistDataException();
+            throw new ExistDataException("deletedAt");
         }
         this.refreshToken = null; // 비활성화 계정 강제 로그아웃을 위한 설정
         this.deletedAt = LocalDateTime.now();

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/converter/DiscussionGroupConverter.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/converter/DiscussionGroupConverter.java
@@ -1,6 +1,6 @@
 package com.geulnamu.domain.shared.converter;
 
-import com.geulnamu.domain.meetingAttendance.DiscussionGroup;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 
 public class DiscussionGroupConverter extends EnumConverter<DiscussionGroup> {
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
@@ -14,11 +14,15 @@ public enum ActionType {
     MEMBER_ACTIVATE("모임원 활성화"),
     MEMBER_DEACTIVATE("모임원 비활성화"),
 
-    // 모임 관리
+    // 모임 관련
     MEETING_CREATE("모임 생성"),
     MEETING_UPDATE("모임 수정"),
     MEETING_UPDATE_DISCUSSION("모임 토론 정보 수정"),
-    MEETING_DELETE("모임 삭제");
+    MEETING_DELETE("모임 삭제"),
+
+    // 출석 관련
+    ATTENDANCE_CREATE("출석");
+
 
     private final String description;
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
@@ -22,8 +22,9 @@ public enum ActionType {
 
     // 출석 관련
     ATTENDANCE_CREATE("출석"),
-    ATTENDANCE_DELETE("출석 삭제");
-
+    ATTENDANCE_DELETE("출석 삭제"),
+    DISCUSSION_GROUP_ORGANIZE("토론 그룹 구성"),
+    DISCUSSION_GROUP_ORGANIZE_SOLO("개인 토론 그룹 할당");
 
     private final String description;
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/ActionType.java
@@ -21,7 +21,8 @@ public enum ActionType {
     MEETING_DELETE("모임 삭제"),
 
     // 출석 관련
-    ATTENDANCE_CREATE("출석");
+    ATTENDANCE_CREATE("출석"),
+    ATTENDANCE_DELETE("출석 삭제");
 
 
     private final String description;

--- a/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/DomainType.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/domain/shared/enums/DomainType.java
@@ -1,0 +1,16 @@
+package com.geulnamu.domain.shared.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum DomainType {
+    MEMBER("member"),
+    MEETING("meeting"),
+    ATTENDANCE("attendance"),
+    BOOK_HISTORY("book_history"),
+    ACTION_HISTORY("action_history");
+
+    private final String description;
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -39,6 +39,10 @@ public class SecurityConfig {
         "/meeting/list/staff",
         "/attendance",
         "/attendance/{attendanceId}/my",
+        "/attendance/{attendanceId}",
+        "/attendance/{attendanceId}/note",
+        "/attendance/{attendanceId}/just-read",
+        "/attendance/{attendanceId}/want-discussion"
     };
 
     private static final String[] AUTH_FOR_STAFF = {
@@ -46,6 +50,7 @@ public class SecurityConfig {
         "/meeting/{meetingId}",
         "/meeting/{meetingId}/discussion",
         "/attendance/discussion",
+        "/attendance/discussion/all",
         "/attendance/group"
     };
 
@@ -55,8 +60,8 @@ public class SecurityConfig {
         "/meeting/list/admin",
         "/meeting/{meetingId}/private",
         "/meeting/{meetingId}/public",
-        "/attendance/{attendanceId}/delete",
-        "/attendance/group/solo"
+        "/attendance/group/solo",
+        "/attendance/{attendanceId}/delete"
     };
 
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -37,7 +37,8 @@ public class SecurityConfig {
         "/member/info",
         "/meeting/list",
         "/meeting/list/staff",
-        "/attendance/{meetingId}"
+        "/attendance/{meetingId}/**",
+        "/attendance/{attendanceId}/my",
     };
 
     private static final String[] AUTH_FOR_STAFF = {

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
         "/meeting/list/staff",
         "/attendance",
         "/attendance/{attendanceId}/my",
-        "/attendance/{attendanceId}",
+        "/attendance/discussion/{attendanceId}",
         "/attendance/{attendanceId}/note",
         "/attendance/{attendanceId}/just-read",
         "/attendance/{attendanceId}/want-discussion"

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -37,14 +37,16 @@ public class SecurityConfig {
         "/member/info",
         "/meeting/list",
         "/meeting/list/staff",
-        "/attendance/{meetingId}/**",
+        "/attendance",
         "/attendance/{attendanceId}/my",
     };
 
     private static final String[] AUTH_FOR_STAFF = {
         "/meeting",
         "/meeting/{meetingId}",
-        "/meeting/{meetingId}/discussion"
+        "/meeting/{meetingId}/discussion",
+        "/attendance/discussion",
+        "/attendance/group"
     };
 
     private static final String[] AUTH_FOR_ADMIN = {
@@ -53,7 +55,8 @@ public class SecurityConfig {
         "/meeting/list/admin",
         "/meeting/{meetingId}/private",
         "/meeting/{meetingId}/public",
-        "/attendance/{attendanceId}/delete"
+        "/attendance/{attendanceId}/delete",
+        "/attendance/group/solo"
     };
 
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -35,12 +35,15 @@ public class SecurityConfig {
     private static final String[] AUTH_ALL = {
         "/login/logout",
         "/member/info",
-        "/meeting/list"
+        "/meeting/list",
+        "/meeting/list/staff",
+        "/attendance/{meetingId}"
     };
 
     private static final String[] AUTH_FOR_STAFF = {
         "/meeting",
-        "/meeting/{meetingId}"
+        "/meeting/{meetingId}",
+        "/meeting/{meetingId}/discussion"
     };
 
     private static final String[] AUTH_FOR_ADMIN = {

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/config/security/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
         "/member/list",
         "/meeting/list/admin",
         "/meeting/{meetingId}/private",
-        "/meeting/{meetingId}/public"
+        "/meeting/{meetingId}/public",
+        "/attendance/{attendanceId}/delete"
     };
 
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/exception/GlobalExceptionHandler.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -23,6 +24,16 @@ public class GlobalExceptionHandler {
     public BaseResponse serverExceptionHandler(ServerException exception) {
         log.error("message: {} ", exception.getMessage());
         return BaseResponse.ofFail(exception.getCode(), exception.getMessage(), exception.getField());
+    }
+
+    /**
+     * HTTP 요청 타입이 잘못됨
+     * HttpStatus 400
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public BaseResponse httpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException exception){
+        log.error("message : {} : {}", ResponseMessage.BAD_REQUEST, exception.getMessage());
+        return BaseResponse.ofFail(400, ResponseMessage.BAD_REQUEST, exception.getMessage());
     }
 
     /**

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/exception/NotFoundDataException.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/exception/NotFoundDataException.java
@@ -11,6 +11,6 @@ public class NotFoundDataException extends ServerException {
     }
 
     public NotFoundDataException(String message) {
-        super(404, message);
+        super(404, ResponseMessage.NOT_FOUND, message);
     }
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -27,6 +27,9 @@ public class ResponseMessage {
 
     public static final String ATTENDANCE_DUPLICATE_ISSUE = "하나의 모임을 중복으로 출석할 수 없습니다.";
 
+    public static final String OVER_DISCUSSION_GROUP_NUMBER = "토론 그룹은 현재 최대 7개 까지만 가능합니다.";
+    public static final String MEMBER_DUPLICATE_DISCUSSION_GROUP_ASSIGNMENT = "특정 모임원이 2개 이상의 토론 그룹에 담겨 있습니다.";
+
     public static final String ACCESS_TOKEN_NOT_VALIDATE = "액세스 토큰이 유효하지 않습니다."; // 401
     public static final String REFRESH_TOKEN_NOT_VALIDATE = "리프레시 토큰이 유효하지 않습니다. 다시 로그인 해 주세요."; // 401
     public static final String NOT_FOUND_ACCESS_TOKEN = "액세스 토큰을 발견하지 못했습니다."; // 401

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -4,7 +4,7 @@ public class ResponseMessage {
     public static final String SUCCESS = "API 호출에 성공했습니다."; // 200
 
     public static final String BAD_REQUEST = "잘못된 요청입니다."; // 400
-    public static final String NOT_SUITABLE_MEMBER = "해당 기능을 수행할 수 있는 당사자가 압니다.";
+    public static final String NOT_SUITABLE_MEMBER = "해당 기능을 수행할 수 있는 당사자가 아닙니다.";
     public static final String NO_AUTHENTICATION = "인증 정보가 존재하지 않습니다."; // 401
     public static final String FORBIDDEN = "접근 권한이 없습니다."; // 403
     public static final String NOT_FOUND = "조회된 데이터가 없습니다."; // 404

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -21,6 +21,7 @@ public class ResponseMessage {
     public static final String MEETING_PRIVACY_TIME_RESTRICTION  = "모임이 이뤄진 당일까지는 비공개 처리할 수 없습니다.";
     public static final String MEETING_DELETION_TIME_EXPIRED = "모임 시작 6시간 전부터는 삭제할 수 없습니다.";
     public static final String MEETING_ATTEND_TIME_RESTRICTION = "모임 출석은 모임 당일만, 모임 시작 1시간 전 부터 가능합니다.";
+    public static final String LATE_THRESHOLD_TIME_RESTRICTION = "지각 기준 시간은 모임 당일이어야 하고, 모임 시간보다 빠를 수 없습니다.";
     public static final String NOT_YET_SETTING_DISCUSSION_TIME = "토론 시간이 아직 설정되지 않았습니다.";
     public static final String DISCUSSION_INTENTION_SETTING_TIME_RESTRICTION = "토론 불참 의사는 토론 시작 30분 전 까지만 가능합니다.";
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -4,6 +4,7 @@ public class ResponseMessage {
     public static final String SUCCESS = "API 호출에 성공했습니다."; // 200
 
     public static final String BAD_REQUEST = "잘못된 요청입니다."; // 400
+    public static final String NOT_SUITABLE_MEMBER = "해당 기능을 수행할 수 있는 당사자가 압니다.";
     public static final String NO_AUTHENTICATION = "인증 정보가 존재하지 않습니다."; // 401
     public static final String FORBIDDEN = "접근 권한이 없습니다."; // 403
     public static final String NOT_FOUND = "조회된 데이터가 없습니다."; // 404
@@ -20,6 +21,8 @@ public class ResponseMessage {
     public static final String MEETING_PRIVACY_TIME_RESTRICTION  = "모임이 이뤄진 당일까지는 비공개 처리할 수 없습니다.";
     public static final String MEETING_DELETION_TIME_EXPIRED = "모임 시작 6시간 전부터는 삭제할 수 없습니다.";
     public static final String MEETING_ATTEND_TIME_RESTRICTION = "모임 출석은 모임 당일만, 모임 시작 1시간 전 부터 가능합니다.";
+    public static final String NOT_YET_SETTING_DISCUSSION_TIME = "토론 시간이 아직 설정되지 않았습니다.";
+    public static final String DISCUSSION_INTENTION_SETTING_TIME_RESTRICTION = "토론 불참 의사는 토론 시작 30분 전 까지만 가능합니다.";
 
     public static final String ATTENDANCE_DUPLICATE_ISSUE = "하나의 모임을 중복으로 출석할 수 없습니다.";
 

--- a/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/infrastructure/response/ResponseMessage.java
@@ -19,6 +19,9 @@ public class ResponseMessage {
     public static final String MEETING_DISCUSSION_TIME_RESTRICTION = "토론 시간은 모임 당일 내에서만, 모임 시간 이후로 가능합니다.";
     public static final String MEETING_PRIVACY_TIME_RESTRICTION  = "모임이 이뤄진 당일까지는 비공개 처리할 수 없습니다.";
     public static final String MEETING_DELETION_TIME_EXPIRED = "모임 시작 6시간 전부터는 삭제할 수 없습니다.";
+    public static final String MEETING_ATTEND_TIME_RESTRICTION = "모임 출석은 모임 당일만, 모임 시작 1시간 전 부터 가능합니다.";
+
+    public static final String ATTENDANCE_DUPLICATE_ISSUE = "하나의 모임을 중복으로 출석할 수 없습니다.";
 
     public static final String ACCESS_TOKEN_NOT_VALIDATE = "액세스 토큰이 유효하지 않습니다."; // 401
     public static final String REFRESH_TOKEN_NOT_VALIDATE = "리프레시 토큰이 유효하지 않습니다. 다시 로그인 해 주세요."; // 401

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceCommandRepository.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceCommandRepository.java
@@ -1,0 +1,7 @@
+package com.geulnamu.repository.attendance;
+
+import com.geulnamu.domain.attendance.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttendanceCommandRepository extends JpaRepository<Attendance, Long> {
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceCommandRepository.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceCommandRepository.java
@@ -1,7 +1,28 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.domain.attendance.Attendance;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface AttendanceCommandRepository extends JpaRepository<Attendance, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE attendances a " +
+        "SET a.discussionGroup = null " +
+        "WHERE a.meeting.id = :meetingId")
+    void resetDiscussionGroups(@Param("meetingId") Long meetingId);
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE attendances a " +
+        "SET a.discussionGroup = :group " +
+        "WHERE a.meeting.id = :meetingId " +
+        "AND a.member.id IN :memberIds ")
+    void assignDiscussionGroup(@Param("meetingId") Long meetingId,
+                               @Param("memberIds") List<Long> memberIds,
+                               @Param("group") DiscussionGroup group);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
@@ -1,0 +1,12 @@
+package com.geulnamu.repository.attendance;
+
+import com.geulnamu.domain.attendance.Attendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AttendanceQueryRepository extends JpaRepository<Attendance, Long> {
+
+    Optional<Attendance> findByMeetingIdAndMemberId(Long meetingId, Long memberId);
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
@@ -3,8 +3,11 @@ package com.geulnamu.repository.attendance;
 import com.geulnamu.domain.attendance.Attendance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AttendanceQueryRepository extends JpaRepository<Attendance, Long>, AttendanceQueryRepositoryCustom {
     Optional<Attendance> findByMeetingIdAndMemberId(Long meetingId, Long memberId);
+    List<Attendance> findByMeetingId(Long meetingId);
+    List<Attendance> findByMeetingIdAndMemberIdIn(Long meetingId, List<Long> memberIds);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface AttendanceQueryRepository extends JpaRepository<Attendance, Long> {
-
+public interface AttendanceQueryRepository extends JpaRepository<Attendance, Long>, AttendanceQueryRepositoryCustom {
     Optional<Attendance> findByMeetingIdAndMemberId(Long meetingId, Long memberId);
-
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -1,9 +1,10 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.DiscussionGroupResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.DiscussionGroup;
 
 import java.util.List;
@@ -14,5 +15,6 @@ public interface AttendanceQueryRepositoryCustom {
     MeetingAttendanceSummaryResponse findMeetingAttendanceSummary(Long meetingId);
     List<MemberIdAndNameResponse> findWantDiscussionMemberList(Long meetingId);
     List<MemberIdAndNameResponse> findMyDiscussionMemberList(Long meetingId, DiscussionGroup discussionGroup);
+    List<DiscussionGroupResponse> findAllDiscussionGroupMemberList(Long meetingId);
     List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -4,6 +4,7 @@ import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +13,6 @@ public interface AttendanceQueryRepositoryCustom {
     Optional<AttendanceInfoResponse> findMyAttendanceInfo(Long attendanceId, Long memberId);
     MeetingAttendanceSummaryResponse findMeetingAttendanceSummary(Long meetingId);
     List<MemberIdAndNameResponse> findWantDiscussionMemberList(Long meetingId);
+    List<MemberIdAndNameResponse> findMyDiscussionMemberList(Long meetingId, DiscussionGroup discussionGroup);
     List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -1,9 +1,14 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface AttendanceQueryRepositoryCustom {
     Optional<AttendanceInfoResponse> findMyAttendanceInfo(Long attendanceId, Long memberId);
+    MeetingAttendanceSummaryResponse findMeetingAttendanceSummary(Long meetingId);
+    List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -3,6 +3,7 @@ package com.geulnamu.repository.attendance;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 
 import java.util.List;
 import java.util.Optional;
@@ -10,5 +11,6 @@ import java.util.Optional;
 public interface AttendanceQueryRepositoryCustom {
     Optional<AttendanceInfoResponse> findMyAttendanceInfo(Long attendanceId, Long memberId);
     MeetingAttendanceSummaryResponse findMeetingAttendanceSummary(Long meetingId);
+    List<MemberIdAndNameResponse> findWantDiscussionMemberList(Long meetingId);
     List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.geulnamu.repository.attendance;
+
+import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+
+import java.util.Optional;
+
+public interface AttendanceQueryRepositoryCustom {
+    Optional<AttendanceInfoResponse> findMyAttendanceInfo(Long attendanceId, Long memberId);
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.QMeeting;
 import com.querydsl.core.types.Projections;
@@ -64,6 +65,19 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
             )
             .from(attendance)
             .where(attendance.meeting.id.eq(meetingId))
+            .orderBy(attendance.member.id.asc())
+            .fetch();
+    }
+
+    @Override
+    public List<MemberIdAndNameResponse> findMyDiscussionMemberList(Long meetingId, DiscussionGroup discussionGroup) {
+        return queryFactory
+            .select(Projections.constructor(MemberIdAndNameResponse.class,
+                attendance.member.id, attendance.member.name)
+            )
+            .from(meeting)
+            .join(attendance).on(meeting.id.eq(meetingId))
+            .where(attendance.discussionGroup.eq(discussionGroup))
             .orderBy(attendance.member.id.asc())
             .fetch();
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -1,14 +1,20 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.QMeeting;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -32,6 +38,41 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
             .where(attendance.id.eq(attendanceId)
                 .and(attendance.member.id.eq(memberId)))
             .fetchOne());
+    }
+
+    @Override
+    public MeetingAttendanceSummaryResponse findMeetingAttendanceSummary(Long meetingId) {
+        return queryFactory
+            .select(Projections.constructor(MeetingAttendanceSummaryResponse.class,
+                meeting.meetingDate, meeting.lateThresholdTime, attendance.member.count(),
+                    normalAttendanceCount(),
+                    attendance.member.count().subtract(normalAttendanceCount()))
+            )
+            .from(meeting)
+            .join(attendance).on(meeting.id.eq(attendance.meeting.id))
+            .where(meeting.id.eq(meetingId))
+            .orderBy(attendance.createdAt.desc())
+            .fetchOne();
+    }
+
+    public List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId) {
+        return queryFactory
+            .select(Projections.constructor(MeetingAttendanceStatusResponse.class,
+                attendance.member.id, attendance.member.name, attendance.createdAt, attendance.createdAt.after(meeting.lateThresholdTime))
+            )
+            .from(meeting)
+            .join(attendance).on(meeting.id.eq(attendance.meeting.id))
+            .where(meeting.id.eq(meetingId))
+            .orderBy(attendance.createdAt.desc())
+            .fetch();
+    }
+
+    private NumberExpression<Long> normalAttendanceCount() {
+        return new CaseBuilder()
+            .when(attendance.createdAt.before(meeting.lateThresholdTime))
+            .then(1)
+            .otherwise(0)
+            .longValue().sum();
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.geulnamu.repository.attendance;
+
+import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.domain.attendance.QAttendance;
+import com.geulnamu.domain.meeting.QMeeting;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QMeeting meeting = QMeeting.meeting;
+    private final QAttendance attendance = QAttendance.attendance;
+
+    @Override
+    public Optional<AttendanceInfoResponse> findMyAttendanceInfo(Long attendanceId, Long memberId) {
+        return Optional.ofNullable(queryFactory
+            .select(Projections.constructor(AttendanceInfoResponse.class,
+                attendance.id, attendance.meeting.meetingType, attendance.meeting.meetingDate,
+                attendance.meeting.lateThresholdTime, attendance.meeting.meetingName, attendance.meeting.meetingPlace,
+                attendance.meeting.description, attendance.note, attendance.meeting.discussionTime,
+                Expressions.nullExpression(String.class), attendance.meeting.createdAt)
+            )
+            .from(attendance)
+            .where(attendance.id.eq(attendanceId)
+                .and(attendance.member.id.eq(memberId)))
+            .fetchOne());
+    }
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.geulnamu.repository.attendance;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.QMeeting;
 import com.querydsl.core.types.Projections;
@@ -53,6 +54,18 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
             .where(meeting.id.eq(meetingId))
             .orderBy(attendance.createdAt.desc())
             .fetchOne();
+    }
+
+    @Override
+    public List<MemberIdAndNameResponse> findWantDiscussionMemberList(Long meetingId) {
+        return queryFactory
+            .select(Projections.constructor(MemberIdAndNameResponse.class,
+                attendance.member.id, attendance.member.name)
+            )
+            .from(attendance)
+            .where(attendance.meeting.id.eq(meetingId))
+            .orderBy(attendance.member.id.asc())
+            .fetch();
     }
 
     public List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId) {

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -1,23 +1,26 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.DiscussionGroupResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.QMeeting;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberExpression;
-import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Repository
 @RequiredArgsConstructor
@@ -75,11 +78,42 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
             .select(Projections.constructor(MemberIdAndNameResponse.class,
                 attendance.member.id, attendance.member.name)
             )
-            .from(meeting)
-            .join(attendance).on(meeting.id.eq(meetingId))
-            .where(attendance.discussionGroup.eq(discussionGroup))
+            .from(attendance)
+            .where(attendance.meeting.id.eq(meetingId),
+                attendance.discussionGroup.eq(discussionGroup))
             .orderBy(attendance.member.id.asc())
             .fetch();
+    }
+
+    @Override
+    public List<DiscussionGroupResponse> findAllDiscussionGroupMemberList(Long meetingId) {
+        // meetingId 값을 기준으로 모두 조회
+        List<Tuple> results = queryFactory
+            .select(attendance.discussionGroup, attendance.member.id, attendance.member.name)
+            .from(attendance)
+            .where(attendance.meeting.id.eq(meetingId)
+                .and(attendance.discussionGroup.isNotNull()))
+            .orderBy(attendance.discussionGroup.asc(), attendance.member.id.asc())
+            .fetch();
+
+        // discussionGroup 값을 기준으로 같은 discussionGroup 끼리 List로 묶어서 map 으로 만들기
+        Map<DiscussionGroup, List<MemberIdAndNameResponse>> groupMap = results.stream()
+            .collect(Collectors.groupingBy(
+                tuple -> tuple.get(attendance.discussionGroup),
+                Collectors.mapping(
+                    tuple -> new MemberIdAndNameResponse(
+                        tuple.get(attendance.member.id),
+                        tuple.get(attendance.member.name)
+                    ),
+                    Collectors.toList()
+                )
+            ));
+
+        // 맵들을 discussionGroup 값으로 정렬하고, 값들을 DiscussionGroupResponse 타입에 담아 전체를 list로 만들어 반환
+        return groupMap.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(entry -> new DiscussionGroupResponse(entry.getValue()))
+            .collect(Collectors.toList());
     }
 
     public List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId) {

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -3,7 +3,7 @@ package com.geulnamu.repository.meeting;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import org.springframework.data.domain.Page;
 
 import java.util.List;

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.geulnamu.repository.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
+import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.StaffResponse;
 import org.springframework.data.domain.Page;
@@ -9,7 +10,6 @@ import java.util.List;
 
 public interface MeetingQueryRepositoryCustom {
     List<StaffResponse> findStaffList();
-    Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request);
-    Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(MeetingListRequest request);
-
+    Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId);
+    Page<MeetingInfoForAdminResponse> findMeetingsForAdminWithPaging(MeetingListRequest request);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -3,13 +3,13 @@ package com.geulnamu.repository.meeting;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface MeetingQueryRepositoryCustom {
-    List<StaffResponse> findStaffList();
+    List<MemberIdAndNameResponse> findStaffList();
     Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId);
     Page<MeetingInfoForAdminResponse> findMeetingsForAdminWithPaging(MeetingListRequest request);
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.geulnamu.repository.meeting;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.AttendanceStatus;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.MeetingType;
@@ -34,9 +34,9 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
 
 
     @Override
-    public List<StaffResponse> findStaffList() {
+    public List<MemberIdAndNameResponse> findStaffList() {
         return queryFactory
-            .select(Projections.constructor(StaffResponse.class,
+            .select(Projections.constructor(MemberIdAndNameResponse.class,
                 member.id, member.name)
             )
             .from(meeting)

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -1,8 +1,11 @@
 package com.geulnamu.repository.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
+import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
 import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.domain.attendance.AttendanceStatus;
+import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.meeting.QMeeting;
 import com.geulnamu.domain.member.QMember;
@@ -10,7 +13,7 @@ import com.geulnamu.infrastructure.util.QueryDslUtil;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.*;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -27,6 +30,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     private final JPAQueryFactory queryFactory;
     private final QMeeting meeting = QMeeting.meeting;
     private final QMember member = QMember.member;
+    private final QAttendance attendance = QAttendance.attendance;
 
 
     @Override
@@ -42,28 +46,34 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     }
 
     @Override
-    public Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request) {
+    public Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId) {
         Pageable pageable = request.toPageable();
 
         List<Long> count = queryFactory
             .select(meeting.count())
             .from(meeting)
+            .leftJoin(attendance).on(meeting.id.eq(attendance.meeting.id)
+                .and(attendance.member.id.eq(myMemberId)))
             .where(meeting.privateAt.isNull(),
                 filterByMeetingType(request.getMeetingType()),
-                filterByMemberId(request.getMeetingCreatorId())
+                filterByMemberId(request.getMeetingCreatorId()),
+                filterByAttendanceStatus(request.getAttendanceStatus())
             )
             .fetch();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
-                meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
-                meeting.createdAt, meeting.privateAt.isNotNull())
+                meeting.meetingPlace, meeting.description, attendanceStatusExpression(), attendance.discussionGroup,
+                meeting.discussionTime, meeting.alarmMessage, meeting.createdAt)
             )
             .from(meeting)
+            .leftJoin(attendance).on(meeting.id.eq(attendance.meeting.id)
+                .and(attendance.member.id.eq(myMemberId)))
             .where(meeting.privateAt.isNull(),
                 filterByMeetingType(request.getMeetingType()),
-                filterByMemberId(request.getMeetingCreatorId())
+                filterByMemberId(request.getMeetingCreatorId()),
+                filterByAttendanceStatus(request.getAttendanceStatus())
             )
             .orderBy(customSorting(request.getSortBy(), request.getIsAsc()),
                 meeting.id.desc())
@@ -75,7 +85,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     }
 
     @Override
-    public Page<MeetingInfoResponse> findMeetingsForAdminWithPaging(MeetingListRequest request) {
+    public Page<MeetingInfoForAdminResponse> findMeetingsForAdminWithPaging(MeetingListRequest request) {
         Pageable pageable = request.toPageable();
 
         List<Long> count = queryFactory
@@ -88,11 +98,11 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
             )
             .fetch();
 
-        List<MeetingInfoResponse> content = queryFactory
-            .select(Projections.constructor(MeetingInfoResponse.class,
+        List<MeetingInfoForAdminResponse> content = queryFactory
+            .select(Projections.constructor(MeetingInfoForAdminResponse.class,
                 meeting.id, meeting.member.name, meeting.meetingType, meeting.meetingName, meeting.meetingDate,
-                meeting.meetingPlace, meeting.description, meeting.discussionTime, meeting.alarmMessage,
-                meeting.createdAt, meeting.privateAt.isNotNull())
+                meeting.lateThresholdTime, meeting.meetingPlace, meeting.description, meeting.discussionTime,
+                meeting.alarmMessage, meeting.createdAt, meeting.privateAt.isNotNull())
             )
             .from(meeting)
             .where(
@@ -109,6 +119,16 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
         return PageableExecutionUtils.getPage(content, pageable, count::size);
     }
 
+
+    private StringExpression attendanceStatusExpression() {
+        return new CaseBuilder()
+            .when(attendance.id.isNull())
+            .then(AttendanceStatus.NOT_ATTENDED.getValue())
+            .when(attendance.createdAt.before(meeting.lateThresholdTime))
+            .then(AttendanceStatus.ATTENDED.getValue())
+            .otherwise(AttendanceStatus.ATTENDED_LATE.getValue())
+            .as("attendanceStatus");
+    }
 
     BooleanExpression filterByMeetingType(MeetingType meetingType) {
         if(meetingType == null) return meeting.meetingType.isNotNull();
@@ -128,6 +148,13 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
         if(isPrivate == null) return null;
         else if(isPrivate.equals(false)) return meeting.privateAt.isNull();
         else return meeting.privateAt.isNotNull();
+    }
+
+    BooleanExpression filterByAttendanceStatus(String attendanceStatus) {
+        if(attendanceStatus == null) return null;
+        else if(attendanceStatus.equals(AttendanceStatus.ATTENDED.getValue())) return attendance.id.isNotNull();
+        else if(attendanceStatus.equals(AttendanceStatus.ATTENDED_LATE.getValue())) return attendance.createdAt.after(meeting.lateThresholdTime);
+        else return attendance.id.isNull();
     }
 
     // 기본 정렬 기준은 이름 오름차순, 다른 정렬 기준을 사용하더라도 2차 정렬 기준은 다시 이름 오름차순

--- a/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -3,7 +3,7 @@ package com.geulnamu.repository.meeting;
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoForAdminResponse;
 import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.AttendanceStatus;
 import com.geulnamu.domain.attendance.QAttendance;
 import com.geulnamu.domain.meeting.MeetingType;

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -1,6 +1,9 @@
 package com.geulnamu.service.attendance;
 
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
@@ -14,6 +17,8 @@ import com.geulnamu.repository.member.MemberQueryRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @AllArgsConstructor
@@ -43,8 +48,16 @@ public class AttendanceService {
     }
 
     @Transactional(readOnly = true)
-    public AttendanceInfoResponse getAttendanceInfo(Long attendanceId, Long memberId) {
+    public AttendanceInfoResponse getMyAttendanceInfo(Long attendanceId, Long memberId) {
         return attendanceQueryRepository.findMyAttendanceInfo(attendanceId, memberId).orElseThrow(NotFoundDataException::new);
+    }
+
+    @Transactional(readOnly = true)
+    public MeetingAttendanceDetailsResponse getMeetingAttendanceStatus(Long meetingId) {
+        MeetingAttendanceSummaryResponse meetingAttendanceSummaryResponse = attendanceQueryRepository.findMeetingAttendanceSummary(meetingId);
+        List<MeetingAttendanceStatusResponse> meetingAttendanceStatusResponseList
+            = attendanceQueryRepository.findMeetingAttendanceStatus(meetingId);
+        return new MeetingAttendanceDetailsResponse(meetingAttendanceSummaryResponse, meetingAttendanceStatusResponseList);
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -26,7 +26,7 @@ public class AttendanceService {
 
     // TODO: 추후 lock을 걸지 고민해 볼 것
     @Transactional(rollbackFor = Exception.class)
-    public void createAttendance(Long meetingId, Long memberId) {
+    public Long createAttendance(Long meetingId, Long memberId) {
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
 
@@ -39,6 +39,13 @@ public class AttendanceService {
 
         Attendance attendance = Attendance.createAttendance(meeting, member);
         attendanceCommandRepository.save(attendance);
+        return attendance.getId();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void deleteAttendance(Long attendanceId) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
+        attendanceQueryRepository.delete(attendance);
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -2,11 +2,8 @@ package com.geulnamu.service.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.DiscussionGroupRequest;
 import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
-import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.attendance.dto.response.*;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.Meeting;
@@ -78,6 +75,11 @@ public class AttendanceService {
         attendance.validateDiscussionGroupMemberListRequestedPerson(memberId);
         return attendanceQueryRepository.findMyDiscussionMemberList(attendance.getMeeting().getId(),
             attendance.getDiscussionGroup());
+    }
+
+    @Transactional(readOnly = true)
+    public List<DiscussionGroupResponse> getAllDiscussionGroupMemberList(Long meetingId) {
+        return attendanceQueryRepository.findAllDiscussionGroupMemberList(meetingId);
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -1,12 +1,17 @@
 package com.geulnamu.service.attendance;
 
+import com.geulnamu.controller.attendance.dto.request.DiscussionGroupRequest;
+import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.Attendance;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
+import com.geulnamu.domain.shared.enums.DomainType;
 import com.geulnamu.infrastructure.exception.BadRequestException;
 import com.geulnamu.infrastructure.exception.NotFoundDataException;
 import com.geulnamu.infrastructure.response.ResponseMessage;
@@ -18,6 +23,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -60,6 +66,11 @@ public class AttendanceService {
         return new MeetingAttendanceDetailsResponse(meetingAttendanceSummaryResponse, meetingAttendanceStatusResponseList);
     }
 
+    @Transactional(readOnly = true)
+    public List<MemberIdAndNameResponse> getWantDiscussionMemberList(Long meetingId) {
+        return attendanceQueryRepository.findWantDiscussionMemberList(meetingId);
+    }
+
     @Transactional(rollbackFor = Exception.class)
     public void writeNote(Long attendanceId, Long memberId, String note) {
         Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
@@ -98,9 +109,52 @@ public class AttendanceService {
     }
 
     @Transactional(rollbackFor = Exception.class)
+    public void manuallyAssignDiscussionGroups(Long meetingId, AssignDiscussionGroupsRequest request) {
+        meetingQueryRepository.findById(meetingId).orElseThrow(() -> new NotFoundDataException(DomainType.MEETING.getDescription()));
+        validateGroupNumberOver(request.getGroups().size()); // 토론 그룹 수 (7개) 초과 체크
+        validateDiscussionGroupAssignment(request); // 모임원 그룹 중복 할당 체크
+        attendanceCommandRepository.resetDiscussionGroups(meetingId); // 기존 그룹 생성 했었다면 초기화 (bulk update)
+        assignGroupsToMembers(request, meetingId); // 토론 그룹 할당
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void assignMemberToDiscussionGroup(Long meetingId, Long memberId, Integer optimizedGroupNumber) {
+        meetingQueryRepository.findById(meetingId).orElseThrow(() -> new NotFoundDataException(DomainType.MEETING.getDescription()));
+        validateGroupNumberOver(optimizedGroupNumber);
+        Attendance attendance = attendanceQueryRepository.findByMeetingIdAndMemberId(meetingId, memberId)
+            .orElseThrow(() -> new NotFoundDataException(DomainType.ATTENDANCE.getDescription()));
+        attendance.updateDiscussionGroup(DiscussionGroup.values()[optimizedGroupNumber]);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
     public void deleteAttendance(Long attendanceId) {
         Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
         attendanceQueryRepository.delete(attendance);
+    }
+
+
+    private static void validateGroupNumberOver(int requestGroupSize) {
+        if(requestGroupSize > DiscussionGroup.values().length) {
+            throw new BadRequestException(ResponseMessage.OVER_DISCUSSION_GROUP_NUMBER);
+        }
+    }
+
+    private static void validateDiscussionGroupAssignment(AssignDiscussionGroupsRequest request) {
+        List<Long> memberIdList = new ArrayList<>();
+        for(DiscussionGroupRequest requestList : request.getGroups()) {
+            memberIdList.addAll(requestList.getMemberIdList());
+        }
+        if(memberIdList.size() != memberIdList.stream().distinct().count()) {
+            throw new BadRequestException(ResponseMessage.MEMBER_DUPLICATE_DISCUSSION_GROUP_ASSIGNMENT);
+        }
+    }
+
+    // 그룹 할당 - 그룹 별로 bulk update 진행 TODO: 현재는 그룹장을 따로 선별하지 않음, 추후 실 운영하면서 그룹장도 요청으로 받을지 고려해 볼 것
+    private void assignGroupsToMembers(AssignDiscussionGroupsRequest request, Long meetingId) {
+        for(int i = 0; i < request.getGroups().size(); i++) {
+            List<Long> memberIds = request.getGroups().get(i).getMemberIdList();
+            attendanceCommandRepository.assignDiscussionGroup(meetingId, memberIds, DiscussionGroup.values()[i]);
+        }
     }
 
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -71,6 +71,15 @@ public class AttendanceService {
         return attendanceQueryRepository.findWantDiscussionMemberList(meetingId);
     }
 
+    @Transactional(readOnly = true)
+    public List<MemberIdAndNameResponse> getMyDiscussionMemberList(Long attendanceId, Long memberId) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId)
+            .orElseThrow(() -> new NotFoundDataException(DomainType.ATTENDANCE.getDescription()));
+        attendance.validateDiscussionGroupMemberListRequestedPerson(memberId);
+        return attendanceQueryRepository.findMyDiscussionMemberList(attendance.getMeeting().getId(),
+            attendance.getDiscussionGroup());
+    }
+
     @Transactional(rollbackFor = Exception.class)
     public void writeNote(Long attendanceId, Long memberId, String note) {
         Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -7,7 +7,6 @@ import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.Meeting;
-import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.enums.DomainType;
 import com.geulnamu.infrastructure.exception.BadRequestException;
 import com.geulnamu.infrastructure.exception.NotFoundDataException;
@@ -15,7 +14,6 @@ import com.geulnamu.infrastructure.response.ResponseMessage;
 import com.geulnamu.repository.attendance.AttendanceCommandRepository;
 import com.geulnamu.repository.attendance.AttendanceQueryRepository;
 import com.geulnamu.repository.meeting.MeetingQueryRepository;
-import com.geulnamu.repository.member.MemberQueryRepository;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,17 +25,16 @@ import java.util.List;
 @AllArgsConstructor
 public class AttendanceService {
 
-    private final MemberQueryRepository memberQueryRepository;
     private final MeetingQueryRepository meetingQueryRepository;
-    private final AttendanceCommandRepository attendanceCommandRepository;
     private final AttendanceQueryRepository attendanceQueryRepository;
+    private final AttendanceCommandRepository attendanceCommandRepository;
 
 
     // TODO: 추후 lock을 걸지 고민해 볼 것
     @Transactional(rollbackFor = Exception.class)
     public Long createAttendance(Long meetingId, Long memberId) {
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
-        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+        meeting.validateRequestedMember(memberId);
 
         meeting.checkTimeCanAttendMeeting();
         // 동일한 모임원이 해당 모임에 출석한 이력이 있는지 확인
@@ -45,14 +42,16 @@ public class AttendanceService {
             throw new BadRequestException(ResponseMessage.ATTENDANCE_DUPLICATE_ISSUE);
         }
 
-        Attendance attendance = Attendance.createAttendance(meeting, member);
+        Attendance attendance = Attendance.createAttendance(meeting, meeting.getMember());
         attendanceCommandRepository.save(attendance);
         return attendance.getId();
     }
 
     @Transactional(readOnly = true)
     public AttendanceInfoResponse getMyAttendanceInfo(Long attendanceId, Long memberId) {
-        return attendanceQueryRepository.findMyAttendanceInfo(attendanceId, memberId).orElseThrow(NotFoundDataException::new);
+        Attendance attendance = getValidateAttendance(attendanceId, memberId);
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList = getDiscussionGroupMembers(attendance);
+        return new AttendanceInfoResponse(attendance, memberIdAndNameResponseList);
     }
 
     @Transactional(readOnly = true)
@@ -70,9 +69,7 @@ public class AttendanceService {
 
     @Transactional(readOnly = true)
     public List<MemberIdAndNameResponse> getMyDiscussionMemberList(Long attendanceId, Long memberId) {
-        Attendance attendance = attendanceQueryRepository.findById(attendanceId)
-            .orElseThrow(() -> new NotFoundDataException(DomainType.ATTENDANCE.getDescription()));
-        attendance.validateDiscussionGroupMemberListRequestedPerson(memberId);
+        Attendance attendance = getValidateAttendance(attendanceId, memberId);
         return attendanceQueryRepository.findMyDiscussionMemberList(attendance.getMeeting().getId(),
             attendance.getDiscussionGroup());
     }
@@ -84,22 +81,15 @@ public class AttendanceService {
 
     @Transactional(rollbackFor = Exception.class)
     public void writeNote(Long attendanceId, Long memberId, String note) {
-        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
-        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
-
-        // 처리 가능한지 체크
-        attendance.checkRequestedMemberAndAttendanceMember(member);
-
+        Attendance attendance = getValidateAttendance(attendanceId, memberId);
         attendance.updateNote(note);
     }
 
     @Transactional(rollbackFor = Exception.class)
     public void notWantDiscussion(Long attendanceId, Long memberId) {
-        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
-        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+        Attendance attendance = getValidateAttendance(attendanceId, memberId);
 
         // 처리 가능한지 체크
-        attendance.checkRequestedMemberAndAttendanceMember(member);
         attendance.checkSettingDiscussionTime();
         attendance.getMeeting().checkTimeCanSwitchAboutDiscussionAttendance();
 
@@ -108,11 +98,9 @@ public class AttendanceService {
 
     @Transactional(rollbackFor = Exception.class)
     public void wantDiscussion(Long attendanceId, Long memberId) {
-        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
-        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+        Attendance attendance = getValidateAttendance(attendanceId, memberId);
 
         // 처리 가능한지 체크
-        attendance.checkRequestedMemberAndAttendanceMember(member);
         attendance.checkSettingDiscussionTime();
         attendance.getMeeting().checkTimeCanSwitchAboutDiscussionAttendance();
 
@@ -143,6 +131,19 @@ public class AttendanceService {
         attendanceQueryRepository.delete(attendance);
     }
 
+    private Attendance getValidateAttendance(Long attendanceId, Long memberId) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId)
+            .orElseThrow(() -> new NotFoundDataException(DomainType.ATTENDANCE.getDescription()));
+        attendance.validateRequestedPerson(memberId);
+        return attendance;
+    }
+
+    private List<MemberIdAndNameResponse> getDiscussionGroupMembers(Attendance attendance) {
+        return attendance.getDiscussionGroup() != null
+            ? attendanceQueryRepository.findMyDiscussionMemberList(
+            attendance.getMeeting().getId(), attendance.getDiscussionGroup())
+            : null;
+    }
 
     private static void validateGroupNumberOver(int requestGroupSize) {
         if(requestGroupSize > DiscussionGroup.values().length) {

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -1,5 +1,6 @@
 package com.geulnamu.service.attendance;
 
+import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
@@ -39,6 +40,11 @@ public class AttendanceService {
         Attendance attendance = Attendance.createAttendance(meeting, member);
         attendanceCommandRepository.save(attendance);
         return attendance.getId();
+    }
+
+    @Transactional(readOnly = true)
+    public AttendanceInfoResponse getAttendanceInfo(Long attendanceId, Long memberId) {
+        return attendanceQueryRepository.findMyAttendanceInfo(attendanceId, memberId).orElseThrow(NotFoundDataException::new);
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -1,0 +1,44 @@
+package com.geulnamu.service.attendance;
+
+import com.geulnamu.domain.attendance.Attendance;
+import com.geulnamu.domain.meeting.Meeting;
+import com.geulnamu.domain.member.Member;
+import com.geulnamu.infrastructure.exception.BadRequestException;
+import com.geulnamu.infrastructure.exception.NotFoundDataException;
+import com.geulnamu.infrastructure.response.ResponseMessage;
+import com.geulnamu.repository.attendance.AttendanceCommandRepository;
+import com.geulnamu.repository.attendance.AttendanceQueryRepository;
+import com.geulnamu.repository.meeting.MeetingQueryRepository;
+import com.geulnamu.repository.member.MemberQueryRepository;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@AllArgsConstructor
+public class AttendanceService {
+
+    private final MemberQueryRepository memberQueryRepository;
+    private final MeetingQueryRepository meetingQueryRepository;
+    private final AttendanceCommandRepository attendanceCommandRepository;
+    private final AttendanceQueryRepository attendanceQueryRepository;
+
+
+    // TODO: 추후 lock을 걸지 고민해 볼 것
+    @Transactional(rollbackFor = Exception.class)
+    public void createAttendance(Long meetingId, Long memberId) {
+        Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
+        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+
+        // 모임 출석 가능 시간 확인
+        meeting.checkTimeCanAttendMeeting();
+        // 동일한 모임원이 해당 모임에 출석한 이력이 있는지 확인
+        if(attendanceQueryRepository.findByMeetingIdAndMemberId(meetingId, memberId).isPresent()) {
+            throw new BadRequestException(ResponseMessage.ATTENDANCE_DUPLICATE_ISSUE);
+        }
+
+        Attendance attendance = Attendance.createAttendance(meeting, member);
+        attendanceCommandRepository.save(attendance);
+    }
+
+}

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -42,6 +42,17 @@ public class AttendanceService {
     }
 
     @Transactional(rollbackFor = Exception.class)
+    public void writeNote(Long attendanceId, Long memberId, String note) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
+        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+
+        // 처리 가능한지 체크
+        attendance.checkRequestedMemberAndAttendanceMember(member);
+
+        attendance.updateNote(note);
+    }
+
+    @Transactional(rollbackFor = Exception.class)
     public void notWantDiscussion(Long attendanceId, Long memberId) {
         Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -30,7 +30,6 @@ public class AttendanceService {
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
 
-        // 모임 출석 가능 시간 확인
         meeting.checkTimeCanAttendMeeting();
         // 동일한 모임원이 해당 모임에 출석한 이력이 있는지 확인
         if(attendanceQueryRepository.findByMeetingIdAndMemberId(meetingId, memberId).isPresent()) {
@@ -40,6 +39,32 @@ public class AttendanceService {
         Attendance attendance = Attendance.createAttendance(meeting, member);
         attendanceCommandRepository.save(attendance);
         return attendance.getId();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void notWantDiscussion(Long attendanceId, Long memberId) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
+        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+
+        // 처리 가능한지 체크
+        attendance.checkRequestedMemberAndAttendanceMember(member);
+        attendance.checkSettingDiscussionTime();
+        attendance.getMeeting().checkTimeCanSwitchAboutDiscussionAttendance();
+
+        attendance.updateNotWantDiscussion();
+    }
+
+    @Transactional(rollbackFor = Exception.class)
+    public void wantDiscussion(Long attendanceId, Long memberId) {
+        Attendance attendance = attendanceQueryRepository.findById(attendanceId).orElseThrow(NotFoundDataException::new);
+        Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
+
+        // 처리 가능한지 체크
+        attendance.checkRequestedMemberAndAttendanceMember(member);
+        attendance.checkSettingDiscussionTime();
+        attendance.getMeeting().checkTimeCanSwitchAboutDiscussionAttendance();
+
+        attendance.updateWantDiscussion();
     }
 
     @Transactional(rollbackFor = Exception.class)

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/login/LoginFacade.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/login/LoginFacade.java
@@ -13,8 +13,6 @@ import com.geulnamu.infrastructure.util.JwtTokenUtil;
 import com.geulnamu.repository.member.MemberCommandRepository;
 import com.geulnamu.repository.member.MemberQueryRepository;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -44,7 +42,7 @@ public class LoginFacade {
 
         // 2.회원 처리
         MemberResult memberResult = findOrCreateMember(userInfo);
-        Member member = memberResult.getMember();
+        Member member = memberResult.member();
         boolean isNewMember = memberResult.isNewMember();
 
         // 3. 토큰 생성 + 쿠키 설정
@@ -54,7 +52,7 @@ public class LoginFacade {
         // 4. 회원의 리프레시 토큰 업데이트(DB)
         member.updateMemberRefreshToken(tokenPair.refreshToken());
 
-        return LoginResponse.of(tokenPair.accessToken(), isNewMember);
+        return LoginResponse.of(member.getId(), tokenPair.accessToken(), isNewMember);
     }
 
     /**
@@ -112,7 +110,7 @@ public class LoginFacade {
 
         member.updateMemberRefreshToken(tokenPair.refreshToken());
 
-        return LoginResponse.of(tokenPair.accessToken(), false);
+        return LoginResponse.of(member.getId(), tokenPair.accessToken(), false);
     }
 
 
@@ -139,10 +137,5 @@ public class LoginFacade {
     /**
      * 회원 조회/생성 결과를 담는 내부 클래스
      */
-    @Getter
-    @AllArgsConstructor
-    private static class MemberResult {
-        private final Member member;
-        private final boolean isNewMember;
-    }
+    private record MemberResult(Member member, boolean isNewMember) {}
 }

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -2,6 +2,7 @@ package com.geulnamu.service.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
 import com.geulnamu.controller.meeting.dto.response.*;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.member.Member;

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -34,10 +34,11 @@ public class MeetingService {
 
 
     @Transactional(rollbackFor = Exception.class)
-    public void createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
+    public Long createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
         Meeting meeting = Meeting.createMeeting(member, meetingName, meetingType, meetingDate, meetingPlace, description);
         meetingCommandRepository.save(meeting);
+        return meeting.getId();
     }
 
     @Transactional(readOnly = true)

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -1,9 +1,7 @@
 package com.geulnamu.service.meeting;
 
 import com.geulnamu.controller.meeting.dto.request.MeetingListRequest;
-import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
-import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.domain.member.Member;
@@ -34,17 +32,18 @@ public class MeetingService {
 
 
     @Transactional(rollbackFor = Exception.class)
-    public Long createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
+    public Long createMeeting(Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, LocalDateTime lateThresholdTime, String meetingPlace, String description) {
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
-        Meeting meeting = Meeting.createMeeting(member, meetingName, meetingType, meetingDate, meetingPlace, description);
+        Meeting meeting = Meeting.createMeeting(member, meetingName, meetingType, meetingDate, lateThresholdTime, meetingPlace, description);
+        meeting.checkLateThresholdTimeBeforeMeetingTime();
         meetingCommandRepository.save(meeting);
         return meeting.getId();
     }
 
     @Transactional(readOnly = true)
-    public MeetingInfoResponse findMeeting(Long meetingId) {
+    public MeetingInfoForAdminResponse findMeeting(Long meetingId) {
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
-        return MeetingInfoResponse.of(meeting);
+        return MeetingInfoForAdminResponse.of(meeting);
     }
 
     @Transactional(readOnly = true)
@@ -53,8 +52,8 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingListResponse getMeetingList(MeetingListRequest request) {
-        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(request);
+    public MeetingListResponse getMeetingList(MeetingListRequest request, Long myMemberId) {
+        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(request, myMemberId);
 
         PagingResponse pagingResponse = PagingResponse.from(meetingDslList);
         List<MeetingInfoResponse> meetingList = meetingDslList.getContent();
@@ -62,16 +61,16 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingListResponse getMeetingListForAdmin(MeetingListRequest request) {
-        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsForAdminWithPaging(request);
+    public MeetingListForAdminResponse getMeetingListForAdmin(MeetingListRequest request) {
+        Page<MeetingInfoForAdminResponse> meetingDslList = meetingQueryRepository.findMeetingsForAdminWithPaging(request);
 
         PagingResponse pagingResponse = PagingResponse.from(meetingDslList);
-        List<MeetingInfoResponse> meetingList = meetingDslList.getContent();
-        return new MeetingListResponse(pagingResponse, meetingList);
+        List<MeetingInfoForAdminResponse> meetingList = meetingDslList.getContent();
+        return new MeetingListForAdminResponse(pagingResponse, meetingList);
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public void updateMeeting(Long meetingId, Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, String meetingPlace, String description) {
+    public void updateMeeting(Long meetingId, Long memberId, String meetingName, MeetingType meetingType, LocalDateTime meetingDate, LocalDateTime lateThresholdTime, String meetingPlace, String description) {
         // 모임 정보 수정 가능 권한 검사
         Meeting meeting = meetingQueryRepository.findById(meetingId).orElseThrow(NotFoundDataException::new);
         Member member = memberQueryRepository.findById(memberId).orElseThrow(NotFoundDataException::new);
@@ -89,6 +88,7 @@ public class MeetingService {
         if(meetingName != null) meeting.updateMeetingName(meetingName);
         if(meetingType != null) meeting.updateMeetingType(meetingType);
         if(meetingDate != null) meeting.updateMeetingDate(meetingDate);
+        if(lateThresholdTime != null) meeting.updateLateThresholdTime(lateThresholdTime);
         if(meetingPlace != null) meeting.updateMeetingPlace(meetingPlace);
         if(description != null) meeting.updateMeetingDescription(description);
     }

--- a/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu-backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -47,7 +47,7 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public List<StaffResponse> getStaffList() {
+    public List<MemberIdAndNameResponse> getStaffList() {
         return meetingQueryRepository.findStaffList();
     }
 

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -455,7 +455,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_get">GET</a>
 <ul class="sectlevel2">
-<li><a href="#_출석_정보_조회">출석 정보 조회</a></li>
+<li><a href="#_본인_출석_정보_조회">본인 출석 정보 조회</a></li>
+<li><a href="#_모임별_참석_현황_조회">모임별 참석 현황 조회</a></li>
 </ul>
 </li>
 <li><a href="#_patch">PATCH</a>
@@ -618,7 +619,7 @@ Content-Type: application/json;charset=UTF-8
 <h2 id="_get"><a class="link" href="#_get">GET</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_정보_조회"><a class="link" href="#_출석_정보_조회">출석 정보 조회</a></h3>
+<h3 id="_본인_출석_정보_조회"><a class="link" href="#_본인_출석_정보_조회">본인 출석 정보 조회</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -626,7 +627,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_2"><a class="link" href="#_request_2">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/1 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/1/my HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -828,13 +829,8 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
+<h3 id="_모임별_참석_현황_조회"><a class="link" href="#_모임별_참석_현황_조회">모임별 참석 현황 조회</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -842,16 +838,11 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 43
-Host: docs.api.com
-
-{
-  "note" : "지각 안 했는데요!"
-}</code></pre>
+Host: docs.api.com</code></pre>
 </div>
 </div>
 </div>
@@ -904,36 +895,6 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
 <h4 id="_response_3"><a class="link" href="#_response_3">response</a></h4>
 <div class="listingblock">
 <div class="content">
@@ -943,7 +904,31 @@ Content-Type: application/json;charset=UTF-8
 {
   "code" : 200,
   "message" : "API 호출에 성공했습니다.",
-  "data" : null
+  "data" : {
+    "meetingAttendanceSummaryResponse" : {
+      "meetingDate" : "2025.05.31 10:30",
+      "lateThresholdTime" : "10:45",
+      "totalAttendCount" : 3,
+      "attendCount" : 2,
+      "lateAttendCount" : 1
+    },
+    "meetingAttendanceStatusResponseList" : [ {
+      "memberId" : 3,
+      "name" : "나뭉삼",
+      "attendanceTime" : "2025.05.31 10:50",
+      "isLate" : true
+    }, {
+      "memberId" : 2,
+      "name" : "나뭉이",
+      "attendanceTime" : "2025.05.31 10:44",
+      "isLate" : false
+    }, {
+      "memberId" : 1,
+      "name" : "나뭉일",
+      "attendanceTime" : "2025.05.31 10:20",
+      "isLate" : false
+    } ]
+  }
 }</code></pre>
 </div>
 </div>
@@ -983,11 +968,81 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 출석 요약 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.meetingDate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 일자 및 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.totalAttendCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 참석 인원수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.attendCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정상 참석자 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.lateAttendCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 참석자 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원별 출석 정보</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].attendanceTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].isLate</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -997,8 +1052,13 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
+<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1006,11 +1066,16 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 43
+Host: docs.api.com
+
+{
+  "note" : "지각 안 했는데요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1058,6 +1123,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
 </tr>
 </tbody>
 </table>
@@ -1127,7 +1222,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1135,7 +1230,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1255,21 +1350,16 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1391,11 +1481,145 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_7"><a class="link" href="#_request_headers_7">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_7"><a class="link" href="#_response_7">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_7"><a class="link" href="#_response_fields_7">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_7"><a class="link" href="#_error_case_7">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-21 01:31:49 +0900
+Last updated 2025-06-23 02:21:50 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -458,6 +458,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_본인_출석_정보_조회">본인 출석 정보 조회</a></li>
 <li><a href="#_모임별_참석_현황_조회">모임별 참석 현황 조회</a></li>
 <li><a href="#_모임_토론_참여_희망_명단_조회">모임 토론 참여 희망 명단 조회</a></li>
+<li><a href="#_본인_토론_그룹_명단_조회">본인 토론 그룹 명단 조회</a></li>
 </ul>
 </li>
 <li><a href="#_patch">PATCH</a>
@@ -505,12 +506,6 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters"><a class="link" href="#_path_parameters">path-parameters</a></h4>
-<div class="paragraph">
-<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/create/path-parameters.adoc[]</p>
-</div>
-</div>
-<div class="sect3">
 <h4 id="_request_headers"><a class="link" href="#_request_headers">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -527,6 +522,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters"><a class="link" href="#_query_parameters">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -618,7 +643,7 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">path-parameters</a></h4>
+<h4 id="_path_parameters"><a class="link" href="#_path_parameters">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -829,12 +854,6 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
-<div class="paragraph">
-<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/view/list/path-parameters.adoc[]</p>
-</div>
-</div>
-<div class="sect3">
 <h4 id="_request_headers_3"><a class="link" href="#_request_headers_3">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -851,6 +870,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -1052,7 +1101,7 @@ Host: docs.api.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters"><a class="link" href="#_query_parameters">query-parameters</a></h4>
+<h4 id="_query_parameters_3"><a class="link" href="#_query_parameters_3">query-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1165,6 +1214,134 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_본인_토론_그룹_명단_조회"><a class="link" href="#_본인_토론_그룹_명단_조회">본인 토론 그룹 명단 조회</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: MEMBER</p>
+</div>
+<div class="sect3">
+<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/discussion/1 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_4"><a class="link" href="#_query_parameters_4">query-parameters</a></h4>
+<div class="paragraph">
+<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/discussion/view/my-group/query-parameters.adoc[]</p>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : [ {
+    "memberId" : 1,
+    "memberName" : "나뭉일"
+  }, {
+    "memberId" : 2,
+    "memberName" : "나뭉이"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 참여 희망자 명단</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_5"><a class="link" href="#_error_case_5">Error case</a></h4>
+<hr>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -1176,7 +1353,7 @@ Content-Type: application/json;charset=UTF-8
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
-<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
+<h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
@@ -1193,7 +1370,7 @@ Host: docs.api.com
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_4"><a class="link" href="#_path_parameters_4">path-parameters</a></h4>
+<h4 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1220,7 +1397,7 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
+<h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1266,135 +1443,6 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "code" : 200,
-  "message" : "API 호출에 성공했습니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">response-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_error_case_5"><a class="link" href="#_error_case_5">Error case</a></h4>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
-<div class="paragraph">
-<p>접근 가능 권한 레벨: MEMBER</p>
-</div>
-<div class="sect3">
-<h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access_token
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
 </tr>
 </tbody>
 </table>
@@ -1464,7 +1512,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1472,7 +1520,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1481,7 +1529,7 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
+<h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1593,30 +1641,48 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론_그룹_구성_수동"><a class="link" href="#_토론_그룹_구성_수동">토론 그룹 구성 - 수동</a></h3>
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_8"><a class="link" href="#_request_8">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group?meetingId=1 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 101
-Host: docs.api.com
-
-{
-  "groups" : [ {
-    "memberIdList" : [ 1, 10 ]
-  }, {
-    "memberIdList" : [ 2, 20 ]
-  } ]
-}</code></pre>
+Host: docs.api.com</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_4"><a class="link" href="#_path_parameters_4">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_8"><a class="link" href="#_request_headers_8">request-headers</a></h4>
@@ -1635,73 +1701,6 @@ Host: docs.api.com
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">query-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">request-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[]</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">7개 이하의 리스트를 담고 있는 리스트</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">전체 그룹(7개 이하)</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[].memberIdList[]</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수가 하나 이상 담긴 리스트</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호 리스트</p></td>
 </tr>
 </tbody>
 </table>
@@ -1771,19 +1770,28 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론_그룹_할당_개인"><a class="link" href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></h3>
+<h3 id="_토론_그룹_구성_수동"><a class="link" href="#_토론_그룹_구성_수동">토론 그룹 구성 - 수동</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
+<p>접근 가능 권한 레벨: STAFF / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_9"><a class="link" href="#_request_9">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group/solo?meetingId=1&amp;memberId=2&amp;groupNumber=3 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group?meetingId=1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 101
+Host: docs.api.com
+
+{
+  "groups" : [ {
+    "memberIdList" : [ 1, 10 ]
+  }, {
+    "memberIdList" : [ 2, 20 ]
+  } ]
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1809,7 +1817,7 @@ Host: docs.api.com</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_query_parameters_3"><a class="link" href="#_query_parameters_3">query-parameters</a></h4>
+<h4 id="_query_parameters_5"><a class="link" href="#_query_parameters_5">query-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1835,19 +1843,42 @@ Host: docs.api.com</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7개 이하의 리스트를 담고 있는 리스트</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 그룹(7개 이하)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupNumber</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[].memberIdList[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상, 7 이하의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수가 하나 이상 담긴 리스트</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호 리스트</p></td>
 </tr>
 </tbody>
 </table>
@@ -1916,13 +1947,8 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론_그룹_할당_개인"><a class="link" href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
 </div>
@@ -1930,40 +1956,13 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group/solo?meetingId=1&amp;memberId=2&amp;groupNumber=3 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
 Host: docs.api.com</code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_10"><a class="link" href="#_request_headers_10">request-headers</a></h4>
@@ -1982,6 +1981,50 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상, 7 이하의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -2052,11 +2095,145 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_11"><a class="link" href="#_request_11">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_11"><a class="link" href="#_request_headers_11">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_11"><a class="link" href="#_response_11">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_11"><a class="link" href="#_error_case_11">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-23 18:39:29 +0900
+Last updated 2025-06-23 20:54:47 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -455,6 +455,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </li>
 <li><a href="#_patch">PATCH</a>
 <ul class="sectlevel2">
+<li><a href="#_비고_작성">비고 작성</a></li>
 <li><a href="#_독서만_할래요">독서만 할래요</a></li>
 <li><a href="#_토론할래요">토론할래요</a></li>
 </ul>
@@ -612,7 +613,7 @@ Content-Type: application/json;charset=UTF-8
 <h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
+<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -620,11 +621,16 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_2"><a class="link" href="#_request_2">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 43
+Host: docs.api.com
+
+{
+  "note" : "지각 안 했는데요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -672,6 +678,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
 </tr>
 </tbody>
 </table>
@@ -741,7 +777,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -749,7 +785,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -869,21 +905,16 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1005,11 +1036,145 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_5"><a class="link" href="#_error_case_5">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-20 15:00:03 +0900
+Last updated 2025-06-20 15:42:44 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -453,6 +453,11 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_모임_출석">모임 출석</a></li>
 </ul>
 </li>
+<li><a href="#_get">GET</a>
+<ul class="sectlevel2">
+<li><a href="#_출석_정보_조회">출석 정보 조회</a></li>
+</ul>
+</li>
 <li><a href="#_patch">PATCH</a>
 <ul class="sectlevel2">
 <li><a href="#_비고_작성">비고 작성</a></li>
@@ -604,16 +609,16 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div class="sect3">
 <h4 id="_error_case"><a class="link" href="#_error_case">Error case</a></h4>
-<hr>
+
 </div>
 </div>
 </div>
 </div>
 <div class="sect1">
-<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
+<h2 id="_get"><a class="link" href="#_get">GET</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
+<h3 id="_출석_정보_조회"><a class="link" href="#_출석_정보_조회">출석 정보 조회</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -621,16 +626,11 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_2"><a class="link" href="#_request_2">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 43
-Host: docs.api.com
-
-{
-  "note" : "지각 안 했는데요!"
-}</code></pre>
+Host: docs.api.com</code></pre>
 </div>
 </div>
 </div>
@@ -656,7 +656,7 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참석 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -683,36 +683,6 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
 <h4 id="_response_2"><a class="link" href="#_response_2">response</a></h4>
 <div class="listingblock">
 <div class="content">
@@ -722,7 +692,19 @@ Content-Type: application/json;charset=UTF-8
 {
   "code" : 200,
   "message" : "API 호출에 성공했습니다.",
-  "data" : null
+  "data" : {
+    "attendanceId" : 1,
+    "meetingType" : "REGULAR",
+    "meetingDateTime" : "2126.06.14 10:30",
+    "lateThresholdTime" : "2126.06.14 10:45",
+    "meetingName" : "1000회 정기모임",
+    "meetingPlace" : "합정 저스티나",
+    "description" : "조심히 오세요~",
+    "note" : "1등으로 왔지롱~",
+    "discussionTime" : "2126.06.14 12:00",
+    "groupMemberList" : null,
+    "createdAt" : "2126.06.13 20:00"
+  }
 }</code></pre>
 </div>
 </div>
@@ -762,11 +744,81 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.attendanceId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참석 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 유형</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingPlace</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.description</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.note</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">참석 관련 비고</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.discussionTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.groupMemberList</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 조 명단</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.createdAt</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설일자</p></td>
 </tr>
 </tbody>
 </table>
@@ -776,8 +828,13 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
+<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -785,11 +842,16 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 43
+Host: docs.api.com
+
+{
+  "note" : "지각 안 했는데요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -837,6 +899,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
 </tr>
 </tbody>
 </table>
@@ -906,7 +998,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -914,7 +1006,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1034,21 +1126,16 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1170,11 +1257,145 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_6"><a class="link" href="#_response_6">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_6"><a class="link" href="#_response_fields_6">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_6"><a class="link" href="#_error_case_6">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-20 15:42:44 +0900
+Last updated 2025-06-21 01:31:49 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -453,6 +453,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_모임_출석">모임 출석</a></li>
 </ul>
 </li>
+<li><a href="#_patch">PATCH</a>
+<ul class="sectlevel2">
+<li><a href="#_독서만_할래요">독서만 할래요</a></li>
+<li><a href="#_토론할래요">토론할래요</a></li>
+</ul>
+</li>
 <li><a href="#_delete">DELETE</a>
 <ul class="sectlevel2">
 <li><a href="#_출석_삭제">출석 삭제</a></li>
@@ -487,6 +493,33 @@ Accept: application/json
 Host: docs.api.com</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters"><a class="link" href="#_path_parameters">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">meetingId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers"><a class="link" href="#_request_headers">request-headers</a></h4>
@@ -576,24 +609,51 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_2"><a class="link" href="#_request_2">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
 Host: docs.api.com</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_2"><a class="link" href="#_request_headers_2">request-headers</a></h4>
@@ -680,13 +740,276 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: MEMBER</p>
+</div>
+<div class="sect3">
+<h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_3"><a class="link" href="#_request_headers_3">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_3"><a class="link" href="#_response_3">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_3"><a class="link" href="#_response_fields_3">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_3"><a class="link" href="#_error_case_3">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_4"><a class="link" href="#_path_parameters_4">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_4"><a class="link" href="#_request_headers_4">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_4"><a class="link" href="#_response_4">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_4"><a class="link" href="#_response_fields_4">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_4"><a class="link" href="#_error_case_4">Error case</a></h4>
+<hr>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-20 13:32:23 +0900
+Last updated 2025-06-20 15:00:03 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -5,7 +5,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.18">
-<title>📚 글나무 출석부 시스템 API 문서</title>
+<title>Attendance API Guide</title>
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
@@ -438,80 +438,24 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
 </head>
-<body class="book toc2 toc-left">
+<body id="title" class="book toc2 toc-left">
 <div id="header">
-<h1>📚 글나무 출석부 시스템 API 문서</h1>
+<h1>Attendance API Guide</h1>
 <div class="details">
 <span id="revnumber">version 0.0.1-SNAPSHOT</span>
 </div>
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
-<li><a href="#_문서_개요">1. 📖 문서 개요</a>
+<li><a href="#_index_페이지로_이동">Index 페이지로 이동</a></li>
+<li><a href="#_post">POST</a>
 <ul class="sectlevel2">
-<li><a href="#_시스템_소개">1.1. 시스템 소개</a></li>
-<li><a href="#_버전_정보">1.2. 버전 정보</a></li>
+<li><a href="#_모임_출석">모임 출석</a></li>
 </ul>
 </li>
-<li><a href="#_인증_및_권한">2. 🔐 인증 및 권한</a>
+<li><a href="#_delete">DELETE</a>
 <ul class="sectlevel2">
-<li><a href="#_인증_방식">2.1. 인증 방식</a></li>
-<li><a href="#_권한_레벨">2.2. 권한 레벨</a></li>
-</ul>
-</li>
-<li><a href="#_에러_코드">3. ❌ 에러 코드</a>
-<ul class="sectlevel2">
-<li><a href="#_http_상태_코드">3.1. HTTP 상태 코드</a></li>
-<li><a href="#_응답_구조">3.2. 응답 구조</a></li>
-</ul>
-</li>
-<li><a href="#_api_목록">4. 📋 API 목록</a>
-<ul class="sectlevel2">
-<li><a href="#_인증_관리">4.1. 🔑 인증 관리</a>
-<ul class="sectlevel3">
-<li><a href="#_로그인_api">4.1.1. 로그인 API</a></li>
-</ul>
-</li>
-<li><a href="#_회원_관리">4.2. 👤 회원 관리</a>
-<ul class="sectlevel3">
-<li><a href="#_회원_api">4.2.1. 회원 API</a></li>
-</ul>
-</li>
-<li><a href="#_모임_관리">4.3. 📅 모임 관리</a>
-<ul class="sectlevel3">
-<li><a href="#_모임_api">4.3.1. 모임 API</a></li>
-</ul>
-</li>
-<li><a href="#_출석_관리">4.4. ✅ 출석 관리</a>
-<ul class="sectlevel3">
-<li><a href="#_출석_api">4.4.1. 출석 API</a></li>
-</ul>
-</li>
-<li><a href="#_발제_관리">4.5. 📝 발제 관리</a>
-<ul class="sectlevel3">
-<li><a href="#_발제_api">4.5.1. 발제 API</a></li>
-</ul>
-</li>
-</ul>
-</li>
-<li><a href="#_시작하기">5. 🚀 시작하기</a>
-<ul class="sectlevel2">
-<li><a href="#_1단계_인증">5.1. 1단계: 인증</a></li>
-<li><a href="#_2단계_기본_정보_입력">5.2. 2단계: 기본 정보 입력</a></li>
-<li><a href="#_3단계_기능_이용">5.3. 3단계: 기능 이용</a></li>
-</ul>
-</li>
-<li><a href="#_개발자_참고사항">6. 🔧 개발자 참고사항</a>
-<ul class="sectlevel2">
-<li><a href="#_요청_헤더">6.1. 요청 헤더</a></li>
-<li><a href="#_페이지네이션">6.2. 페이지네이션</a></li>
-<li><a href="#_에러_처리_예시">6.3. 에러 처리 예시</a></li>
-</ul>
-</li>
-<li><a href="#_지원_및_문의">7. 📞 지원 및 문의</a>
-<ul class="sectlevel2">
-<li><a href="#_개발팀_연락처">7.1. 개발팀 연락처</a></li>
-<li><a href="#_변경_이력">7.2. 변경 이력</a></li>
+<li><a href="#_출석_삭제">출석 삭제</a></li>
 </ul>
 </li>
 </ul>
@@ -519,423 +463,221 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </div>
 <div id="content">
 <div class="sect1">
-<h2 id="_문서_개요"><a class="link" href="#_문서_개요">1. 📖 문서 개요</a></h2>
+<h2 id="_index_페이지로_이동"><a class="link" href="#_index_페이지로_이동"><a href="index.html">Index 페이지로 이동</a></a></h2>
 <div class="sectionbody">
-<div class="sect2">
-<h3 id="_시스템_소개"><a class="link" href="#_시스템_소개">1.1. 시스템 소개</a></h3>
-<div class="paragraph">
-<p>글나무 출석부 시스템은 모임 출석을 효율적으로 관리하기 위한 웹 기반 시스템입니다.<br>
-사용자 권한에 따라 다양한 출석 관리 기능을 제공합니다.</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_버전_정보"><a class="link" href="#_버전_정보">1.2. 버전 정보</a></h3>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>문서 버전</strong>: v1.0.0</p>
-</li>
-<li>
-<p><strong>베이스 URL</strong>: <code>아직 없음</code></p>
-</li>
-</ul>
-</div>
-</div>
+
 </div>
 </div>
 <div class="sect1">
-<h2 id="_인증_및_권한"><a class="link" href="#_인증_및_권한">2. 🔐 인증 및 권한</a></h2>
+<h2 id="_post"><a class="link" href="#_post">POST</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_인증_방식"><a class="link" href="#_인증_방식">2.1. 인증 방식</a></h3>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>OAuth 2.0</strong>: 카카오 소셜 로그인</p>
-</li>
-<li>
-<p><strong>JWT Token</strong>: 액세스 토큰 기반 인증</p>
-</li>
-<li>
-<p><strong>Refresh Token</strong>: 쿠키 기반 토큰 갱신</p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_권한_레벨"><a class="link" href="#_권한_레벨">2.2. 권한 레벨</a></h3>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">권한</th>
-<th class="tableblock halign-left valign-top">설명</th>
-<th class="tableblock halign-left valign-top">접근 가능 기능</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">PUBLIC</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모든 사용자</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">로그인, 토큰 재발급</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">MEMBER</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">인증된 사용자</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">개인 정보 조회/수정, 출석 처리, 로그아웃</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">STAFF</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">운영진</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 생성/관리, 출석 현황 조회</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ADMIN</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">관리자</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모든 기능 + 회원 권한 관리, 이름 변경</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_에러_코드"><a class="link" href="#_에러_코드">3. ❌ 에러 코드</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_http_상태_코드"><a class="link" href="#_http_상태_코드">3.1. HTTP 상태 코드</a></h3>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">상태 코드</th>
-<th class="tableblock halign-left valign-top">설명</th>
-<th class="tableblock halign-left valign-top">발생 상황</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">200</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성공</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청이 정상적으로 처리됨</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">잘못된 요청</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청 파라미터가 잘못되었거나 누락됨</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">401</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">인증 실패</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">토큰이 유효하지 않거나 만료됨</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">403</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">권한 없음</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">해당 기능에 대한 접근 권한이 없음</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">404</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">리소스 없음</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청한 자원이 존재하지 않음</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">417</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">유효성 검사 실패</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">입력값의 형식이나 제약조건에 맞지 않음</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">422</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">처리 불가능</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">요청은 올바르지만 현재 상태에서 처리할 수 없음</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">500</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">서버 오류</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">서버 내부에서 오류가 발생함</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect2">
-<h3 id="_응답_구조"><a class="link" href="#_응답_구조">3.2. 응답 구조</a></h3>
+<h3 id="_모임_출석"><a class="link" href="#_모임_출석">모임 출석</a></h3>
 <div class="paragraph">
-<p>모든 API는 다음과 같은 공통 응답 구조를 가집니다:</p>
+<p>접근 가능 권한 레벨: MEMBER / 로그 생성</p>
 </div>
+<div class="sect3">
+<h4 id="_request"><a class="link" href="#_request">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-json hljs" data-lang="json">{
-    "code": 200,
-    "message": "Success",
-    "data": { /* 실제 응답 데이터 */ }
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">POST /attendance/1 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers"><a class="link" href="#_request_headers">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response"><a class="link" href="#_response">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : 1
 }</code></pre>
 </div>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_api_목록"><a class="link" href="#_api_목록">4. 📋 API 목록</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_인증_관리"><a class="link" href="#_인증_관리">4.1. 🔑 인증 관리</a></h3>
 <div class="sect3">
-<h4 id="_로그인_api"><a class="link" href="#_로그인_api">4.1.1. <a href="login-api-guide.html">로그인 API</a></a></h4>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>카카오 OAuth 로그인</strong>: 소셜 로그인을 통한 인증</p>
-</li>
-<li>
-<p><strong>토큰 재발급</strong>: 만료된 액세스 토큰 갱신</p>
-</li>
-<li>
-<p><strong>로그아웃</strong>: 사용자 리프레시 토큰 말소</p>
-</li>
-</ul>
-</div>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_회원_관리"><a class="link" href="#_회원_관리">4.2. 👤 회원 관리</a></h3>
-<div class="sect3">
-<h4 id="_회원_api"><a class="link" href="#_회원_api">4.2.1. <a href="member-api-guide.html">회원 API</a></a></h4>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>회원 정보 조회</strong>: 개인 정보 입력 여부 확인</p>
-</li>
-<li>
-<p><strong>회원 정보 수정</strong>: 이름, 성별, 생년월일 변경</p>
-</li>
-<li>
-<p><strong>회원 권한 변경</strong>: 관리자 전용 권한 수정 기능</p>
-</li>
-<li>
-<p><strong>회원 상태 변경</strong>: 관리자 전용 계정 활성화/비활성화</p>
-</li>
-</ul>
-</div>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_모임_관리"><a class="link" href="#_모임_관리">4.3. 📅 모임 관리</a></h3>
-<div class="sect3">
-<h4 id="_모임_api"><a class="link" href="#_모임_api">4.3.1. <a href="meeting-api-guide.html">모임 API</a></a></h4>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>모임 생성</strong>: 새로운 모임 등록</p>
-</li>
-<li>
-<p><strong>모임 목록 조회</strong>: 진행 중인 모임 리스트</p>
-</li>
-<li>
-<p><strong>모임 상세 정보</strong>: 특정 모임의 세부 정보</p>
-</li>
-<li>
-<p><strong>QR 코드 생성</strong>: 출석용 QR 코드 발급</p>
-</li>
-</ul>
-</div>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_출석_관리"><a class="link" href="#_출석_관리">4.4. ✅ 출석 관리</a></h3>
-<div class="sect3">
-<h4 id="_출석_api"><a class="link" href="#_출석_api">4.4.1. <a href="attendance-api-guide.html">출석 API</a></a></h4>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>출석 처리</strong>: QR 코드 또는 GPS 기반 출석</p>
-</li>
-<li>
-<p><strong>출석 현황 조회</strong>: 개인별/모임별 출석 이력</p>
-</li>
-<li>
-<p><strong>지각자 조회</strong>: 운영진 전용 지각자 명단</p>
-</li>
-<li>
-<p><strong>토론 그룹 관리</strong>: 모임별 토론 조 편성</p>
-</li>
-</ul>
-</div>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_발제_관리"><a class="link" href="#_발제_관리">4.5. 📝 발제 관리</a></h3>
-<div class="sect3">
-<h4 id="_발제_api"><a class="link" href="#_발제_api">4.5.1. <a href="book-question-api-guide.html">발제 API</a></a></h4>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>발제 작성</strong>: 오늘의 발제 등록</p>
-</li>
-<li>
-<p><strong>발제 조회</strong>: 조별/모임별 발제 목록</p>
-</li>
-<li>
-<p><strong>맞춤법 검사</strong>: 발제문 자동 교정</p>
-</li>
-<li>
-<p><strong>발제 승인</strong>: 운영진의 발제 검토 및 승인</p>
-</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_시작하기"><a class="link" href="#_시작하기">5. 🚀 시작하기</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_1단계_인증"><a class="link" href="#_1단계_인증">5.1. 1단계: 인증</a></h3>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p><strong>카카오 로그인</strong>: <a href="login-api-guide.html#카카오-oauth-로그인">GET /login/oauth/kakao</a> 호출</p>
-</li>
-<li>
-<p><strong>토큰 저장</strong>: 응답에서 받은 액세스 토큰을 Authorization 헤더에 포함</p>
-</li>
-<li>
-<p><strong>토큰 갱신</strong>: 토큰 만료 시 <a href="login-api-guide.html#액세스-토큰-재발급">POST /login/re-issue/accessToken</a> 호출</p>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_2단계_기본_정보_입력"><a class="link" href="#_2단계_기본_정보_입력">5.2. 2단계: 기본 정보 입력</a></h3>
-<div class="olist arabic">
-<ol class="arabic">
-<li>
-<p><strong>정보 입력 여부 확인</strong>: <a href="member-api-guide.html#모임원-정보-입력-여부-확인">GET /member/info</a></p>
-</li>
-<li>
-<p><strong>정보 미입력 시</strong>: <a href="member-api-guide.html#모임원-정보-수정">PATCH /member/info</a>로 개인정보 등록</p>
-</li>
-</ol>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_3단계_기능_이용"><a class="link" href="#_3단계_기능_이용">5.3. 3단계: 기능 이용</a></h3>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>출석</strong>: QR 코드 스캔 또는 GPS 기반 출석 처리</p>
-</li>
-<li>
-<p><strong>모임 참여</strong>: 배정된 토론 그룹 확인 및 발제 작성</p>
-</li>
-<li>
-<p><strong>이력 조회</strong>: 개인 출석 현황 및 참여 이력 확인</p>
-</li>
-</ul>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_개발자_참고사항"><a class="link" href="#_개발자_참고사항">6. 🔧 개발자 참고사항</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_요청_헤더"><a class="link" href="#_요청_헤더">6.1. 요청 헤더</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">Content-Type: application/json
-Authorization: Bearer {access_token}
-Accept: application/json</code></pre>
-</div>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_페이지네이션"><a class="link" href="#_페이지네이션">6.2. 페이지네이션</a></h3>
-<div class="paragraph">
-<p>목록 조회 API는 다음 파라미터를 지원합니다:
-- <code>page</code>: 페이지 번호 (기본값: 0)
-- <code>size</code>: 페이지 크기 (기본값: 20, 최대: 100)
-- <code>sort</code>: 정렬 조건 (예: createdAt,desc)</p>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_에러_처리_예시"><a class="link" href="#_에러_처리_예시">6.3. 에러 처리 예시</a></h3>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-javascript hljs" data-lang="javascript">try {
-  const response = await fetch('/api/member/info', {
-    headers: { 'Authorization': `Bearer ${token}` }
-  });
-
-  const result = await response.json();
-
-  if (result.code !== 200) {
-    throw new Error(result.message);
-  }
-
-  return result.data;
-} catch (error) {
-  console.error('API 오류:', error.message);
-}</code></pre>
-</div>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_지원_및_문의"><a class="link" href="#_지원_및_문의">7. 📞 지원 및 문의</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="_개발팀_연락처"><a class="link" href="#_개발팀_연락처">7.1. 개발팀 연락처</a></h3>
-<div class="ulist">
-<ul>
-<li>
-<p><strong>이메일</strong>: <a href="mailto:jeongookjang@naver.com">jeongookjang@naver.com</a></p>
-</li>
-<li>
-<p><strong>GitHub</strong>: <a href="https://github.com/jujang/Geulnamu" class="bare">https://github.com/jujang/Geulnamu</a></p>
-</li>
-</ul>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_변경_이력"><a class="link" href="#_변경_이력">7.2. 변경 이력</a></h3>
+<h4 id="_response_fields"><a class="link" href="#_response_fields">response-fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">버전</th>
-<th class="tableblock halign-left valign-top">날짜</th>
-<th class="tableblock halign-left valign-top">변경 내용</th>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">v1.0.0</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">2025-05-30</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">초기 버전 출시</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
 </tr>
 </tbody>
 </table>
+</div>
+<div class="sect3">
+<h4 id="_error_case"><a class="link" href="#_error_case">Error case</a></h4>
 <hr>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
 <div class="paragraph">
-<p><strong>💡 팁</strong>: 각 API 문서 페이지에서는 실제 요청/응답 예시와 함께 더 자세한 정보를 확인할 수 있습니다.</p>
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_2"><a class="link" href="#_request_2">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_2"><a class="link" href="#_request_headers_2">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_2"><a class="link" href="#_response_2">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_2"><a class="link" href="#_response_fields_2">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_2"><a class="link" href="#_error_case_2">Error case</a></h4>
+<hr>
 </div>
 </div>
 </div>
@@ -944,7 +686,7 @@ Accept: application/json</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-20 03:21:09 +0900
+Last updated 2025-06-20 13:32:23 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -459,6 +459,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_모임별_참석_현황_조회">모임별 참석 현황 조회</a></li>
 <li><a href="#_모임_토론_참여_희망_명단_조회">모임 토론 참여 희망 명단 조회</a></li>
 <li><a href="#_본인_토론_그룹_명단_조회">본인 토론 그룹 명단 조회</a></li>
+<li><a href="#_전체_토론_그룹_명단_조회">전체 토론 그룹 명단 조회</a></li>
 </ul>
 </li>
 <li><a href="#_patch">PATCH</a>
@@ -1232,6 +1233,33 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
+<h4 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
 <h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
@@ -1251,12 +1279,6 @@ Host: docs.api.com</code></pre>
 </tr>
 </tbody>
 </table>
-</div>
-<div class="sect3">
-<h4 id="_query_parameters_4"><a class="link" href="#_query_parameters_4">query-parameters</a></h4>
-<div class="paragraph">
-<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/discussion/view/my-group/query-parameters.adoc[]</p>
-</div>
 </div>
 <div class="sect3">
 <h4 id="_response_5"><a class="link" href="#_response_5">response</a></h4>
@@ -1342,59 +1364,22 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
+<h3 id="_전체_토론_그룹_명단_조회"><a class="link" href="#_전체_토론_그룹_명단_조회">전체 토론 그룹 명단 조회</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: MEMBER</p>
+<p>접근 가능 권한 레벨: STAFF</p>
 </div>
 <div class="sect3">
 <h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/discussion/all?meetingId=1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 43
-Host: docs.api.com
-
-{
-  "note" : "지각 안 했는데요!"
-}</code></pre>
+Host: docs.api.com</code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_2"><a class="link" href="#_path_parameters_2">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_6"><a class="link" href="#_request_headers_6">request-headers</a></h4>
@@ -1418,7 +1403,7 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
+<h4 id="_query_parameters_4"><a class="link" href="#_query_parameters_4">query-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1429,7 +1414,7 @@ Host: docs.api.com
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">파라미터</th>
 <th class="tableblock halign-left valign-top">타입</th>
 <th class="tableblock halign-left valign-top">필수여부</th>
 <th class="tableblock halign-left valign-top">제약조건</th>
@@ -1438,11 +1423,11 @@ Host: docs.api.com
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -1457,7 +1442,23 @@ Content-Type: application/json;charset=UTF-8
 {
   "code" : 200,
   "message" : "API 호출에 성공했습니다.",
-  "data" : null
+  "data" : [ {
+    "memberIdAndNameResponseList" : [ {
+      "memberId" : 1,
+      "memberName" : "나뭉일"
+    }, {
+      "memberId" : 2,
+      "memberName" : "나뭉이"
+    } ]
+  }, {
+    "memberIdAndNameResponseList" : [ {
+      "memberId" : 3,
+      "memberName" : "나뭉삼"
+    }, {
+      "memberId" : 4,
+      "memberName" : "나뭉사"
+    } ]
+  } ]
 }</code></pre>
 </div>
 </div>
@@ -1498,10 +1499,38 @@ Content-Type: application/json;charset=UTF-8
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 참여 희망자 명단</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 토론 그룹</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberIdAndNameResponseList</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 그룹별 명단</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberIdAndNameResponseList[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberIdAndNameResponseList[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 이름</p></td>
 </tr>
 </tbody>
 </table>
@@ -1511,8 +1540,13 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_patch"><a class="link" href="#_patch">PATCH</a></h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
+<h3 id="_비고_작성"><a class="link" href="#_비고_작성">비고 작성</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1520,11 +1554,16 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Host: docs.api.com</code></pre>
+Content-Length: 43
+Host: docs.api.com
+
+{
+  "note" : "지각 안 했는데요!"
+}</code></pre>
 </div>
 </div>
 </div>
@@ -1572,6 +1611,36 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>note</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
 </tr>
 </tbody>
 </table>
@@ -1641,7 +1710,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1649,7 +1718,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_8"><a class="link" href="#_request_8">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1770,12 +1839,141 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: MEMBER</p>
+</div>
+<div class="sect3">
+<h4 id="_request_9"><a class="link" href="#_request_9">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_9"><a class="link" href="#_request_headers_9">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_9"><a class="link" href="#_response_9">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_9"><a class="link" href="#_error_case_9">Error case</a></h4>
+<hr>
+</div>
+</div>
+<div class="sect2">
 <h3 id="_토론_그룹_구성_수동"><a class="link" href="#_토론_그룹_구성_수동">토론 그룹 구성 - 수동</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: STAFF / 로그 생성</p>
 </div>
 <div class="sect3">
-<h4 id="_request_9"><a class="link" href="#_request_9">request</a></h4>
+<h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group?meetingId=1 HTTP/2.0
@@ -1796,7 +1994,7 @@ Host: docs.api.com
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_headers_9"><a class="link" href="#_request_headers_9">request-headers</a></h4>
+<h4 id="_request_headers_10"><a class="link" href="#_request_headers_10">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1884,152 +2082,6 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_response_9"><a class="link" href="#_response_9">response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "code" : 200,
-  "message" : "API 호출에 성공했습니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">response-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_error_case_9"><a class="link" href="#_error_case_9">Error case</a></h4>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_토론_그룹_할당_개인"><a class="link" href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></h3>
-<div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
-</div>
-<div class="sect3">
-<h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group/solo?meetingId=1&amp;memberId=2&amp;groupNumber=3 HTTP/2.0
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access_token
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_request_headers_10"><a class="link" href="#_request_headers_10">request-headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">query-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">파라미터</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수여부</th>
-<th class="tableblock halign-left valign-top">제약조건</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupNumber</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상, 7 이하의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 번호</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
 <h4 id="_response_10"><a class="link" href="#_response_10">response</a></h4>
 <div class="listingblock">
 <div class="content">
@@ -2093,13 +2145,8 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론_그룹_할당_개인"><a class="link" href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
 </div>
@@ -2107,40 +2154,13 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_11"><a class="link" href="#_request_11">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group/solo?meetingId=1&amp;memberId=2&amp;groupNumber=3 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
 Host: docs.api.com</code></pre>
 </div>
 </div>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_11"><a class="link" href="#_request_headers_11">request-headers</a></h4>
@@ -2159,6 +2179,50 @@ Host: docs.api.com</code></pre>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_6"><a class="link" href="#_query_parameters_6">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상, 7 이하의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -2229,11 +2293,145 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_12"><a class="link" href="#_request_12">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_12"><a class="link" href="#_request_headers_12">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_12"><a class="link" href="#_response_12">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_12"><a class="link" href="#_error_case_12">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-23 20:54:47 +0900
+Last updated 2025-06-24 00:00:09 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -457,6 +457,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#_본인_출석_정보_조회">본인 출석 정보 조회</a></li>
 <li><a href="#_모임별_참석_현황_조회">모임별 참석 현황 조회</a></li>
+<li><a href="#_모임_토론_참여_희망_명단_조회">모임 토론 참여 희망 명단 조회</a></li>
 </ul>
 </li>
 <li><a href="#_patch">PATCH</a>
@@ -464,6 +465,8 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_비고_작성">비고 작성</a></li>
 <li><a href="#_독서만_할래요">독서만 할래요</a></li>
 <li><a href="#_토론할래요">토론할래요</a></li>
+<li><a href="#_토론_그룹_구성_수동">토론 그룹 구성 - 수동</a></li>
+<li><a href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></li>
 </ul>
 </li>
 <li><a href="#_delete">DELETE</a>
@@ -493,7 +496,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <h4 id="_request"><a class="link" href="#_request">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">POST /attendance/1 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">POST /attendance?meetingId=1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -503,30 +506,9 @@ Host: docs.api.com</code></pre>
 </div>
 <div class="sect3">
 <h4 id="_path_parameters"><a class="link" href="#_path_parameters">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">meetingId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/create/path-parameters.adoc[]</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_request_headers"><a class="link" href="#_request_headers">request-headers</a></h4>
@@ -838,7 +820,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/1 HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance?meetingId=1 HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -848,30 +830,9 @@ Host: docs.api.com</code></pre>
 </div>
 <div class="sect3">
 <h4 id="_path_parameters_3"><a class="link" href="#_path_parameters_3">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in attendance-api-guide.adoc - include::C:\Workspace\Geulnamu\geulnamu-backend\build\generated-snippets/attendance/view/list/path-parameters.adoc[]</p>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_request_headers_3"><a class="link" href="#_request_headers_3">request-headers</a></h4>
@@ -1049,6 +1010,158 @@ Content-Type: application/json;charset=UTF-8
 </div>
 <div class="sect3">
 <h4 id="_error_case_3"><a class="link" href="#_error_case_3">Error case</a></h4>
+
+</div>
+</div>
+<div class="sect2">
+<h3 id="_모임_토론_참여_희망_명단_조회"><a class="link" href="#_모임_토론_참여_희망_명단_조회">모임 토론 참여 희망 명단 조회</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: STAFF</p>
+</div>
+<div class="sect3">
+<h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">GET /attendance/discussion?meetingId=1 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_4"><a class="link" href="#_request_headers_4">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters"><a class="link" href="#_query_parameters">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_4"><a class="link" href="#_response_4">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : [ {
+    "memberId" : 1,
+    "memberName" : "나뭉일"
+  }, {
+    "memberId" : 2,
+    "memberName" : "나뭉이"
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_4"><a class="link" href="#_response_fields_4">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 참여 희망자 명단</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].memberName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_4"><a class="link" href="#_error_case_4">Error case</a></h4>
 <hr>
 </div>
 </div>
@@ -1063,7 +1176,7 @@ Content-Type: application/json;charset=UTF-8
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
-<h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
+<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/note HTTP/2.0
@@ -1107,7 +1220,7 @@ Host: docs.api.com
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_headers_4"><a class="link" href="#_request_headers_4">request-headers</a></h4>
+<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -1153,135 +1266,6 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">비고(출석 관련 사유 작성)</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_response_4"><a class="link" href="#_response_4">response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
-Content-Type: application/json;charset=UTF-8
-
-{
-  "code" : 200,
-  "message" : "API 호출에 성공했습니다.",
-  "data" : null
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_4"><a class="link" href="#_response_fields_4">response-fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">타입</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_error_case_4"><a class="link" href="#_error_case_4">Error case</a></h4>
-<hr>
-</div>
-</div>
-<div class="sect2">
-<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
-<div class="paragraph">
-<p>접근 가능 권한 레벨: MEMBER</p>
-</div>
-<div class="sect3">
-<h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer access_token
-Accept: application/json
-Host: docs.api.com</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-<col style="width: 25%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">필수값</th>
-<th class="tableblock halign-left valign-top">양식</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_headers_5"><a class="link" href="#_request_headers_5">request-headers</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">필드명</th>
-<th class="tableblock halign-left valign-top">설명</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
 </tr>
 </tbody>
 </table>
@@ -1351,7 +1335,7 @@ Content-Type: application/json;charset=UTF-8
 </div>
 </div>
 <div class="sect2">
-<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
+<h3 id="_독서만_할래요"><a class="link" href="#_독서만_할래요">독서만 할래요</a></h3>
 <div class="paragraph">
 <p>접근 가능 권한 레벨: MEMBER</p>
 </div>
@@ -1359,7 +1343,7 @@ Content-Type: application/json;charset=UTF-8
 <h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/just-read HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1368,7 +1352,7 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
+<h4 id="_path_parameters_5"><a class="link" href="#_path_parameters_5">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1479,21 +1463,16 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
-<div class="sectionbody">
 <div class="sect2">
-<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<h3 id="_토론할래요"><a class="link" href="#_토론할래요">토론할래요</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+<p>접근 가능 권한 레벨: MEMBER</p>
 </div>
 <div class="sect3">
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/1/want-discussion HTTP/2.0
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
@@ -1502,7 +1481,7 @@ Host: docs.api.com</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">path-parameters</a></h4>
+<h4 id="_path_parameters_6"><a class="link" href="#_path_parameters_6">path-parameters</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 25%;">
@@ -1613,13 +1592,471 @@ Content-Type: application/json;charset=UTF-8
 <hr>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_토론_그룹_구성_수동"><a class="link" href="#_토론_그룹_구성_수동">토론 그룹 구성 - 수동</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: STAFF</p>
+</div>
+<div class="sect3">
+<h4 id="_request_8"><a class="link" href="#_request_8">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group?meetingId=1 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Content-Length: 101
+Host: docs.api.com
+
+{
+  "groups" : [ {
+    "memberIdList" : [ 1, 10 ]
+  }, {
+    "memberIdList" : [ 2, 20 ]
+  } ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_8"><a class="link" href="#_request_headers_8">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_2"><a class="link" href="#_query_parameters_2">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">request-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">7개 이하의 리스트를 담고 있는 리스트</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">전체 그룹(7개 이하)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groups[].memberIdList[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수가 하나 이상 담긴 리스트</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호 리스트</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_8"><a class="link" href="#_response_8">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_8"><a class="link" href="#_error_case_8">Error case</a></h4>
+<hr>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_토론_그룹_할당_개인"><a class="link" href="#_토론_그룹_할당_개인">토론 그룹 할당 - 개인</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN</p>
+</div>
+<div class="sect3">
+<h4 id="_request_9"><a class="link" href="#_request_9">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">PATCH /attendance/group/solo?meetingId=1&amp;memberId=2&amp;groupNumber=3 HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_9"><a class="link" href="#_request_headers_9">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_query_parameters_3"><a class="link" href="#_query_parameters_3">query-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">파라미터</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수여부</th>
+<th class="tableblock halign-left valign-top">제약조건</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>groupNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상, 7 이하의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">그룹 번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_9"><a class="link" href="#_response_9">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_9"><a class="link" href="#_error_case_9">Error case</a></h4>
+<hr>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_delete"><a class="link" href="#_delete">DELETE</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_출석_삭제"><a class="link" href="#_출석_삭제">출석 삭제</a></h3>
+<div class="paragraph">
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
+</div>
+<div class="sect3">
+<h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">DELETE /attendance/1/delete HTTP/2.0
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer access_token
+Accept: application/json
+Host: docs.api.com</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_path_parameters_7"><a class="link" href="#_path_parameters_7">path-parameters</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+<col style="width: 25%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">attendanceId</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">1 이상의 정수</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_request_headers_10"><a class="link" href="#_request_headers_10">request-headers</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">액세스 토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_response_10"><a class="link" href="#_response_10">response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
+Content-Type: application/json;charset=UTF-8
+
+{
+  "code" : 200,
+  "message" : "API 호출에 성공했습니다.",
+  "data" : null
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">response-fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">필드명</th>
+<th class="tableblock halign-left valign-top">타입</th>
+<th class="tableblock halign-left valign-top">필수값</th>
+<th class="tableblock halign-left valign-top">양식</th>
+<th class="tableblock halign-left valign-top">설명</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_error_case_10"><a class="link" href="#_error_case_10">Error case</a></h4>
+<hr>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-23 02:21:50 +0900
+Last updated 2025-06-23 18:39:29 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:42:58 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 16:32:09 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:42:58 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 16:32:08 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Fri, 19 Dec 2025 17:22:49 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 09:40:12 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Fri, 19 Dec 2025 17:22:49 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 09:40:12 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 16:11:10 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 04:35:25 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -706,7 +706,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_카카오_oauth_로그인"><a class="link" href="#_카카오_oauth_로그인">카카오 OAuth 로그인</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: PUBLIC</p>
+<p>접근 가능 권한 레벨: PUBLIC / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
@@ -754,12 +754,13 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 16 Dec 2025 16:11:09 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 04:35:25 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
   "message" : "API 호출에 성공했습니다.",
   "data" : {
+    "memberId" : 1,
     "accessToken" : "Bearer accessToken",
     "newMember" : true
   }
@@ -823,6 +824,13 @@ Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Exp
 <td class="tableblock halign-left valign-top"><p class="tableblock">결과 메세지</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
@@ -850,7 +858,7 @@ Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Exp
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-08 21:53:10 +0900
+Last updated 2025-06-20 13:33:02 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 09:40:12 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 11:55:47 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 09:40:12 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 11:55:47 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 15:00:44 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 17:05:18 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 15:00:43 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 17:05:18 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 04:35:25 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:00:17 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 04:35:25 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:00:17 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 16:32:09 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Fri, 19 Dec 2025 17:22:49 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 16:32:08 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Fri, 19 Dec 2025 17:22:49 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:00:17 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:42:58 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:00:17 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Wed, 17 Dec 2025 06:42:58 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/login-api-guide.html
@@ -516,7 +516,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 11:55:47 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 15:00:44 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -754,7 +754,7 @@ Host: docs.api.com</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 11:55:47 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sat, 20 Dec 2025 15:00:43 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
@@ -1682,7 +1682,7 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 제목</p></td>
 </tr>
 <tr>
@@ -1696,7 +1696,7 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingPlace</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 장소</p></td>
 </tr>
 <tr>

--- a/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
@@ -500,13 +500,14 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 233
+Content-Length: 276
 Host: docs.api.com
 
 {
   "meetingType" : "REGULAR",
   "meetingName" : "제 200회 정기모임",
   "meetingDate" : "21260614 10:30",
+  "lateThresholdTime" : "21260614 10:45",
   "meetingPlace" : "추후 공지 예정 (합정역 주변 카페)",
   "description" : "늦지 않게 오세요~"
 }</code></pre>
@@ -574,6 +575,13 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간(모임 개최일자보다 빠르면 안 됨. 입력 안 할 시 모임 개최시간과 동일값 처리)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingPlace</code></p></td>
@@ -741,7 +749,8 @@ Content-Type: application/json;charset=UTF-8
     "meetingCreatorName" : "나뭉이",
     "meetingType" : "REGULAR",
     "meetingName" : "1회 정기모임",
-    "meetingDateTime" : "2025.05.31 10:45",
+    "meetingDateTime" : "2025.05.31 10:30",
+    "lateThresholdTime" : "2025.05.31 10:45",
     "meetingPlace" : "추후 공지 예정 (합정역 주변 카페)",
     "description" : "~~",
     "discussionTime" : "2025.05.31 12:00",
@@ -821,6 +830,13 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingPlace</code></p></td>
@@ -1100,10 +1116,11 @@ Content-Type: application/json;charset=UTF-8
       "meetingDateTime" : "2025.05.31 10:45",
       "meetingPlace" : "합정 빌리프커피로스터리스",
       "description" : "~~",
+      "attendanceStatus" : "true",
+      "discussionGroup" : "A",
       "discussionTime" : "2025.05.31 12:00",
       "alarmMessage" : null,
-      "createdAt" : "2025.05.01 12:30",
-      "isPrivateMeeting" : false
+      "createdAt" : "2025.05.01 12:30"
     }, {
       "meetingId" : 2,
       "meetingCreatorName" : "나뭉이",
@@ -1112,10 +1129,11 @@ Content-Type: application/json;charset=UTF-8
       "meetingDateTime" : "2025.06.03 18:30",
       "meetingPlace" : "합정 저스티나",
       "description" : "~~",
+      "attendanceStatus" : "true_late",
+      "discussionGroup" : null,
       "discussionTime" : "2025.05.01 12:31",
       "alarmMessage" : null,
-      "createdAt" : "2025.05.01 12:30",
-      "isPrivateMeeting" : false
+      "createdAt" : "2025.05.01 12:30"
     } ]
   }
 }</code></pre>
@@ -1241,6 +1259,20 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 상세내용</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].attendanceStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">출석 상태</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].discussionGroup</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 조</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].discussionTime</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -1260,13 +1292,6 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개설일자</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].isPrivateMeeting</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">비공개 여부</p></td>
 </tr>
 </tbody>
 </table>
@@ -1393,7 +1418,8 @@ Content-Type: application/json;charset=UTF-8
       "meetingCreatorName" : "나뭉이",
       "meetingType" : "REGULAR",
       "meetingName" : "1회 정기모임",
-      "meetingDateTime" : "2025.05.31 10:45",
+      "meetingDateTime" : "2025.05.31 10:30",
+      "lateThresholdTime" : "2025.05.31 10:45",
       "meetingPlace" : "합정 빌리프커피로스터리스",
       "description" : "~~",
       "discussionTime" : "2025.05.31 12:00",
@@ -1406,6 +1432,7 @@ Content-Type: application/json;charset=UTF-8
       "meetingType" : "FLASH",
       "meetingName" : "금요 독서벙",
       "meetingDateTime" : "2025.06.03 18:30",
+      "lateThresholdTime" : "2025.05.31 10:45",
       "meetingPlace" : "합정 저스티나",
       "description" : "~~",
       "discussionTime" : "2025.05.01 12:31",
@@ -1523,6 +1550,13 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingList[].meetingPlace</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
@@ -1590,13 +1624,14 @@ Content-Type: application/json;charset=UTF-8
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer access_token
 Accept: application/json
-Content-Length: 168
+Content-Length: 199
 Host: docs.api.com
 
 {
   "meetingType" : null,
   "meetingName" : null,
   "meetingDate" : null,
+  "lateThresholdTime" : null,
   "meetingPlace" : "합정 저스티나",
   "description" : "늦지 않게 오세요~"
 }</code></pre>
@@ -1691,6 +1726,13 @@ Host: docs.api.com
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">모임 개최일자</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>lateThresholdTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">지각 기준 시간(모임 개최 시간보다 빠르면 안 됨)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>meetingPlace</code></p></td>

--- a/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/meeting-api-guide.html
@@ -490,7 +490,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="sect2">
 <h3 id="_모임_생성"><a class="link" href="#_모임_생성">모임 생성</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF / 미래 시간만 생성 가능</p>
+<p>접근 가능 권한 레벨: STAFF / 로그 생성 / 미래 시간만 생성 가능</p>
 </div>
 <div class="sect3">
 <h4 id="_request"><a class="link" href="#_request">request</a></h4>
@@ -602,7 +602,7 @@ Content-Type: application/json;charset=UTF-8
 {
   "code" : 200,
   "message" : "API 호출에 성공했습니다.",
-  "data" : null
+  "data" : 1
 }</code></pre>
 </div>
 </div>
@@ -643,10 +643,10 @@ Content-Type: application/json;charset=UTF-8
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">-</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임 고유번호</p></td>
 </tr>
 </tbody>
 </table>
@@ -1580,7 +1580,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임_수정_기본_정보"><a class="link" href="#_모임_수정_기본_정보">모임 수정 - 기본 정보</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)</p>
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 모임 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 모임 시작 후에도 가능)</p>
 </div>
 <div class="sect3">
 <h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
@@ -1776,7 +1776,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임_수정_조별_활동_관련"><a class="link" href="#_모임_수정_조별_활동_관련">모임 수정 - 조별 활동 관련</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)</p>
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 토론 시작 전, 미래 시간으로만 수정 가능 (관리자 급은 토론 시작 후에도 가능)</p>
 </div>
 <div class="sect3">
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
@@ -2211,7 +2211,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_개설한_모임_삭제"><a class="link" href="#_개설한_모임_삭제">개설한 모임 삭제</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 모임 시작 6시간 전까지만 가능</p>
+<p>접근 가능 권한 레벨: STAFF (STAFF 중에서는 개설 당사자만 가능) / 로그 생성 / 모임 시작 6시간 전까지만 가능</p>
 </div>
 <div class="sect3">
 <h4 id="_request_10"><a class="link" href="#_request_10">request</a></h4>
@@ -2343,7 +2343,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-19 19:30:27 +0900
+Last updated 2025-06-20 13:35:06 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/main/resources/static/docs/member-api-guide.html
+++ b/geulnamu-backend/src/main/resources/static/docs/member-api-guide.html
@@ -859,7 +859,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_개인_정보_수정"><a class="link" href="#_개인_정보_수정">개인 정보 수정</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: MEMBER</p>
+<p>접근 가능 권한 레벨: MEMBER / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_3"><a class="link" href="#_request_3">request</a></h4>
@@ -1012,7 +1012,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임원_등급_변경"><a class="link" href="#_모임원_등급_변경">모임원 등급 변경</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN / 해당 모임원 재로그인 필요</p>
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성 / 해당 모임원 재로그인 필요</p>
 </div>
 <div class="sect3">
 <h4 id="_request_4"><a class="link" href="#_request_4">request</a></h4>
@@ -1176,7 +1176,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임원_이름_변경"><a class="link" href="#_모임원_이름_변경">모임원 이름 변경</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_5"><a class="link" href="#_request_5">request</a></h4>
@@ -1340,7 +1340,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임원_활성화"><a class="link" href="#_모임원_활성화">모임원 활성화</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_6"><a class="link" href="#_request_6">request</a></h4>
@@ -1469,7 +1469,7 @@ Content-Type: application/json;charset=UTF-8
 <div class="sect2">
 <h3 id="_모임원_비활성화"><a class="link" href="#_모임원_비활성화">모임원 비활성화</a></h3>
 <div class="paragraph">
-<p>접근 가능 권한 레벨: ADMIN</p>
+<p>접근 가능 권한 레벨: ADMIN / 로그 생성</p>
 </div>
 <div class="sect3">
 <h4 id="_request_7"><a class="link" href="#_request_7">request</a></h4>
@@ -1601,7 +1601,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-06-08 21:53:10 +0900
+Last updated 2025-06-20 13:35:06 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -1,5 +1,7 @@
 package com.geulnamu.controller.attendance;
 
+import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
+import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.shared.ControllerTest;
 import com.geulnamu.infrastructure.response.ResponseMessage;
 import com.geulnamu.service.attendance.AttendanceService;
@@ -73,6 +75,52 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.NUMBER).description("출석 고유번호")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void writeNoteTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+        AttendanceNoteRequest request = new AttendanceNoteRequest("지각 안 했는데요!");
+
+        doNothing().when(attendanceService).writeNote(any(), any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.patch("/attendance/{attendanceId}/note", 1L)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "attendance/modify/note",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                requestFields(
+                    fieldWithPath("note").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("비고(출석 관련 사유 작성)")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
                 )
             ));
     }

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -268,6 +268,53 @@ public class AttendanceControllerTest extends ControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
+    public void getMyDiscussionGroupMemberListTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+        MemberIdAndNameResponse memberIdAndNameResponse_1 = new MemberIdAndNameResponse(1L, "나뭉일");
+        MemberIdAndNameResponse memberIdAndNameResponse_2 = new MemberIdAndNameResponse(2L, "나뭉이");
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList = new ArrayList<>();
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_1);
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_2);
+
+        given(attendanceService.getMyDiscussionMemberList(any(), any())).willReturn(memberIdAndNameResponseList);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                get("/attendance/discussion/{attendanceId}", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/attendance/discussion/view/my-group",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("토론 참여 희망자 명단"),
+                    fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
+                    fieldWithPath("data[].memberName").type(JsonFieldType.STRING).description("모임원 이름")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
     public void writeNoteTest() throws Exception {
         // given
         String accessToken = "Bearer access_token";

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -2,6 +2,9 @@ package com.geulnamu.controller.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
+import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.controller.shared.ControllerTest;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
@@ -16,6 +19,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentRequest;
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentResponse;
@@ -84,7 +89,7 @@ public class AttendanceControllerTest extends ControllerTest {
 
     @Test
     @WithMockUser(roles = "MEMBER")
-    public void getAttendanceInfoTest() throws Exception {
+    public void getMyAttendanceInfoTest() throws Exception {
         // given
         String accessToken = "Bearer access_token";
         AttendanceInfoResponse attendanceInfoResponse = new AttendanceInfoResponse(
@@ -95,12 +100,12 @@ public class AttendanceControllerTest extends ControllerTest {
             LocalDateTime.of(2126, 6, 13, 20, 0)
         );
 
-        given(attendanceService.getAttendanceInfo(any(), any())).willReturn(attendanceInfoResponse);
+        given(attendanceService.getMyAttendanceInfo(any(), any())).willReturn(attendanceInfoResponse);
 
         // when
         ResultActions actions =
             mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/attendance/{attendanceId}", 1L)
+                RestDocumentationRequestBuilders.get("/attendance/{attendanceId}/my", 1L)
                     .header("Authorization", accessToken)
                     .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -111,7 +116,7 @@ public class AttendanceControllerTest extends ControllerTest {
             .andExpect(jsonPath("code").value(200))
             .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
             .andDo(document(
-                "/attendance/view",
+                "/attendance/view/myInfo",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 pathParameters(
@@ -134,6 +139,76 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("data.discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
                     fieldWithPath("data.groupMemberList").type(JsonFieldType.STRING).description("토론 조 명단").optional(),
                     fieldWithPath("data.createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void getMeetingAttendanceStatusTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        MeetingAttendanceSummaryResponse meetingAttendanceSummaryResponse = new MeetingAttendanceSummaryResponse(
+            LocalDateTime.of(2025, 5, 31, 10, 30),
+            LocalDateTime.of(2025, 5, 31, 10, 45),
+            3L, 2L, 1L
+        );
+
+        MeetingAttendanceStatusResponse meetingAttendanceStatusResponse_1 = new MeetingAttendanceStatusResponse(
+            1L, "나뭉일", LocalDateTime.of(2025, 5, 31, 10, 20), false);
+        MeetingAttendanceStatusResponse meetingAttendanceStatusResponse_2 = new MeetingAttendanceStatusResponse(
+            2L, "나뭉이", LocalDateTime.of(2025, 5, 31, 10, 44), false);
+        MeetingAttendanceStatusResponse meetingAttendanceStatusResponse_3 = new MeetingAttendanceStatusResponse(
+            3L, "나뭉삼", LocalDateTime.of(2025, 5, 31, 10, 50), true);
+        List<MeetingAttendanceStatusResponse> meetingAttendanceStatusResponseList = new ArrayList<>();
+        meetingAttendanceStatusResponseList.add(meetingAttendanceStatusResponse_3);
+        meetingAttendanceStatusResponseList.add(meetingAttendanceStatusResponse_2);
+        meetingAttendanceStatusResponseList.add(meetingAttendanceStatusResponse_1);
+
+        MeetingAttendanceDetailsResponse meetingAttendanceDetailsResponse =
+            new MeetingAttendanceDetailsResponse(meetingAttendanceSummaryResponse, meetingAttendanceStatusResponseList);
+
+        given(attendanceService.getMeetingAttendanceStatus(any())).willReturn(meetingAttendanceDetailsResponse);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/attendance/{attendanceId}", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/attendance/view/list",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse").type(JsonFieldType.OBJECT).description("모임 출석 요약 정보"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.meetingDate").type(JsonFieldType.STRING).description("모임 일자 및 시간"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.lateThresholdTime").type(JsonFieldType.STRING).description("지각 기준 시간"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.totalAttendCount").type(JsonFieldType.NUMBER).description("전체 참석 인원수"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.attendCount").type(JsonFieldType.NUMBER).description("정상 참석자 수"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.lateAttendCount").type(JsonFieldType.NUMBER).description("지각 참석자 수"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[]").type(JsonFieldType.ARRAY).description("모임원별 출석 정보"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].name").type(JsonFieldType.STRING).description("모임원 이름"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].attendanceTime").type(JsonFieldType.STRING).description("출석 시간"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].isLate").type(JsonFieldType.BOOLEAN).description("지각 여부")
                 )
             ));
     }

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -1,10 +1,13 @@
 package com.geulnamu.controller.attendance;
 
+import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
+import com.geulnamu.controller.attendance.dto.request.DiscussionGroupRequest;
 import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
+import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.controller.shared.ControllerTest;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
@@ -24,16 +27,18 @@ import java.util.List;
 
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentRequest;
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentResponse;
+import static com.geulnamu.infrastructure.format.DocumentOptionalGenerator.setAttributes;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -57,7 +62,7 @@ public class AttendanceControllerTest extends ControllerTest {
         // when
         ResultActions actions =
             mockMvc.perform(
-                RestDocumentationRequestBuilders.post("/attendance/{meetingId}", 1)
+                RestDocumentationRequestBuilders.post("/attendance?meetingId={meetingId}", 1)
                     .header("Authorization", accessToken)
                     .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -73,11 +78,11 @@ public class AttendanceControllerTest extends ControllerTest {
                 "attendance/create",
                 getDocumentRequest(),
                 getDocumentResponse(),
-                pathParameters(
-                    parameterWithName("meetingId").attributes(key("format").value("1 이상의 정수")).description("모임 고유번호")
-                ),
                 requestHeaders(
                     headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임 고유번호")
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
@@ -174,7 +179,7 @@ public class AttendanceControllerTest extends ControllerTest {
         // when
         ResultActions actions =
             mockMvc.perform(
-                RestDocumentationRequestBuilders.get("/attendance/{attendanceId}", 1)
+                RestDocumentationRequestBuilders.get("/attendance?meetingId={meetingId}", 1)
                     .header("Authorization", accessToken)
                     .accept(MediaType.APPLICATION_JSON)
                     .contentType(MediaType.APPLICATION_JSON)
@@ -189,11 +194,11 @@ public class AttendanceControllerTest extends ControllerTest {
                 "/attendance/view/list",
                 getDocumentRequest(),
                 getDocumentResponse(),
-                pathParameters(
-                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
-                ),
                 requestHeaders(
                     headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임 고유번호")
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
@@ -209,6 +214,54 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].name").type(JsonFieldType.STRING).description("모임원 이름"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].attendanceTime").type(JsonFieldType.STRING).description("출석 시간"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].isLate").type(JsonFieldType.BOOLEAN).description("지각 여부")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "STAFF")
+    public void getWantDiscussionMemberListTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+        MemberIdAndNameResponse memberIdAndNameResponse_1 = new MemberIdAndNameResponse(1L, "나뭉일");
+        MemberIdAndNameResponse memberIdAndNameResponse_2 = new MemberIdAndNameResponse(2L, "나뭉이");
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList = new ArrayList<>();
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_1);
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_2);
+
+        given(attendanceService.getWantDiscussionMemberList(any())).willReturn(memberIdAndNameResponseList);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                get("/attendance/discussion")
+                    .param("meetingId", "1")
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/attendance/discussion",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임 고유번호")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("토론 참여 희망자 명단"),
+                    fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
+                    fieldWithPath("data[].memberName").type(JsonFieldType.STRING).description("모임원 이름")
                 )
             ));
     }
@@ -332,6 +385,112 @@ public class AttendanceControllerTest extends ControllerTest {
                 ),
                 requestHeaders(
                     headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "STAFF")
+    public void manuallyAssignDiscussionGroupsTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        List<Long> memberIdList_1 = new ArrayList<>();
+        memberIdList_1.add(1L);
+        memberIdList_1.add(10L);
+        DiscussionGroupRequest discussionGroupRequest_1 = new DiscussionGroupRequest(memberIdList_1);
+
+        List<Long> memberIdList_2 = new ArrayList<>();
+        memberIdList_2.add(2L);
+        memberIdList_2.add(20L);
+        DiscussionGroupRequest discussionGroupRequest_2 = new DiscussionGroupRequest(memberIdList_2);
+
+        List<DiscussionGroupRequest> discussionGroupRequestList = new ArrayList<>();
+        discussionGroupRequestList.add(discussionGroupRequest_1);
+        discussionGroupRequestList.add(discussionGroupRequest_2);
+
+        AssignDiscussionGroupsRequest request = new AssignDiscussionGroupsRequest(
+            discussionGroupRequestList);
+
+        doNothing().when(attendanceService).manuallyAssignDiscussionGroups(any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                patch("/attendance/group?meetingId={meetingId}", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request))
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "attendance/group/assign",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임 고유번호")
+                ),
+                requestFields(
+                    fieldWithPath("groups[]").type(JsonFieldType.ARRAY).attributes(key("format").value("7개 이하의 리스트를 담고 있는 리스트")).description("전체 그룹(7개 이하)"),
+                    fieldWithPath("groups[].memberIdList[]").type(JsonFieldType.ARRAY).attributes(key("format").value("1 이상의 정수가 하나 이상 담긴 리스트")).description("모임원 고유번호 리스트")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    public void manuallyAssignDiscussionGroupTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        doNothing().when(attendanceService).assignMemberToDiscussionGroup(any(), any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                patch("/attendance/group/solo" +
+                        "?meetingId={meetingId}&memberId={memberId}&groupNumber={groupNumber}",
+                        1, 2, 3)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "attendance/group/assign/solo",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임 고유번호"),
+                    parameterWithName("memberId").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상의 정수")).description("모임원 고유번호"),
+                    parameterWithName("groupNumber").attributes(key("type").value(JsonFieldType.NUMBER)).attributes(setAttributes("1 이상, 7 이하의 정수")).description("그룹 번호")
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -1,8 +1,9 @@
 package com.geulnamu.controller.attendance;
 
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
-import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
+import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
 import com.geulnamu.controller.shared.ControllerTest;
+import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
 import com.geulnamu.service.attendance.AttendanceService;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,8 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.ResultActions;
+
+import java.time.LocalDateTime;
 
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentRequest;
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentResponse;
@@ -75,6 +78,62 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.NUMBER).description("출석 고유번호")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void getAttendanceInfoTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+        AttendanceInfoResponse attendanceInfoResponse = new AttendanceInfoResponse(
+            1L, MeetingType.REGULAR, LocalDateTime.of(2126, 6, 14, 10, 30),
+            LocalDateTime.of(2126, 6, 14, 10, 45), "1000회 정기모임",
+            "합정 저스티나", "조심히 오세요~", "1등으로 왔지롱~",
+            LocalDateTime.of(2126, 6, 14, 12, 0), null,
+            LocalDateTime.of(2126, 6, 13, 20, 0)
+        );
+
+        given(attendanceService.getAttendanceInfo(any(), any())).willReturn(attendanceInfoResponse);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.get("/attendance/{attendanceId}", 1L)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/attendance/view",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("참석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data.attendanceId").type(JsonFieldType.NUMBER).description("참석 고유번호"),
+                    fieldWithPath("data.meetingType").type(JsonFieldType.STRING).description("모임 유형"),
+                    fieldWithPath("data.meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.lateThresholdTime").type(JsonFieldType.STRING).description("지각 기준 시간"),
+                    fieldWithPath("data.meetingName").type(JsonFieldType.STRING).description("모임 제목"),
+                    fieldWithPath("data.meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
+                    fieldWithPath("data.description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
+                    fieldWithPath("data.note").type(JsonFieldType.STRING).description("참석 관련 비고").optional(),
+                    fieldWithPath("data.discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
+                    fieldWithPath("data.groupMemberList").type(JsonFieldType.STRING).description("토론 조 명단").optional(),
+                    fieldWithPath("data.createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자")
                 )
             ));
     }

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -1,0 +1,72 @@
+package com.geulnamu.controller.attendance;
+
+import com.geulnamu.controller.shared.ControllerTest;
+import com.geulnamu.infrastructure.response.ResponseMessage;
+import com.geulnamu.service.attendance.AttendanceService;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static com.geulnamu.common.ApiDocumentUtils.getDocumentRequest;
+import static com.geulnamu.common.ApiDocumentUtils.getDocumentResponse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = AttendanceController.class)
+public class AttendanceControllerTest extends ControllerTest {
+
+    @MockitoBean
+    private AttendanceService attendanceService;
+
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void meetingAttendTest() throws Exception  {
+        // given
+        String accessToken = "Bearer access_token";
+
+        doNothing().when(attendanceService).createAttendance(any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.post("/attendance/{meetingId}", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "attendance/create",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                )
+            ));
+    }
+
+}

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentRequest;
 import static com.geulnamu.common.ApiDocumentUtils.getDocumentResponse;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -35,9 +36,10 @@ public class AttendanceControllerTest extends ControllerTest {
     @WithMockUser(roles = "MEMBER")
     public void meetingAttendTest() throws Exception  {
         // given
+        Long attendanceId = 1L;
         String accessToken = "Bearer access_token";
 
-        doNothing().when(attendanceService).createAttendance(any(), any());
+        given(attendanceService.createAttendance(any(), any())).willReturn(attendanceId);
 
         // when
         ResultActions actions =
@@ -53,9 +55,47 @@ public class AttendanceControllerTest extends ControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("code").value(200))
             .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
-            .andExpect(jsonPath("data").value((Object) null))
+            .andExpect(jsonPath("data").value(attendanceId))
             .andDo(document(
                 "attendance/create",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("출석 고유번호")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    public void DeleteMeetingAttendTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        doNothing().when(attendanceService).deleteAttendance(any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.delete("/attendance/{attendanceId}/delete", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "attendance/delete",
                 getDocumentRequest(),
                 getDocumentResponse(),
                 requestHeaders(

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -3,11 +3,8 @@ package com.geulnamu.controller.attendance;
 import com.geulnamu.controller.attendance.dto.request.AssignDiscussionGroupsRequest;
 import com.geulnamu.controller.attendance.dto.request.AttendanceNoteRequest;
 import com.geulnamu.controller.attendance.dto.request.DiscussionGroupRequest;
-import com.geulnamu.controller.attendance.dto.response.AttendanceInfoResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceDetailsResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
-import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
-import com.geulnamu.controller.meeting.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.controller.attendance.dto.response.*;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.controller.shared.ControllerTest;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
@@ -309,6 +306,69 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("data").type(JsonFieldType.ARRAY).description("토론 참여 희망자 명단"),
                     fieldWithPath("data[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
                     fieldWithPath("data[].memberName").type(JsonFieldType.STRING).description("모임원 이름")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "STAFF")
+    public void getAllDiscussionGroupMemberList() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        MemberIdAndNameResponse memberIdAndNameResponse_1 = new MemberIdAndNameResponse(1L, "나뭉일");
+        MemberIdAndNameResponse memberIdAndNameResponse_2 = new MemberIdAndNameResponse(2L, "나뭉이");
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList_1 = new ArrayList<>();
+        memberIdAndNameResponseList_1.add(memberIdAndNameResponse_1);
+        memberIdAndNameResponseList_1.add(memberIdAndNameResponse_2);
+
+        MemberIdAndNameResponse memberIdAndNameResponse_3 = new MemberIdAndNameResponse(3L, "나뭉삼");
+        MemberIdAndNameResponse memberIdAndNameResponse_4 = new MemberIdAndNameResponse(4L, "나뭉사");
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList_2 = new ArrayList<>();
+        memberIdAndNameResponseList_2.add(memberIdAndNameResponse_3);
+        memberIdAndNameResponseList_2.add(memberIdAndNameResponse_4);
+
+        DiscussionGroupResponse discussionGroupResponseList_1 = new DiscussionGroupResponse(memberIdAndNameResponseList_1);
+        DiscussionGroupResponse discussionGroupResponseList_2 = new DiscussionGroupResponse(memberIdAndNameResponseList_2);
+        List<DiscussionGroupResponse> discussionGroupResponseList = new ArrayList<>();
+        discussionGroupResponseList.add(discussionGroupResponseList_1);
+        discussionGroupResponseList.add(discussionGroupResponseList_2);
+
+        given(attendanceService.getAllDiscussionGroupMemberList(any())).willReturn(discussionGroupResponseList);
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                get("/attendance/discussion/all?meetingId={meetingId}", 1)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andDo(document(
+                "/attendance/discussion/view/all-group",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                queryParameters(
+                    parameterWithName("meetingId").attributes(key("type").value(JsonFieldType.NUMBER))
+                        .attributes(setAttributes("1 이상의 정수")).description("모임 고유번호")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.ARRAY).description("토론 참여 희망자 명단"),
+                    fieldWithPath("data[]").type(JsonFieldType.ARRAY).description("전체 토론 그룹"),
+                    fieldWithPath("data[].memberIdAndNameResponseList").type(JsonFieldType.ARRAY).description("토론 그룹별 명단"),
+                    fieldWithPath("data[].memberIdAndNameResponseList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
+                    fieldWithPath("data[].memberIdAndNameResponseList[].memberName").type(JsonFieldType.STRING).description("모임원 이름")
                 )
             ));
     }

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -22,6 +22,9 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.snippet.Attributes.key;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -60,6 +63,9 @@ public class AttendanceControllerTest extends ControllerTest {
                 "attendance/create",
                 getDocumentRequest(),
                 getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("meetingId").attributes(key("format").value("1 이상의 정수")).description("모임 고유번호")
+                ),
                 requestHeaders(
                     headerWithName("Authorization").description("액세스 토큰")
                 ),
@@ -67,6 +73,88 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data").type(JsonFieldType.NUMBER).description("출석 고유번호")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void notWantDiscussionTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        doNothing().when(attendanceService).notWantDiscussion(any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.patch("/attendance/{attendanceId}/just-read", 1L)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "attendance/modify/just-read",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                )
+            ));
+    }
+
+    @Test
+    @WithMockUser(roles = "MEMBER")
+    public void wantDiscussionTest() throws Exception {
+        // given
+        String accessToken = "Bearer access_token";
+
+        doNothing().when(attendanceService).wantDiscussion(any(), any());
+
+        // when
+        ResultActions actions =
+            mockMvc.perform(
+                RestDocumentationRequestBuilders.patch("/attendance/{attendanceId}/want-discussion", 1L)
+                    .header("Authorization", accessToken)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.APPLICATION_JSON)
+            );
+
+        // then
+        actions
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("code").value(200))
+            .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data").value((Object) null))
+            .andDo(document(
+                "attendance/modify/want-discussion",
+                getDocumentRequest(),
+                getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
+                requestHeaders(
+                    headerWithName("Authorization").description("액세스 토큰")
+                ),
+                responseFields(
+                    fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
+                    fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
                 )
             ));
     }
@@ -98,6 +186,9 @@ public class AttendanceControllerTest extends ControllerTest {
                 "attendance/delete",
                 getDocumentRequest(),
                 getDocumentResponse(),
+                pathParameters(
+                    parameterWithName("attendanceId").attributes(key("format").value("1 이상의 정수")).description("출석 고유번호")
+                ),
                 requestHeaders(
                     headerWithName("Authorization").description("액세스 토큰")
                 ),

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/login/LoginControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/login/LoginControllerTest.java
@@ -45,7 +45,7 @@ public class LoginControllerTest extends ControllerTest {
     public void processKakaoLoginTest() throws Exception {
         // given
         String accessToken = "Bearer accessToken";
-        LoginResponse loginResponse = new LoginResponse(accessToken, true);
+        LoginResponse loginResponse = new LoginResponse(1L, accessToken, true);
         Cookie cookie = new Cookie("refreshToken", "random_refreshToken_code");
         cookie.setMaxAge((int) (TokenInfo.REFRESH_TOKEN_VALID_TIME/1000));
         cookie.setPath("/");
@@ -75,6 +75,7 @@ public class LoginControllerTest extends ControllerTest {
             .andExpect(cookie().value(cookie.getName(), cookie.getValue()))
             .andExpect(jsonPath("code").value(200))
             .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
+            .andExpect(jsonPath("data.memberId").value(loginResponse.memberId()))
             .andExpect(jsonPath("data.accessToken").value(loginResponse.accessToken()))
             .andExpect(jsonPath("data.newMember").value(loginResponse.newMember()))
             .andDo(document(
@@ -90,6 +91,7 @@ public class LoginControllerTest extends ControllerTest {
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
+                    fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
                     fieldWithPath("data.accessToken").type(JsonFieldType.STRING).description("액세스 토큰 값"),
                     fieldWithPath("data.newMember").type(JsonFieldType.BOOLEAN).description("멤버 신규 여부")
                 )

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -3,10 +3,9 @@ package com.geulnamu.controller.meeting;
 import com.geulnamu.controller.meeting.dto.request.MeetingCreateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
-import com.geulnamu.controller.meeting.dto.response.MeetingInfoResponse;
-import com.geulnamu.controller.meeting.dto.response.MeetingListResponse;
-import com.geulnamu.controller.meeting.dto.response.StaffResponse;
+import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.controller.shared.ControllerTest;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;
 import com.geulnamu.infrastructure.response.paging.PagingResponse;
@@ -53,10 +52,12 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         Long meetingId = 1L;
         String accessToken = "Bearer access_token";
-        MeetingCreateRequest request = new MeetingCreateRequest(
-            "REGULAR", "제 200회 정기모임", LocalDateTime.of(2126, 6, 14, 10, 30), "추후 공지 예정 (합정역 주변 카페)", "늦지 않게 오세요~");
+        MeetingCreateRequest request = new MeetingCreateRequest("REGULAR", "제 200회 정기모임",
+            LocalDateTime.of(2126, 6, 14, 10, 30),
+            LocalDateTime.of(2126, 6, 14, 10, 45),
+            "추후 공지 예정 (합정역 주변 카페)", "늦지 않게 오세요~");
 
-        given(meetingService.createMeeting(any(), any(), any(), any(), any(), any())).willReturn(meetingId);
+        given(meetingService.createMeeting(any(), any(), any(), any(), any(), any(), any())).willReturn(meetingId);
 
         // when
         ResultActions actions =
@@ -85,6 +86,7 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류"),
                     fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목"),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자"),
+                    fieldWithPath("lateThresholdTime").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("지각 기준 시간(모임 개최일자보다 빠르면 안 됨. 입력 안 할 시 모임 개최시간과 동일값 처리)").optional(),
                     fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소"),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),
@@ -102,13 +104,14 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
 
-        MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
-            1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "추후 공지 예정 (합정역 주변 카페)", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
+        MeetingInfoForAdminResponse meetingInfoForAdminResponse_01 = new MeetingInfoForAdminResponse(
+            1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 30),
+            LocalDateTime.of(2025, 5, 31, 10, 45), "추후 공지 예정 (합정역 주변 카페)", "~~",
+            LocalDateTime.of(2025, 5, 31, 12, 0), null,
             LocalDateTime.of(2025, 5, 1, 12, 30), false
         );
 
-        given(meetingService.findMeeting(any())).willReturn(meetingInfoResponse_01);
+        given(meetingService.findMeeting(any())).willReturn(meetingInfoForAdminResponse_01);
 
         // when
         ResultActions actions =
@@ -142,6 +145,7 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingType").type(JsonFieldType.STRING).description("모임 유형"),
                     fieldWithPath("data.meetingName").type(JsonFieldType.STRING).description("모임 제목"),
                     fieldWithPath("data.meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.lateThresholdTime").type(JsonFieldType.STRING).description("지각 기준 시간"),
                     fieldWithPath("data.meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
                     fieldWithPath("data.discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
@@ -204,13 +208,15 @@ public class MeetingControllerTest extends ControllerTest {
 
         MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
             1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "합정 빌리프커피로스터리스", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
-            LocalDateTime.of(2025, 5, 1, 12, 30), false
+            "합정 빌리프커피로스터리스", "~~", "true", DiscussionGroup.A,
+            LocalDateTime.of(2025, 5, 31, 12, 0), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30)
         );
         MeetingInfoResponse meetingInfoResponse_02 = new MeetingInfoResponse(
             2L, "나뭉이", MeetingType.FLASH, "금요 독서벙", LocalDateTime.of(2025, 6, 3, 18, 30),
-            "합정 저스티나", "~~", LocalDateTime.of(2025, 5, 1, 12, 31), null,
-            LocalDateTime.of(2025, 5, 1, 12, 30), false
+            "합정 저스티나", "~~", "true_late", null,
+            LocalDateTime.of(2025, 5, 1, 12, 31), null,
+            LocalDateTime.of(2025, 5, 1, 12, 30)
         );
         List<MeetingInfoResponse> meetingInfoResponseList = new ArrayList<>();
         meetingInfoResponseList.add(meetingInfoResponse_01);
@@ -221,7 +227,7 @@ public class MeetingControllerTest extends ControllerTest {
 
         MeetingListResponse meetingListResponse = new MeetingListResponse(pagingResponse, meetingInfoResponseList);
 
-        given(meetingService.getMeetingList(any())).willReturn(meetingListResponse);
+        given(meetingService.getMeetingList(any(), any())).willReturn(meetingListResponse);
 
         // when
         ResultActions actions =
@@ -269,10 +275,11 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingList[].meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
                     fieldWithPath("data.meetingList[].meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.meetingList[].description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
+                    fieldWithPath("data.meetingList[].attendanceStatus").type(JsonFieldType.STRING).description("출석 상태"),
+                    fieldWithPath("data.meetingList[].discussionGroup").type(JsonFieldType.STRING).description("토론 조").optional(),
                     fieldWithPath("data.meetingList[].discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
                     fieldWithPath("data.meetingList[].alarmMessage").type(JsonFieldType.STRING).description("토론 시작 알림 메세지").optional(),
-                    fieldWithPath("data.meetingList[].createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자"),
-                    fieldWithPath("data.meetingList[].isPrivateMeeting").type(JsonFieldType.BOOLEAN).description("비공개 여부")
+                    fieldWithPath("data.meetingList[].createdAt").type(JsonFieldType.STRING).optional().description("모임 개설일자")
                 )
             ));
     }
@@ -283,26 +290,28 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
 
-        MeetingInfoResponse meetingInfoResponse_01 = new MeetingInfoResponse(
-            1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 45),
-            "합정 빌리프커피로스터리스", "~~", LocalDateTime.of(2025, 5, 31, 12, 0), null,
+        MeetingInfoForAdminResponse meetingInfoForAdminResponse_01 = new MeetingInfoForAdminResponse(
+            1L, "나뭉이", MeetingType.REGULAR, "1회 정기모임", LocalDateTime.of(2025, 5, 31, 10, 30),
+            LocalDateTime.of(2025, 5, 31, 10, 45), "합정 빌리프커피로스터리스", "~~",
+            LocalDateTime.of(2025, 5, 31, 12, 0), null,
             LocalDateTime.of(2025, 5, 1, 12, 30), false
         );
-        MeetingInfoResponse meetingInfoResponse_02 = new MeetingInfoResponse(
+        MeetingInfoForAdminResponse meetingInfoForAdminResponse_02 = new MeetingInfoForAdminResponse(
             2L, "나뭉이", MeetingType.FLASH, "금요 독서벙", LocalDateTime.of(2025, 6, 3, 18, 30),
-            "합정 저스티나", "~~", LocalDateTime.of(2025, 5, 1, 12, 31), null,
+            LocalDateTime.of(2025, 5, 31, 10, 45), "합정 저스티나", "~~",
+            LocalDateTime.of(2025, 5, 1, 12, 31), null,
             LocalDateTime.of(2025, 5, 1, 12, 30), false
         );
-        List<MeetingInfoResponse> meetingInfoResponseList = new ArrayList<>();
-        meetingInfoResponseList.add(meetingInfoResponse_01);
-        meetingInfoResponseList.add(meetingInfoResponse_02);
+        List<MeetingInfoForAdminResponse> meetingInfoForAdminResponseList = new ArrayList<>();
+        meetingInfoForAdminResponseList.add(meetingInfoForAdminResponse_01);
+        meetingInfoForAdminResponseList.add(meetingInfoForAdminResponse_02);
 
         PagingResponse pagingResponse = new PagingResponse(
             1, 3, 6);
 
-        MeetingListResponse meetingListResponse = new MeetingListResponse(pagingResponse, meetingInfoResponseList);
+        MeetingListForAdminResponse meetingListForAdminResponse = new MeetingListForAdminResponse(pagingResponse, meetingInfoForAdminResponseList);
 
-        given(meetingService.getMeetingListForAdmin(any())).willReturn(meetingListResponse);
+        given(meetingService.getMeetingListForAdmin(any())).willReturn(meetingListForAdminResponse);
 
         // when
         ResultActions actions =
@@ -350,6 +359,7 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingList[].meetingType").type(JsonFieldType.STRING).description("모임 유형"),
                     fieldWithPath("data.meetingList[].meetingName").type(JsonFieldType.STRING).description("모임 제목"),
                     fieldWithPath("data.meetingList[].meetingDateTime").type(JsonFieldType.STRING).description("모임 개최일자"),
+                    fieldWithPath("data.meetingList[].lateThresholdTime").type(JsonFieldType.STRING).description("지각 기준 시간"),
                     fieldWithPath("data.meetingList[].meetingPlace").type(JsonFieldType.STRING).description("모임 장소"),
                     fieldWithPath("data.meetingList[].description").type(JsonFieldType.STRING).description("모임 상세내용").optional(),
                     fieldWithPath("data.meetingList[].discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
@@ -366,10 +376,10 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
         MeetingUpdateRequest request = new MeetingUpdateRequest(
-            null, null, null, "합정 저스티나", "늦지 않게 오세요~"
+            null, null, null, null, "합정 저스티나", "늦지 않게 오세요~"
         );
 
-        doNothing().when(meetingService).updateMeeting(any(), any(), any(), any(), any(), any(), any());
+        doNothing().when(meetingService).updateMeeting(any(), any(), any(), any(), any(), any(), any(), any());
 
         // when
         ResultActions actions =
@@ -401,6 +411,7 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
                     fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하의 문자열")).description("모임 제목").optional(),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자").optional(),
+                    fieldWithPath("lateThresholdTime").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("지각 기준 시간(모임 개최 시간보다 빠르면 안 됨)").optional(),
                     fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("모임 장소").optional(),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -5,6 +5,7 @@ import com.geulnamu.controller.meeting.dto.request.MeetingGroupUpdateRequest;
 import com.geulnamu.controller.meeting.dto.request.MeetingUpdateRequest;
 import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.controller.shared.ControllerTest;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
 import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.MeetingType;
 import com.geulnamu.infrastructure.response.ResponseMessage;

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -51,11 +51,12 @@ public class MeetingControllerTest extends ControllerTest {
     @WithMockUser(roles = "STAFF")
     public void createMeetingTest() throws Exception {
         // given
+        Long meetingId = 1L;
         String accessToken = "Bearer access_token";
         MeetingCreateRequest request = new MeetingCreateRequest(
             "REGULAR", "제 200회 정기모임", LocalDateTime.of(2126, 6, 14, 10, 30), "추후 공지 예정 (합정역 주변 카페)", "늦지 않게 오세요~");
 
-        doNothing().when(meetingService).createMeeting(any(), any(), any(), any(), any(), any());
+        given(meetingService.createMeeting(any(), any(), any(), any(), any(), any())).willReturn(meetingId);
 
         // when
         ResultActions actions =
@@ -72,7 +73,7 @@ public class MeetingControllerTest extends ControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("code").value(200))
             .andExpect(jsonPath("message").value(ResponseMessage.SUCCESS))
-            .andExpect(jsonPath("data").value((Object) null))
+            .andExpect(jsonPath("data").value(meetingId))
             .andDo(document(
                 "meeting/open",
                 getDocumentRequest(),
@@ -90,7 +91,7 @@ public class MeetingControllerTest extends ControllerTest {
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
-                    fieldWithPath("data").type(JsonFieldType.NULL).description("-")
+                    fieldWithPath("data").type(JsonFieldType.NUMBER).description("모임 고유번호")
                 )
             ));
     }

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -162,13 +162,13 @@ public class MeetingControllerTest extends ControllerTest {
         // given
         String accessToken = "Bearer access_token";
 
-        StaffResponse staffResponse_01 = new StaffResponse(1L, "나뭉모임장");
-        StaffResponse staffResponse_02 = new StaffResponse(2L, "나순부모임장");
-        List<StaffResponse> staffResponseList = new ArrayList<>();
-        staffResponseList.add(staffResponse_01);
-        staffResponseList.add(staffResponse_02);
+        MemberIdAndNameResponse memberIdAndNameResponse_01 = new MemberIdAndNameResponse(1L, "나뭉모임장");
+        MemberIdAndNameResponse memberIdAndNameResponse_02 = new MemberIdAndNameResponse(2L, "나순부모임장");
+        List<MemberIdAndNameResponse> memberIdAndNameResponseList = new ArrayList<>();
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_01);
+        memberIdAndNameResponseList.add(memberIdAndNameResponse_02);
 
-        given(meetingService.getStaffList()).willReturn(staffResponseList);
+        given(meetingService.getStaffList()).willReturn(memberIdAndNameResponseList);
 
         // when
         ResultActions actions =

--- a/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu-backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -399,9 +399,9 @@ public class MeetingControllerTest extends ControllerTest {
                 ),
                 requestFields(
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
-                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목").optional(),
+                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하의 문자열")).description("모임 제목").optional(),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자").optional(),
-                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소").optional(),
+                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("모임 장소").optional(),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),
                 responseFields(


### PR DESCRIPTION
# 변경 내역
## Attendance Domain 기능 구현
### 구현 API 리스트
- 출석: [POST] /attendance (접근 레벨: MEMBER)
- 개인 출석 정보 조회: [GET] /attendance/{attendanceId}/my (접근 레벨: MEMBER)
- 모임별 참석 현황 조회: [GET] /attendance (접근 레벨: MEMBER)
- 모임 토론 참여 희망 명단 조회: [GET] /attendance/discussion (접근 레벨: STAFF)
- 본인 토론 그룹 명단 조회: [GET] /attendance/discussion/{attendanceId} (접근 레벨: MEMBER)
- 전체 토론 그룹 명단 조회: [GET] /attendacne/discussion/all (접근 레벨: STAFF)
- 비고 작성: [PATCH] /attendance/{attendanceId}/note (접근 레벨: MEMBER)
- 독서만 할래요: [PATCH] /attendance/{attendanceId}/just-read (접근 레벨: MEMBER)
- 토론할래요: [PATCH] /attendance/{attendanceId}/want-discussion (접근 레벨: MEMBER)
- 토론 그룹 구성 - 수동: [PATCH] /attendance/group (접근 레벨: STAFF)
- 토론 그룹 할당 - 개인: [PATCH] /attendance/group/solo (접근 레벨: ADMIN)
- 출석 삭제: [DELETE] /attendance/{attendanceId}/delete (접근 레벨: ADMIN)

## Attendance Domain 수정
- 컬럼 추가: `note` (비고)
- 컬럼 추가: `not_want_discussion` (토론 불참 희망 여부)

## 로깅 기능 수정
- post 메서드에 해당하는 API 수행 시, 응답값에 생성한 id 반환하도록 변경 (로그 확인 편리성 향상)

## 테스트 코드 및 API 문서 작성
- 구현한 기능 및 수정된 기능들에 대해서 api layer 테스트 코드 작성 및 API 문서 작성