### PR TITLE
[Feat/FE] 설정 페이지

### DIFF
--- a/geulnamu_frontend/lib/core/colors.dart
+++ b/geulnamu_frontend/lib/core/colors.dart
@@ -10,6 +10,9 @@ class GeulnamuColors {
   static const Color primaryVariantLight = Color(0xFF6BC4AE);
   static const Color secondaryLight = Color(0xFFF5F1E8);
   
+  /// 어두운 베이지 색상: 가독성 개선된 베이지 계열 (따뜻한 브라운 베이지)
+  static const Color darkBeigeLight = Color(0xFF8B7355);
+  
   /// 배경 및 표면 색상 (라이트) - 🎯 명확한 대비 보장
   static const Color backgroundLight = Color(0xFFFAFAFA);      // 오프화이트 배경 (유지)
   static const Color surfaceLight = Color(0xFFFFFFFF);        // 카드는 완전한 흰색 (명확한 대비!)
@@ -27,6 +30,9 @@ class GeulnamuColors {
   static const Color primaryDark = Color(0xFF5BAB98);
   static const Color primaryVariantDark = Color(0xFF4A9B8E);
   static const Color secondaryDark = Color(0xFF3A3A3A);
+  
+  /// 어두운 베이지 색상 (다크 모드): 더 밝게 조정된 브라운 베이지
+  static const Color darkBeigeDark = Color(0xFFB8A082);
   
   /// 배경 및 표면 색상 (다크) - 🎯 더 명확한 대비 제공
   static const Color backgroundDark = Color(0xFF0F0F0F);       // 더 어두운 배경 (거의 검정)

--- a/geulnamu_frontend/lib/core/services/settings_service.dart
+++ b/geulnamu_frontend/lib/core/services/settings_service.dart
@@ -1,0 +1,160 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// 설정 관리 서비스
+/// SharedPreferences를 사용하여 로컬에 설정값 저장
+class SettingsService {
+  static final SettingsService _instance = SettingsService._internal();
+  factory SettingsService() => _instance;
+  SettingsService._internal();
+
+  // 설정 키 상수
+  static const String _themeKey = 'theme_mode';
+  static const String _notificationKey = 'meeting_notification';
+
+  /// 테마 모드 가져오기
+  /// 기본값: system
+  Future<ThemeMode> getThemeMode() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final themeString = prefs.getString(_themeKey) ?? 'system';
+      
+      switch (themeString) {
+        case 'light':
+          return ThemeMode.light;
+        case 'dark':
+          return ThemeMode.dark;
+        case 'system':
+        default:
+          return ThemeMode.system;
+      }
+    } catch (e) {
+      print('❌ [SettingsService] 테마 모드 로드 실패: $e');
+      return ThemeMode.system; // 기본값
+    }
+  }
+
+  /// 테마 모드 저장하기
+  Future<bool> setThemeMode(ThemeMode themeMode) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      String themeString;
+      
+      switch (themeMode) {
+        case ThemeMode.light:
+          themeString = 'light';
+          break;
+        case ThemeMode.dark:
+          themeString = 'dark';
+          break;
+        case ThemeMode.system:
+        default:
+          themeString = 'system';
+          break;
+      }
+      
+      final success = await prefs.setString(_themeKey, themeString);
+      
+      if (success) {
+        print('✅ [SettingsService] 테마 모드 저장 성공: $themeString');
+      } else {
+        print('❌ [SettingsService] 테마 모드 저장 실패');
+      }
+      
+      return success;
+    } catch (e) {
+      print('❌ [SettingsService] 테마 모드 저장 오류: $e');
+      return false;
+    }
+  }
+
+  /// 모임 알림 설정 가져오기
+  /// 기본값: true (켜짐)
+  Future<bool> getMeetingNotification() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final enabled = prefs.getBool(_notificationKey) ?? true; // 기본값: 켜짐
+      
+      print('📱 [SettingsService] 모임 알림 상태: $enabled');
+      return enabled;
+    } catch (e) {
+      print('❌ [SettingsService] 모임 알림 설정 로드 실패: $e');
+      return true; // 기본값
+    }
+  }
+
+  /// 모임 알림 설정 저장하기
+  Future<bool> setMeetingNotification(bool enabled) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final success = await prefs.setBool(_notificationKey, enabled);
+      
+      if (success) {
+        print('✅ [SettingsService] 모임 알림 설정 저장 성공: $enabled');
+      } else {
+        print('❌ [SettingsService] 모임 알림 설정 저장 실패');
+      }
+      
+      return success;
+    } catch (e) {
+      print('❌ [SettingsService] 모임 알림 설정 저장 오류: $e');
+      return false;
+    }
+  }
+
+  /// 모든 설정 초기화 (디버그/테스트용)
+  Future<bool> resetAllSettings() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      
+      final results = await Future.wait([
+        prefs.remove(_themeKey),
+        prefs.remove(_notificationKey),
+      ]);
+      
+      final success = results.every((result) => result);
+      
+      if (success) {
+        print('✅ [SettingsService] 모든 설정 초기화 성공');
+      } else {
+        print('❌ [SettingsService] 일부 설정 초기화 실패');
+      }
+      
+      return success;
+    } catch (e) {
+      print('❌ [SettingsService] 설정 초기화 오류: $e');
+      return false;
+    }
+  }
+
+  /// 설정 정보 디버그 출력
+  Future<void> debugPrintSettings() async {
+    try {
+      final themeMode = await getThemeMode();
+      final notification = await getMeetingNotification();
+      
+      print('🔧 [SettingsService] 현재 설정:');
+      print('   테마 모드: $themeMode');
+      print('   모임 알림: $notification');
+    } catch (e) {
+      print('❌ [SettingsService] 설정 정보 출력 실패: $e');
+    }
+  }
+
+  /// 테마 모드를 문자열로 변환 (UI 표시용)
+  String getThemeModeDisplayName(ThemeMode themeMode) {
+    switch (themeMode) {
+      case ThemeMode.light:
+        return '라이트';
+      case ThemeMode.dark:
+        return '다크';
+      case ThemeMode.system:
+        return '시스템 설정';
+    }
+  }
+
+  /// 모든 테마 모드 옵션 반환
+  List<ThemeMode> getAllThemeModes() {
+    return [ThemeMode.light, ThemeMode.dark, ThemeMode.system];
+  }
+}

--- a/geulnamu_frontend/lib/core/theme.dart
+++ b/geulnamu_frontend/lib/core/theme.dart
@@ -184,10 +184,14 @@ class GeulnamuTheme {
       
       // 🎯 SnackBar 테마
       snackBarTheme: SnackBarThemeData(
-        backgroundColor: const Color(0xFF2C3E50),
-        contentTextStyle: GoogleFonts.notoSans(color: Colors.white),
+        backgroundColor: colorScheme.primary, // 🎨 글나무 민트색
+        contentTextStyle: GoogleFonts.notoSans(
+          color: colorScheme.onPrimary, // 민트색 배경에 대비되는 텍스트 색상
+          fontWeight: FontWeight.w500,
+        ),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         behavior: SnackBarBehavior.floating,
+        elevation: 3,
       ),
       
       // 🎯 Divider 테마
@@ -402,10 +406,14 @@ class GeulnamuTheme {
       ),
       
       snackBarTheme: SnackBarThemeData(
-        backgroundColor: colorScheme.surfaceVariant,
-        contentTextStyle: GoogleFonts.notoSans(color: colorScheme.onSurfaceVariant),
+        backgroundColor: colorScheme.primary, // 🎨 글나무 민트색 (다크 모드)
+        contentTextStyle: GoogleFonts.notoSans(
+          color: colorScheme.onPrimary, // 민트색 배경에 대비되는 텍스트 색상
+          fontWeight: FontWeight.w500,
+        ),
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
         behavior: SnackBarBehavior.floating,
+        elevation: 3,
       ),
       
       dividerTheme: DividerThemeData(

--- a/geulnamu_frontend/lib/core/theme.dart
+++ b/geulnamu_frontend/lib/core/theme.dart
@@ -482,6 +482,11 @@ extension GeulnamuThemeExtension on BuildContext {
   Color get errorColor => GeulnamuColors.error;
   Color get infoColor => GeulnamuColors.info;
   
+  /// 어두운 베이지 색상 (테마 자동 선택)
+  Color get darkBeigeColor => isDarkMode 
+      ? GeulnamuColors.darkBeigeDark 
+      : GeulnamuColors.darkBeigeLight;
+  
   /// 현재 테마에 맞는 그라데이션
   LinearGradient get primaryGradient => isDarkMode 
       ? GeulnamuColors.primaryGradientDark 

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -9,6 +9,7 @@ import 'core/theme.dart';  // 🎯 모든 테마 설정이 여기에!
 
 // Provider imports
 import 'providers/auth_provider.dart';
+import 'providers/theme_provider.dart';
 
 // Screen imports
 import 'screens/splash/splash_screen.dart';
@@ -17,6 +18,7 @@ import 'screens/auth/login_screen.dart';
 import 'screens/home/home_screen.dart';
 import 'screens/profile/profile_screen.dart';
 import 'screens/introduction/introduction_screen.dart'; // 글나무 소개 화면
+import 'screens/settings_screen.dart'; // 설정 화면
 import 'services/home/home_route_service.dart'; // 🎯 RouteObserver import
 
 // 🎯 Global Navigator Key - 전역에서 접근 가능
@@ -43,25 +45,39 @@ void main() async {
   }
 }
 
-class GeulnamuApp extends StatelessWidget {
+class GeulnamuApp extends StatefulWidget {
   const GeulnamuApp({super.key});
+
+  @override
+  State<GeulnamuApp> createState() => _GeulnamuAppState();
+}
+
+class _GeulnamuAppState extends State<GeulnamuApp> {
 
   @override
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider(create: (_) => AuthProvider()),
+        ChangeNotifierProvider(create: (_) {
+          final themeProvider = ThemeProvider();
+          // 비동기로 초기화 실행
+          Future.microtask(() => themeProvider.initialize());
+          return themeProvider;
+        }),
         // 추후 다른 Provider들 추가 가능
       ],
-      child: MaterialApp(
-        navigatorKey: navigatorKey,  // 🎯 Global Navigator Key 설정
-        title: '글나무 - 독서 토론 커뮤니티',
-        debugShowCheckedModeBanner: false,
+      child: Consumer<ThemeProvider>(
+        builder: (context, themeProvider, child) {
+          return MaterialApp(
+            navigatorKey: navigatorKey,  // 🎯 Global Navigator Key 설정
+            title: '글나무 - 독서 토론 커뮤니티',
+            debugShowCheckedModeBanner: false,
 
-        // 🎯 핵심: Material Theme + 시스템 다크모드 지원
-        theme: GeulnamuTheme.lightTheme,      // 라이트 테마 (FAFAFA 배경 + 흰색 카드)
-        darkTheme: GeulnamuTheme.darkTheme,   // 다크 테마 (0F0F0F 배경 + 회색 카드)
-        themeMode: ThemeMode.system,          // 시스템 설정에 따라 자동 전환
+            // 🎯 핵심: ThemeProvider와 연동된 테마 시스템
+            theme: GeulnamuTheme.lightTheme,      // 라이트 테마 (FAFAFA 배경 + 흰색 카드)
+            darkTheme: GeulnamuTheme.darkTheme,   // 다크 테마 (0F0F0F 배경 + 회색 카드)
+            themeMode: themeProvider.themeMode,   // 🎯 ThemeProvider에서 관리하는 테마 모드
 
         // 🎯 한국어 지원 추가
         localizationsDelegates: const [
@@ -85,11 +101,14 @@ class GeulnamuApp extends StatelessWidget {
           '/home': (context) => const HomeScreen(),
           '/profile': (context) => const ProfileScreen(), // 프로필 화면
           '/introduction': (context) => const IntroductionScreen(), // 글나무 소개 화면
+          '/settings': (context) => const SettingsScreen(), // 설정 화면
         },
 
-        // 404 처리
-        onUnknownRoute: (settings) {
-          return MaterialPageRoute(builder: (context) => const LoginScreen());
+            // 404 처리
+            onUnknownRoute: (settings) {
+              return MaterialPageRoute(builder: (context) => const LoginScreen());
+            },
+          );
         },
       ),
     );

--- a/geulnamu_frontend/lib/providers/theme_provider.dart
+++ b/geulnamu_frontend/lib/providers/theme_provider.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import '../core/services/settings_service.dart';
+
+/// 테마 상태 관리 Provider
+/// SettingsService와 연동하여 테마 모드 관리
+class ThemeProvider extends ChangeNotifier {
+  final SettingsService _settingsService = SettingsService();
+  
+  ThemeMode _themeMode = ThemeMode.system; // 기본값: 시스템 설정
+  bool _isLoading = false;
+
+  /// 현재 테마 모드
+  ThemeMode get themeMode => _themeMode;
+  
+  /// 로딩 상태
+  bool get isLoading => _isLoading;
+
+  /// 현재 테마 모드의 표시명
+  String get currentThemeDisplayName => _settingsService.getThemeModeDisplayName(_themeMode);
+
+  /// 초기화 - 저장된 테마 모드 로드
+  Future<void> initialize() async {
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      _themeMode = await _settingsService.getThemeMode();
+      print('✅ [ThemeProvider] 테마 모드 초기화 완료: $_themeMode');
+    } catch (e) {
+      print('❌ [ThemeProvider] 테마 모드 초기화 실패: $e');
+      _themeMode = ThemeMode.system; // 실패 시 기본값
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// 테마 모드 변경
+  Future<void> setThemeMode(ThemeMode newThemeMode) async {
+    if (_themeMode == newThemeMode) {
+      print('🔄 [ThemeProvider] 동일한 테마 모드 - 변경 없음: $newThemeMode');
+      return;
+    }
+
+    _isLoading = true;
+    notifyListeners();
+
+    try {
+      // 먼저 UI 업데이트
+      _themeMode = newThemeMode;
+      notifyListeners();
+
+      // 설정 저장
+      final success = await _settingsService.setThemeMode(newThemeMode);
+      
+      if (success) {
+        print('✅ [ThemeProvider] 테마 모드 변경 성공: $newThemeMode');
+      } else {
+        print('❌ [ThemeProvider] 테마 모드 저장 실패 - UI는 이미 변경됨');
+      }
+    } catch (e) {
+      print('❌ [ThemeProvider] 테마 모드 변경 오류: $e');
+      // 에러 발생 시 이전 상태로 복원하지 않음 (UI 우선)
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  /// 다음 테마 모드로 순환 (라이트 → 다크 → 시스템 → 라이트...)
+  Future<void> toggleThemeMode() async {
+    ThemeMode nextTheme;
+    
+    switch (_themeMode) {
+      case ThemeMode.light:
+        nextTheme = ThemeMode.dark;
+        break;
+      case ThemeMode.dark:
+        nextTheme = ThemeMode.system;
+        break;
+      case ThemeMode.system:
+        nextTheme = ThemeMode.light;
+        break;
+    }
+    
+    await setThemeMode(nextTheme);
+  }
+
+  /// 다크 모드 여부 확인 (시스템 테마 모드 고려)
+  bool isDarkMode(BuildContext context) {
+    switch (_themeMode) {
+      case ThemeMode.light:
+        return false;
+      case ThemeMode.dark:
+        return true;
+      case ThemeMode.system:
+        return MediaQuery.of(context).platformBrightness == Brightness.dark;
+    }
+  }
+
+  /// 모든 테마 모드 옵션 반환
+  List<ThemeMode> get allThemeModes => _settingsService.getAllThemeModes();
+
+  /// 테마 모드 표시명 반환
+  String getThemeModeDisplayName(ThemeMode mode) => _settingsService.getThemeModeDisplayName(mode);
+}

--- a/geulnamu_frontend/lib/screens/introduction/introduction_screen.dart
+++ b/geulnamu_frontend/lib/screens/introduction/introduction_screen.dart
@@ -546,7 +546,7 @@ class IntroductionScreen extends StatelessWidget {
           children: [
             Icon(
               Icons.flash_on_rounded,
-              color: context.colors.secondary,
+              color: context.darkBeigeColor,
               size: 24,
             ),
             const SizedBox(width: 8),
@@ -554,7 +554,7 @@ class IntroductionScreen extends StatelessWidget {
               '독서벙',
               style: context.textStyles.headlineSmall?.copyWith(
                 fontWeight: FontWeight.bold,
-                color: context.colors.secondary,
+                color: context.darkBeigeColor,
               ),
             ),
           ],
@@ -572,8 +572,8 @@ class IntroductionScreen extends StatelessWidget {
                 begin: Alignment.topLeft,
                 end: Alignment.bottomRight,
                 colors: [
-                  context.colors.secondary.withOpacity(0.1),
-                  context.colors.secondary.withOpacity(0.05),
+                  context.darkBeigeColor.withOpacity(0.1),
+                  context.darkBeigeColor.withOpacity(0.05),
                 ],
               ),
             ),
@@ -663,13 +663,13 @@ class IntroductionScreen extends StatelessWidget {
     return Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Icon(icon, color: context.colors.secondary, size: 18),
+        Icon(icon, color: context.darkBeigeColor, size: 18),
         const SizedBox(width: 8),
         Text(
           '$title: ',
           style: context.textStyles.bodyMedium?.copyWith(
             fontWeight: FontWeight.w600,
-            color: context.colors.secondary,
+            color: context.darkBeigeColor,
           ),
         ),
         Expanded(

--- a/geulnamu_frontend/lib/screens/profile/profile_screen.dart
+++ b/geulnamu_frontend/lib/screens/profile/profile_screen.dart
@@ -80,6 +80,7 @@ class _ProfileScreenState extends State<ProfileScreen>
     return MainLayoutHelpers.sub(
       title: isEditMode ? '프로필 편집' : '프로필',
       body: _buildBody(),
+      showProfileMenu: false, // 프로필 페이지에서는 사용자 메뉴 숨김
       // 🎯 편집 모드에 따른 액션 버튼들
       actions: _buildAppBarActions(),
       // 🎯 하단 액션 버튼 (편집 모드에서만)

--- a/geulnamu_frontend/lib/screens/settings_screen.dart
+++ b/geulnamu_frontend/lib/screens/settings_screen.dart
@@ -1,0 +1,231 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/services/settings_service.dart';
+import '../../providers/theme_provider.dart';
+import '../../widgets/common/main_layout.dart';
+import '../../widgets/common/settings_widgets.dart';
+
+/// 설정 화면
+/// 테마 설정, 알림 설정 등 앱 설정 관리
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  final SettingsService _settingsService = SettingsService();
+  
+  // 상태 변수
+  bool _meetingNotificationEnabled = true;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  /// 모든 설정 로드
+  Future<void> _loadSettings() async {
+    if (!mounted) return;
+    
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // 모임 알림 설정 로드
+      _meetingNotificationEnabled = await _settingsService.getMeetingNotification();
+      
+      if (mounted) {
+        setState(() {});
+      }
+      
+      debugPrint('✅ [SettingsScreen] 설정 로드 완료');
+      debugPrint('   모임 알림: $_meetingNotificationEnabled');
+    } catch (e) {
+      debugPrint('❌ [SettingsScreen] 설정 로드 실패: $e');
+      if (mounted) {
+        _showErrorSnackBar('설정을 불러오는데 실패했습니다.');
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  /// 테마 모드 변경 처리
+  Future<void> _handleThemeChange(ThemeMode newThemeMode) async {
+    debugPrint('🎨 [SettingsScreen] 테마 변경 요청: $newThemeMode');
+    
+    try {
+      final themeProvider = Provider.of<ThemeProvider>(context, listen: false);
+      await themeProvider.setThemeMode(newThemeMode);
+      
+      if (mounted) {
+        _showSuccessSnackBar('테마가 변경되었습니다.');
+      }
+    } catch (e) {
+      debugPrint('❌ [SettingsScreen] 테마 변경 실패: $e');
+      if (mounted) {
+        _showErrorSnackBar('테마 변경에 실패했습니다.');
+      }
+    }
+  }
+
+  /// 모임 알림 설정 변경 처리
+  Future<void> _handleNotificationChange(bool enabled) async {
+    debugPrint('🔔 [SettingsScreen] 알림 설정 변경 요청: $enabled');
+    
+    // 즉시 UI 업데이트 (낙관적 업데이트)
+    if (mounted) {
+      setState(() {
+        _meetingNotificationEnabled = enabled;
+      });
+    }
+
+    try {
+      final success = await _settingsService.setMeetingNotification(enabled);
+      
+      if (success) {
+        if (mounted) {
+          _showSuccessSnackBar(enabled ? '모임 알림이 켜졌습니다.' : '모임 알림이 꺼졌습니다.');
+        }
+      } else {
+        // 저장 실패 시 이전 상태로 복원
+        if (mounted) {
+          setState(() {
+            _meetingNotificationEnabled = !enabled;
+          });
+          _showErrorSnackBar('알림 설정 저장에 실패했습니다.');
+        }
+      }
+    } catch (e) {
+      debugPrint('❌ [SettingsScreen] 알림 설정 변경 실패: $e');
+      
+      // 에러 발생 시 이전 상태로 복원
+      if (mounted) {
+        setState(() {
+          _meetingNotificationEnabled = !enabled;
+        });
+        _showErrorSnackBar('알림 설정 변경에 실패했습니다.');
+      }
+    }
+  }
+
+  /// 뒤로가기 처리
+  void _handleBackPressed() {
+    debugPrint('🔙 [SettingsScreen] 설정 화면 나가기');
+    Navigator.of(context).pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ThemeProvider>(
+      builder: (context, themeProvider, child) {
+        return MainLayout(
+          title: '설정',
+          isHomePage: false, // 뒤로가기 버튼 표시
+          onBackPressed: _handleBackPressed,
+          body: _isLoading 
+              ? SettingsWidgets.buildLoadingIndicator(context)
+              : _buildSettingsContent(context, themeProvider),
+        );
+      },
+    );
+  }
+
+  /// 설정 콘텐츠 빌드
+  Widget _buildSettingsContent(BuildContext context, ThemeProvider themeProvider) {
+    return SingleChildScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 🎨 외관 설정 섹션
+          SettingsWidgets.buildSectionHeader(
+            context,
+            title: '외관',
+            icon: Icons.palette_outlined,
+          ),
+          SettingsWidgets.buildThemeSelector(
+            context,
+            currentTheme: themeProvider.themeMode,
+            onThemeChanged: _handleThemeChange,
+            getThemeDisplayName: themeProvider.getThemeModeDisplayName,
+          ),
+          
+          // 🔔 알림 설정 섹션
+          SettingsWidgets.buildSectionHeader(
+            context,
+            title: '알림',
+            icon: Icons.notifications_outlined,
+          ),
+          SettingsWidgets.buildNotificationSwitch(
+            context,
+            enabled: _meetingNotificationEnabled,
+            onChanged: _handleNotificationChange,
+          ),
+          
+          // 설정 완료 안내
+          const SizedBox(height: 24),
+          SettingsWidgets.buildCompletionCard(context),
+          
+          // 하단 여백
+          const SizedBox(height: 32),
+        ],
+      ),
+    );
+  }
+
+  /// 성공 스낵바 표시
+  void _showSuccessSnackBar(String message) {
+    if (!mounted) return;
+    
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            const Icon(
+              Icons.check_circle,
+              color: Colors.white,
+              size: 20,
+            ),
+            const SizedBox(width: 12),
+            Expanded(child: Text(message)),
+          ],
+        ),
+        backgroundColor: Theme.of(context).colorScheme.primary, // 🎨 글나무 민트색 사용
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  /// 에러 스낵바 표시
+  void _showErrorSnackBar(String message) {
+    if (!mounted) return;
+    
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            const Icon(
+              Icons.error,
+              color: Colors.white,
+              size: 20,
+            ),
+            const SizedBox(width: 12),
+            Expanded(child: Text(message)),
+          ],
+        ),
+        backgroundColor: Theme.of(context).colorScheme.error, // 🎨 테마 에러 색상 사용
+        duration: const Duration(seconds: 3),
+      ),
+    );
+  }
+}

--- a/geulnamu_frontend/lib/screens/settings_screen.dart
+++ b/geulnamu_frontend/lib/screens/settings_screen.dart
@@ -131,6 +131,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
         return MainLayout(
           title: '설정',
           isHomePage: false, // 뒤로가기 버튼 표시
+          showProfileMenu: false, // 설정 페이지에서는 사용자 메뉴 숨김
           onBackPressed: _handleBackPressed,
           body: _isLoading 
               ? SettingsWidgets.buildLoadingIndicator(context)

--- a/geulnamu_frontend/lib/services/home/home_service.dart
+++ b/geulnamu_frontend/lib/services/home/home_service.dart
@@ -53,7 +53,7 @@ class HomeService {
         Navigator.pushNamed(context, '/profile'); // 프로필 화면으로 이동
         break;
       case 'settings':
-        _showSnackBar(context, '설정 기능은 개발 중입니다.');
+        Navigator.pushNamed(context, '/settings');
         break;
       case 'logout':
         await handleLogout(context, authProvider);
@@ -252,7 +252,7 @@ class HomeService {
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),
-        backgroundColor: Theme.of(context).colorScheme.inverseSurface,
+        backgroundColor: Theme.of(context).colorScheme.primary, // 🎨 글나무 민트색
       ),
     );
   }

--- a/geulnamu_frontend/lib/widgets/common/app_header.dart
+++ b/geulnamu_frontend/lib/widgets/common/app_header.dart
@@ -57,7 +57,7 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
       
       // 🏷️ 제목 또는 로고
       title: _buildTitleWidget(context),
-      centerTitle: title != null, // 제목이 있으면 가운데 정렬
+      centerTitle: true, // 항상 가운데 정렬 (제목과 로고 모두)
       
       // ⚙️ 액션 버튼들 + 사용자 메뉴
       actions: _buildActions(context),
@@ -141,6 +141,7 @@ class AppHeader extends StatelessWidget implements PreferredSizeWidget {
             '로그인',
             style: context.textStyles.bodyMedium?.copyWith(
               fontWeight: FontWeight.w600,
+              color: context.colors.onPrimary, // 한 색상 명시적 지정
             ),
           ),
           style: TextButton.styleFrom(

--- a/geulnamu_frontend/lib/widgets/common/main_layout.dart
+++ b/geulnamu_frontend/lib/widgets/common/main_layout.dart
@@ -285,10 +285,7 @@ class MainLayout extends StatelessWidget {
         Navigator.pushNamed(context, '/profile');
         break;
       case 'settings':
-        // TODO: 설정 화면 구현 후 연결
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('설정 화면은 준비 중입니다.')),
-        );
+        Navigator.pushNamed(context, '/settings');
         break;
       case 'help':
         // TODO: 도움말 화면 구현 후 연결

--- a/geulnamu_frontend/lib/widgets/common/main_layout.dart
+++ b/geulnamu_frontend/lib/widgets/common/main_layout.dart
@@ -36,6 +36,9 @@ class MainLayout extends StatelessWidget {
   /// 사용자 메뉴 위젯 (null이면 기본 프로필 메뉴 사용)
   final Widget? customProfileWidget;
   
+  /// 사용자 메뉴 표시 여부 (기본: true)
+  final bool showProfileMenu;
+  
   /// 로고 클릭 핸들러 (홈으로 이동 등)
   final VoidCallback? onLogoTap;
   
@@ -60,6 +63,7 @@ class MainLayout extends StatelessWidget {
     this.floatingActionButton,
     this.bottomNavigationBar,
     this.customProfileWidget,
+    this.showProfileMenu = true, // 기본값: true
     this.onLogoTap,
     this.onMenuTap,
     this.onLoginTap,
@@ -82,8 +86,8 @@ class MainLayout extends StatelessWidget {
             // 🔐 로그인 상태별 처리
             showLoginButton: !authProvider.isAuthenticated,
             onLoginPressed: authProvider.isAuthenticated ? null : onLoginTap,
-            // 👤 사용자 메뉴 (로그인 시에만)
-            profileWidget: authProvider.isAuthenticated 
+            // 👤 사용자 메뉴 (로그인 시에만 + showProfileMenu가 true일 때만)
+            profileWidget: authProvider.isAuthenticated && showProfileMenu
                 ? (customProfileWidget ?? _buildDefaultProfileMenu(context, authProvider))
                 : null,
             // 🏠 로고 클릭으로 홈 이동
@@ -317,6 +321,7 @@ class MainLayoutHelpers {
     Widget? floatingActionButton,
     Widget? bottomNavigationBar,
     Widget? customProfileWidget,
+    bool showProfileMenu = true, // 기본값: true
     VoidCallback? onLogoTap,
     Function(String)? onMenuTap,
     VoidCallback? onLoginTap,
@@ -330,6 +335,7 @@ class MainLayoutHelpers {
       floatingActionButton: floatingActionButton,
       bottomNavigationBar: bottomNavigationBar,
       customProfileWidget: customProfileWidget,
+      showProfileMenu: showProfileMenu, // 사용자 메뉴 표시 여부
       onLogoTap: onLogoTap,
       onMenuTap: onMenuTap,
       onLoginTap: onLoginTap,
@@ -345,6 +351,7 @@ class MainLayoutHelpers {
     Widget? floatingActionButton,
     Widget? bottomNavigationBar,
     Widget? customProfileWidget,
+    bool showProfileMenu = true, // 기본값: true
     VoidCallback? onLogoTap,
     Function(String)? onMenuTap,
     VoidCallback? onLoginTap,
@@ -359,6 +366,7 @@ class MainLayoutHelpers {
       floatingActionButton: floatingActionButton,
       bottomNavigationBar: bottomNavigationBar,
       customProfileWidget: customProfileWidget,
+      showProfileMenu: showProfileMenu, // 사용자 메뉴 표시 여부
       onLogoTap: onLogoTap,
       onMenuTap: onMenuTap,
       onLoginTap: onLoginTap,

--- a/geulnamu_frontend/lib/widgets/common/settings_widgets.dart
+++ b/geulnamu_frontend/lib/widgets/common/settings_widgets.dart
@@ -1,0 +1,367 @@
+import 'package:flutter/material.dart';
+
+/// 설정 화면 UI 위젯들
+/// Static Methods 패턴으로 재사용 가능한 위젯들 제공
+class SettingsWidgets {
+  
+  /// 섹션 헤더 위젯
+  static Widget buildSectionHeader(
+    BuildContext context, {
+    required String title,
+    required IconData icon,
+  }) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 12),
+      child: Row(
+        children: [
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Icon(
+              icon,
+              size: 18,
+              color: Theme.of(context).colorScheme.primary,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Text(
+            title,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: Theme.of(context).colorScheme.onBackground,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 테마 모드 선택 카드
+  static Widget buildThemeSelector(
+    BuildContext context, {
+    required ThemeMode currentTheme,
+    required Function(ThemeMode) onThemeChanged,
+    required String Function(ThemeMode) getThemeDisplayName,
+  }) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(
+                  Icons.palette_outlined,
+                  size: 20,
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '테마 모드',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Column(
+              children: [
+                _buildThemeOption(
+                  context,
+                  title: '라이트',
+                  subtitle: '밝은 테마',
+                  themeMode: ThemeMode.light,
+                  currentTheme: currentTheme,
+                  onChanged: onThemeChanged,
+                  icon: Icons.wb_sunny_outlined,
+                ),
+                _buildThemeOption(
+                  context,
+                  title: '다크',
+                  subtitle: '어두운 테마',
+                  themeMode: ThemeMode.dark,
+                  currentTheme: currentTheme,
+                  onChanged: onThemeChanged,
+                  icon: Icons.nightlight_outlined,
+                ),
+                _buildThemeOption(
+                  context,
+                  title: '시스템 설정',
+                  subtitle: '기기 설정에 따라 자동',
+                  themeMode: ThemeMode.system,
+                  currentTheme: currentTheme,
+                  onChanged: onThemeChanged,
+                  icon: Icons.smartphone_outlined,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 테마 옵션 라디오 버튼
+  static Widget _buildThemeOption(
+    BuildContext context, {
+    required String title,
+    required String subtitle,
+    required ThemeMode themeMode,
+    required ThemeMode currentTheme,
+    required Function(ThemeMode) onChanged,
+    required IconData icon,
+  }) {
+    final isSelected = currentTheme == themeMode;
+    
+    return InkWell(
+      onTap: () => onChanged(themeMode),
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 8),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: 20,
+              color: isSelected 
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
+                      color: isSelected 
+                          ? Theme.of(context).colorScheme.primary
+                          : Theme.of(context).colorScheme.onSurface,
+                    ),
+                  ),
+                  Text(
+                    subtitle,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Radio<ThemeMode>(
+              value: themeMode,
+              groupValue: currentTheme,
+              onChanged: (value) {
+                if (value != null) {
+                  onChanged(value);
+                }
+              },
+              activeColor: Theme.of(context).colorScheme.primary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 알림 설정 스위치 카드
+  static Widget buildNotificationSwitch(
+    BuildContext context, {
+    required bool enabled,
+    required Function(bool) onChanged,
+  }) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: enabled 
+                    ? Theme.of(context).colorScheme.primary.withOpacity(0.1)
+                    : Theme.of(context).colorScheme.onSurfaceVariant.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(
+                enabled ? Icons.notifications_active : Icons.notifications_off,
+                size: 20,
+                color: enabled 
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    '모임 알림',
+                    style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    enabled ? '모임 관련 알림을 받습니다' : '모임 관련 알림을 받지 않습니다',
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Switch(
+              value: enabled,
+              onChanged: onChanged,
+              activeColor: Theme.of(context).colorScheme.primary,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 설정 완료 메시지 카드
+  static Widget buildCompletionCard(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.all(16),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            Container(
+              width: 64,
+              height: 64,
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.primary.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(32),
+              ),
+              child: Icon(
+                Icons.settings_outlined,
+                size: 32,
+                color: Theme.of(context).colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '설정 완료',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '설정이 자동으로 저장됩니다.\n변경된 설정은 즉시 적용됩니다.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 로딩 인디케이터
+  static Widget buildLoadingIndicator(BuildContext context) {
+    return const Center(
+      child: Padding(
+        padding: EdgeInsets.all(32),
+        child: CircularProgressIndicator(),
+      ),
+    );
+  }
+
+  /// 에러 상태 위젯
+  static Widget buildErrorState(
+    BuildContext context, {
+    required String message,
+    VoidCallback? onRetry,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '오류 발생',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 16),
+              ElevatedButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 시도'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 설정 항목이 없는 상태 (향후 확장용)
+  static Widget buildEmptyState(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.settings_outlined,
+              size: 64,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '설정 항목 없음',
+              style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '현재 설정할 수 있는 항목이 없습니다.',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# 변경 내역
## 설정 페이지
### 페이지 구현
- 설정 기능: 테마 적용, 알림 적용

## 소개 페이지, 메인 페이지
### 디자인 수정
- 소개 페이지: '독서벙' 항목 폰트 색 변경: 어둡게 (가독성 & 시인성 향상)
- (로그인 전) 메인 페이지: 사용자 메뉴 '로그인' 폰트 색 변경: 어두운 색으로 통일감 있게

## 프로필 페이지, 설정 페이지
### 디자인 수정
- 사용자 메뉴 안 보이도록 수정