### PR TITLE
[Feat/BE] 로그인 API 설정 수정 - cors 우회

### DIFF
--- a/geulnamu_backend/src/main/java/com/geulnamu/service/login/AuthTokenService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/login/AuthTokenService.java
@@ -99,7 +99,7 @@ public class AuthTokenService {
             .maxAge(TokenInfo.REFRESH_TOKEN_VALID_TIME / 1000)
             .path("/")
             .secure(true)
-            .httpOnly(true)
+            .httpOnly(false) // cors 관련 필요 설정, TODO: 추후 https 적용 후에 다시 필요한 설정인지 확인해 볼 것
             .sameSite("None")
             .build();
         response.setHeader("Set-Cookie", cookie.toString());


### PR DESCRIPTION
# 변경 내역
## 로그인 기능 수정
- 리프레시 토큰 생성시 httpOnly 옵션 flase로 변경 => cors 에러 우회 목적 (추후 운영 환경 에서는 다시 변경 필요)