### PR TITLE
[Feat/FE] member list page

### DIFF
--- a/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/util/EnumOrderUtil.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/util/EnumOrderUtil.java
@@ -1,0 +1,26 @@
+package com.geulnamu.infrastructure.util;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.EnumPath;
+import com.querydsl.core.types.dsl.Expressions;
+
+public class EnumOrderUtil {
+
+    public static <T extends Enum<T>> OrderSpecifier<Integer> createEnumOrder(
+        EnumPath<T> enumPath, Class<T> enumClass, boolean isAsc) {
+
+        var caseBuilder = Expressions.cases();
+        T[] enumValues = enumClass.getEnumConstants();
+
+        var result = caseBuilder.when(enumPath.eq(enumValues[0]))
+            .then(isAsc ? 1 : enumValues.length);
+
+        for(int i = 0; i < enumValues.length; i++) {
+            int orderValue = isAsc ? (i + 1) : (enumValues.length - i);
+            result = result.when(enumPath.eq(enumValues[i])).then(orderValue);
+        }
+
+        return result.otherwise(isAsc ? 99 : 0).asc();
+    }
+
+}

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/actionHistory/ActionHistoryQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/actionHistory/ActionHistoryQueryRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ActionHistoryQueryRepositoryImpl implements ActionHistoryQueryRepos
     public Page<ActionHistoryResponse> findActionHistoriesWithPaging(ActionHistoryListRequest request) {
         Pageable pageable = request.toPageable();
 
-        List<Long> count = queryFactory
+        final Long totalCount = queryFactory
             .select(actionHistory.count())
             .from(actionHistory)
             .where(
@@ -39,7 +39,7 @@ public class ActionHistoryQueryRepositoryImpl implements ActionHistoryQueryRepos
                 filterByActionDomain(request.getActionDomain()),
                 filterByApiMethod(request.getApiMethod())
             )
-            .fetch();
+            .fetchOne();
 
         List<ActionHistoryResponse> content = queryFactory
             .select(Projections.constructor(ActionHistoryResponse.class,
@@ -63,7 +63,7 @@ public class ActionHistoryQueryRepositoryImpl implements ActionHistoryQueryRepos
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::size);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount != null ? totalCount : 0L);
     }
 
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -50,7 +50,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     public Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId) {
         Pageable pageable = request.toPageable();
 
-        List<Long> count = queryFactory
+        final Long totalCount = queryFactory
             .select(meeting.count())
             .from(meeting)
             .leftJoin(attendance).on(meeting.id.eq(attendance.meeting.id)
@@ -60,7 +60,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
                 filterByMemberId(request.getMeetingCreatorId()),
                 filterByAttendanceStatus(request.getAttendanceStatus())
             )
-            .fetch();
+            .fetchOne();
 
         List<MeetingInfoResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoResponse.class,
@@ -82,7 +82,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::size);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount != null ? totalCount : 0L);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     public Page<MeetingInfoForStaffResponse> findMeetingsForAdminWithPaging(MeetingListRequest request) {
         Pageable pageable = request.toPageable();
 
-        List<Long> count = queryFactory
+        final Long totalCount = queryFactory
             .select(meeting.count())
             .from(meeting)
             .where(
@@ -118,7 +118,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
                 filterByMemberId(request.getMeetingCreatorId()),
                 filterByIsPrivateOrNot(request.getIsPrivate())
             )
-            .fetch();
+            .fetchOne();
 
         List<MeetingInfoForStaffResponse> content = queryFactory
             .select(Projections.constructor(MeetingInfoForStaffResponse.class,
@@ -139,7 +139,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::size);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount != null ? totalCount : 0L);
     }
 
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/member/MemberQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/member/MemberQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.geulnamu.controller.member.dto.response.MemberInfoResponse;
 import com.geulnamu.domain.member.Gender;
 import com.geulnamu.domain.member.QMember;
 import com.geulnamu.domain.shared.enums.Role;
+import com.geulnamu.infrastructure.util.EnumOrderUtil;
 import com.geulnamu.infrastructure.util.QueryDslUtil;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -30,13 +31,13 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
     public Page<MemberInfoResponse> findMembersWithPaging(MemberListRequest request) {
         Pageable pageable = request.toPageable();
 
-        List<Long> count = queryFactory
+        final Long totalCount = queryFactory
             .select(member.count())
             .from(member)
             .where(filterByGender(request.getGender()),
                 filterByRole(request.getRole()),
                 filterByIsDeleted(request.getIsDeleted()))
-            .fetch();
+            .fetchOne();
 
         List<MemberInfoResponse> content = queryFactory
             .select(Projections.constructor(MemberInfoResponse.class,
@@ -51,12 +52,12 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::size);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount != null ? totalCount : 0L);
     }
 
 
     BooleanExpression filterByGender(Gender gender) {
-        if(gender == null) return member.gender.isNotNull();
+        if(gender == null) return null;
         else if(gender.equals(Gender.MALE)) return member.gender.eq(Gender.MALE);
         else return member.gender.eq(Gender.FEMALE);
     }
@@ -75,7 +76,7 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
 
     BooleanExpression filterByIsDeleted(Boolean isDeleted) {
         if(isDeleted == null) {
-            return member.deletedAt.isNull().or(member.deletedAt.isNotNull());
+            return null;
         } else if(isDeleted) {
             return member.deletedAt.isNotNull();
         } else {
@@ -88,7 +89,12 @@ public class MemberQueryRepositoryImpl implements MemberQueryRepositoryCustom {
         if(sortBy == null) return QueryDslUtil.getSortedColumn(Order.ASC, member, "name");
         if(isAsc == null) isAsc = false;
 
-        return (isAsc) ? QueryDslUtil.getSortedColumn(Order.ASC, member, sortBy)
-            : QueryDslUtil.getSortedColumn(Order.DESC, member, sortBy);
+        if(sortBy.equals("role")) {
+            return EnumOrderUtil.createEnumOrder(member.role, Role.class, isAsc);
+        } else {
+            return (isAsc) ? QueryDslUtil.getSortedColumn(Order.ASC, member, sortBy)
+                : QueryDslUtil.getSortedColumn(Order.DESC, member, sortBy);
+        }
+
     }
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/voc/VoCQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/voc/VoCQueryRepositoryImpl.java
@@ -30,12 +30,12 @@ public class VoCQueryRepositoryImpl implements VoCQueryRepositoryCustom {
     public Page<VoCViewResponse> findVoCIssuesWithPaging(VoCViewListRequest request) {
         Pageable pageable = request.toPageable();
 
-        List<Long> count = queryFactory
+        final Long totalCount = queryFactory
             .select(voC.count())
             .from(voC)
             .where(filterByIssueStatus(request.getIssueStatus()),
                 filterByVoCType(request.getVoCType()))
-            .fetch();
+            .fetchOne();
 
         List<VoCViewResponse> content = queryFactory
             .select(Projections.constructor(VoCViewResponse.class,
@@ -51,7 +51,7 @@ public class VoCQueryRepositoryImpl implements VoCQueryRepositoryCustom {
             .limit(pageable.getPageSize())
             .fetch();
 
-        return PageableExecutionUtils.getPage(content, pageable, count::size);
+        return PageableExecutionUtils.getPage(content, pageable, () -> totalCount != null ? totalCount : 0L);
     }
 
 

--- a/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
@@ -532,7 +532,7 @@ Host: docs.api.com
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Mon, 12 Jan 2026 09:38:12 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 01:39:48 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -697,7 +697,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Mon, 12 Jan 2026 09:38:12 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 01:39:48 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
@@ -1165,21 +1165,21 @@ Content-Type: application/json;charset=UTF-8
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberList[].name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberList[].gender</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.memberList[].birthDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생년월일</p></td>
 </tr>

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/member/MemberControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/member/MemberControllerTest.java
@@ -255,9 +255,9 @@ public class MemberControllerTest extends ControllerTest {
                     fieldWithPath("data.pagingResponse.totalElements").type(JsonFieldType.NUMBER).description("전체 데이터 수"),
                     fieldWithPath("data.memberList[]").type(JsonFieldType.ARRAY).description("데이터 정보"),
                     fieldWithPath("data.memberList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
-                    fieldWithPath("data.memberList[].name").type(JsonFieldType.STRING).description("이름"),
-                    fieldWithPath("data.memberList[].gender").type(JsonFieldType.STRING).description("성별"),
-                    fieldWithPath("data.memberList[].birthDate").type(JsonFieldType.STRING).description("생년월일"),
+                    fieldWithPath("data.memberList[].name").type(JsonFieldType.STRING).description("이름").optional(),
+                    fieldWithPath("data.memberList[].gender").type(JsonFieldType.STRING).description("성별").optional(),
+                    fieldWithPath("data.memberList[].birthDate").type(JsonFieldType.STRING).description("생년월일").optional(),
                     fieldWithPath("data.memberList[].nickname").type(JsonFieldType.STRING).description("닉네임(카카오 닉네임)"),
                     fieldWithPath("data.memberList[].role").type(JsonFieldType.STRING).description("권한 등급"),
                     fieldWithPath("data.memberList[].deletedAt").type(JsonFieldType.STRING).optional().description("삭제일자 (삭제되지 않은 경우 null)")

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -18,6 +18,7 @@ import 'screens/auth/login_screen.dart';
 import 'screens/home/home_screen.dart';
 import 'screens/profile/profile_screen.dart';
 import 'screens/introduction/introduction_screen.dart'; // 글나무 소개 화면
+import 'screens/member/member_list_screen.dart'; // 모임원 목록 화면
 import 'screens/settings_screen.dart'; // 설정 화면
 import 'services/home/home_route_service.dart'; // 🎯 RouteObserver import
 
@@ -101,6 +102,7 @@ class _GeulnamuAppState extends State<GeulnamuApp> {
           '/home': (context) => const HomeScreen(),
           '/profile': (context) => const ProfileScreen(), // 프로필 화면
           '/introduction': (context) => const IntroductionScreen(), // 글나무 소개 화면
+          '/member-list': (context) => const MemberListScreen(), // 모임원 목록 화면
           '/settings': (context) => const SettingsScreen(), // 설정 화면
         },
 

--- a/geulnamu_frontend/lib/models/member/member_list_model.dart
+++ b/geulnamu_frontend/lib/models/member/member_list_model.dart
@@ -187,10 +187,10 @@ class MemberListFilter {
     this.gender,
     this.role,
     this.isDeleted,
-    this.sortBy = 'role', // 기본값: 권한순
-    this.isAsc = false, // 기본값: 내림차순 (높은 권한부터)
+    this.sortBy = 'id', // 기본값: ID순으로 변경
+    this.isAsc = false, // 기본값: 내림차순 (높은 ID부터)
     this.page = 1,
-    this.size = 20,
+    this.size = 10, // 페이지 크기 10명으로 변경
   });
 
   /// 쿼리 파라미터로 변환
@@ -264,7 +264,7 @@ enum SortOption {
   static SortOption fromValue(String value) {
     return values.firstWhere(
       (option) => option.value == value,
-      orElse: () => SortOption.role,
+      orElse: () => SortOption.id, // 기본값을 ID순으로 변경
     );
   }
 }
@@ -311,8 +311,8 @@ enum RoleOption {
   }
 
   /// 해당 권한이 항상 활성 계정만 보여야 하는지 확인
-  /// 준운영진, 운영진은 비활성 필터 옵션 제공 안함
+  /// 이 옵션은 사용하지 않음 (모든 권한에 대해 계정 상태 선택 가능)
   bool get forceActiveOnly {
-    return this == RoleOption.viceStaff || this == RoleOption.staff;
+    return false; // 모든 권한에 대해 계정 상태 선택 가능도록 수정
   }
 }

--- a/geulnamu_frontend/lib/models/member/member_list_model.dart
+++ b/geulnamu_frontend/lib/models/member/member_list_model.dart
@@ -310,9 +310,10 @@ enum RoleOption {
     );
   }
 
-  /// 해당 권한이 항상 활성 계정만 보여야 하는지 확인
-  /// 이 옵션은 사용하지 않음 (모든 권한에 대해 계정 상태 선택 가능)
+  /// 해당 권한이 비활성 계정 필터를 사용할 수 있는지 확인
+  /// 더 이상 사용하지 않음 - MemberService.canUseDeletedFilter() 사용
+  @Deprecated('더 이상 사용하지 않음. MemberService.canUseDeletedFilter() 사용하세요.')
   bool get forceActiveOnly {
-    return false; // 모든 권한에 대해 계정 상태 선택 가능도록 수정
+    return false;
   }
 }

--- a/geulnamu_frontend/lib/models/member/member_list_model.dart
+++ b/geulnamu_frontend/lib/models/member/member_list_model.dart
@@ -1,0 +1,318 @@
+/// 모임원 목록 조회 응답 모델
+///
+/// 백엔드 API 응답과 매핑되는 모임원 목록 데이터
+class MemberListResponse {
+  final PagingResponse pagingResponse;
+  final List<MemberListItem> memberList;
+
+  const MemberListResponse({
+    required this.pagingResponse,
+    required this.memberList,
+  });
+
+  /// 백엔드 API 응답에서 MemberListResponse 생성
+  factory MemberListResponse.fromJson(Map<String, dynamic> json) {
+    return MemberListResponse(
+      pagingResponse: PagingResponse.fromJson(json['pagingResponse']),
+      memberList: (json['memberList'] as List)
+          .map((item) => MemberListItem.fromJson(item))
+          .toList(),
+    );
+  }
+}
+
+/// 페이지네이션 정보 모델
+class PagingResponse {
+  final int pageNumber;
+  final int totalPages;
+  final int totalElements;
+
+  const PagingResponse({
+    required this.pageNumber,
+    required this.totalPages,
+    required this.totalElements,
+  });
+
+  factory PagingResponse.fromJson(Map<String, dynamic> json) {
+    return PagingResponse(
+      pageNumber: json['pageNumber'] as int,
+      totalPages: json['totalPages'] as int,
+      totalElements: json['totalElements'] as int,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'PagingResponse(pageNumber: $pageNumber, totalPages: $totalPages, totalElements: $totalElements)';
+  }
+}
+
+/// 모임원 목록 아이템 모델
+class MemberListItem {
+  final int memberId;
+  final String? name; // null 허용 - 이름 미입력
+  final String? gender; // null 허용 - 성별 미선택
+  final String? birthDate; // null 허용 - 생년월일 미입력
+  final String nickname;
+  final String role;
+  final String? deletedAt; // null이면 활성 계정
+
+  const MemberListItem({
+    required this.memberId,
+    this.name,
+    this.gender,
+    this.birthDate,
+    required this.nickname,
+    required this.role,
+    this.deletedAt,
+  });
+
+  /// 백엔드 API 응답에서 MemberListItem 생성
+  factory MemberListItem.fromJson(Map<String, dynamic> json) {
+    return MemberListItem(
+      memberId: json['memberId'] as int,
+      name: json['name'] as String?,
+      gender: json['gender'] as String?,
+      birthDate: json['birthDate'] as String?,
+      nickname: json['nickname'] as String,
+      role: json['role'] as String,
+      deletedAt: json['deletedAt'] as String?,
+    );
+  }
+
+  /// 계정이 활성화되어 있는지 확인
+  bool get isActive => deletedAt == null;
+
+  /// 성별 한국어 표시
+  String get genderDisplayName {
+    if (gender == null) return '미선택';
+
+    switch (gender!) {
+      case 'MALE':
+        return '남성';
+      case 'FEMALE':
+        return '여성';
+      default:
+        return '미설정';
+    }
+  }
+
+  /// 권한 한국어 표시
+  String get roleDisplayName {
+    switch (role) {
+      case 'LEADER':
+        return '모임장';
+      case 'VICE_LEADER':
+        return '부모임장';
+      case 'ADMIN':
+        return '관리자';
+      case 'STAFF':
+        return '운영진';
+      case 'VICE_STAFF':
+        return '준운영진';
+      case 'MEMBER':
+        return '일반 회원';
+      default:
+        return '알 수 없음';
+    }
+  }
+
+  /// 표시용 이름 (빈 값 처리)
+  String get displayName {
+    if (name == null || name!.trim().isEmpty) {
+      return '이름 미입력';
+    }
+    return name!;
+  }
+
+  /// 표시용 생년월일 (간단 형식)
+  String get displayBirthDate {
+    if (birthDate == null) {
+      return '생년월일 미입력';
+    }
+    
+    // 2022-01-01 형식을 22.01.01 형식으로 변경
+    try {
+      final parts = birthDate!.split('-');
+      if (parts.length == 3) {
+        final year = parts[0].substring(2); // 2022 -> 22
+        final month = parts[1];
+        final day = parts[2];
+        return '$year.$month.$day';
+      }
+    } catch (e) {
+      // 파싱 실패 시 원본 반환
+    }
+    return birthDate!;
+  }
+
+  /// 권한 레벨 (정렬용)
+  int get roleLevel {
+    switch (role) {
+      case 'LEADER':
+        return 6;
+      case 'VICE_LEADER':
+        return 5;
+      case 'ADMIN':
+        return 4;
+      case 'STAFF':
+        return 3;
+      case 'VICE_STAFF':
+        return 2;
+      case 'MEMBER':
+        return 1;
+      default:
+        return 0;
+    }
+  }
+
+  @override
+  String toString() {
+    return 'MemberListItem(memberId: $memberId, name: $name, gender: $gender, '
+        'birthDate: $birthDate, nickname: $nickname, role: $role, deletedAt: $deletedAt)';
+  }
+}
+
+/// 모임원 목록 필터 옵션
+class MemberListFilter {
+  final String? gender; // null이면 전체
+  final String? role; // null이면 전체
+  final bool? isDeleted; // null이면 전체
+  final String sortBy; // 정렬 기준
+  final bool isAsc; // 오름차순 여부
+  final int page;
+  final int size;
+
+  const MemberListFilter({
+    this.gender,
+    this.role,
+    this.isDeleted,
+    this.sortBy = 'role', // 기본값: 권한순
+    this.isAsc = false, // 기본값: 내림차순 (높은 권한부터)
+    this.page = 1,
+    this.size = 20,
+  });
+
+  /// 쿼리 파라미터로 변환
+  Map<String, dynamic> toQueryParameters() {
+    final params = <String, dynamic>{
+      'page': page,
+      'size': size,
+      'sortBy': sortBy,
+      'isAsc': isAsc,
+    };
+
+    if (gender != null) {
+      params['gender'] = gender;
+    }
+    if (role != null) {
+      params['role'] = role;
+    }
+    if (isDeleted != null) {
+      params['isDeleted'] = isDeleted.toString();
+    }
+
+    return params;
+  }
+
+  /// 필터 복사 (일부 값 변경)
+  MemberListFilter copyWith({
+    String? gender,
+    String? role,
+    bool? isDeleted,
+    String? sortBy,
+    bool? isAsc,
+    int? page,
+    int? size,
+  }) {
+    return MemberListFilter(
+      gender: gender ?? this.gender,
+      role: role ?? this.role,
+      isDeleted: isDeleted ?? this.isDeleted,
+      sortBy: sortBy ?? this.sortBy,
+      isAsc: isAsc ?? this.isAsc,
+      page: page ?? this.page,
+      size: size ?? this.size,
+    );
+  }
+
+  /// 필터 초기화
+  MemberListFilter reset() {
+    return const MemberListFilter();
+  }
+
+  @override
+  String toString() {
+    return 'MemberListFilter(gender: $gender, role: $role, isDeleted: $isDeleted, '
+        'sortBy: $sortBy, isAsc: $isAsc, page: $page, size: $size)';
+  }
+}
+
+/// 정렬 옵션 열거형
+enum SortOption {
+  id('id', 'ID 순'),
+  role('role', '권한 순'),
+  name('name', '이름 순'),
+  gender('gender', '성별 순'),
+  birthDate('birthDate', '생년월일 순');
+
+  const SortOption(this.value, this.displayName);
+
+  final String value;
+  final String displayName;
+
+  static SortOption fromValue(String value) {
+    return values.firstWhere(
+      (option) => option.value == value,
+      orElse: () => SortOption.role,
+    );
+  }
+}
+
+/// 성별 옵션 열거형
+enum GenderOption {
+  all(null, '전체'),
+  male('MALE', '남성'),
+  female('FEMALE', '여성');
+
+  const GenderOption(this.value, this.displayName);
+
+  final String? value;
+  final String displayName;
+
+  static GenderOption fromValue(String? value) {
+    return values.firstWhere(
+      (option) => option.value == value,
+      orElse: () => GenderOption.all,
+    );
+  }
+}
+
+/// 권한 옵션 열거형
+enum RoleOption {
+  all(null, '전체'),
+  leader('LEADER', '모임장'),
+  viceLeader('VICE_LEADER', '부모임장'),
+  admin('ADMIN', '관리자'),
+  staff('STAFF', '운영진'),
+  viceStaff('VICE_STAFF', '준운영진'),
+  member('MEMBER', '일반 회원');
+
+  const RoleOption(this.value, this.displayName);
+
+  final String? value;
+  final String displayName;
+
+  static RoleOption fromValue(String? value) {
+    return values.firstWhere(
+      (option) => option.value == value,
+      orElse: () => RoleOption.all,
+    );
+  }
+
+  /// 해당 권한이 항상 활성 계정만 보여야 하는지 확인
+  /// 준운영진, 운영진은 비활성 필터 옵션 제공 안함
+  bool get forceActiveOnly {
+    return this == RoleOption.viceStaff || this == RoleOption.staff;
+  }
+}

--- a/geulnamu_frontend/lib/models/profile/profile_model.dart
+++ b/geulnamu_frontend/lib/models/profile/profile_model.dart
@@ -89,13 +89,13 @@ class ProfileModel {
     switch (role) {
       case 'LEADER':
         return '모임장';
-      case 'SUB_LEADER':
+      case 'VICE_LEADER':
         return '부모임장';
       case 'ADMIN':
         return '관리자';
       case 'STAFF':
         return '운영진';
-      case 'SUB_STAFF':
+      case 'VICE_STAFF':
         return '준운영진';
       case 'MEMBER':
         return '일반 회원';

--- a/geulnamu_frontend/lib/providers/auth_provider.dart
+++ b/geulnamu_frontend/lib/providers/auth_provider.dart
@@ -198,6 +198,47 @@ class AuthProvider with ChangeNotifier {
     return _userInfo?['profileImageUrl'];
   }
 
+  /// 사용자 권한 가져오기
+  String? get userRole {
+    return _userInfo?['role'];
+  }
+
+  /// 임원진 이상 권한 확인 (운영진, 준운영진, 관리자, 부모임장, 모임장)
+  bool get isStaffLevel {
+    if (userRole == null) return false;
+    const staffRoles = ['STAFF', 'VICE_STAFF', 'ADMIN', 'VICE_LEADER', 'LEADER'];
+    return staffRoles.contains(userRole);
+  }
+
+  /// 관리자급 이상 권한 확인 (관리자, 부모임장, 모임장)
+  bool get isAdminLevel {
+    if (userRole == null) return false;
+    const adminRoles = ['ADMIN', 'VICE_LEADER', 'LEADER'];
+    return adminRoles.contains(userRole);
+  }
+
+  /// 권한 레벨 표시명 가져오기
+  String get roleDisplayName {
+    if (userRole == null) return '알 수 없음';
+    
+    switch (userRole!) {
+      case 'LEADER':
+        return '모임장';
+      case 'VICE_LEADER':
+        return '부모임장';
+      case 'ADMIN':
+        return '관리자';
+      case 'STAFF':
+        return '운영진';
+      case 'VICE_STAFF':
+        return '준운영진';
+      case 'MEMBER':
+        return '일반 회원';
+      default:
+        return '알 수 없음';
+    }
+  }
+
   // Private methods
   void _setStatus(AuthStatus status) {
     _status = status;

--- a/geulnamu_frontend/lib/screens/member/member_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/member/member_list_screen.dart
@@ -4,6 +4,7 @@ import '../../providers/auth_provider.dart';
 import '../../widgets/common/main_layout.dart';
 import '../../core/theme.dart';
 import '../../models/member/member_list_model.dart';
+import '../../services/home/home_service.dart'; // 🎯 HomeService import 추가
 import 'mixins/member_logic_mixin.dart';
 import 'widgets/member_widgets.dart';
 
@@ -23,6 +24,8 @@ class MemberListScreen extends StatefulWidget {
 
 class _MemberListScreenState extends State<MemberListScreen> 
     with MemberLogicMixin {
+
+  final HomeService _homeService = HomeService(); // 🎯 HomeService 인스턴스 추가
 
   @override
   void initState() {
@@ -59,7 +62,10 @@ class _MemberListScreenState extends State<MemberListScreen>
   Widget build(BuildContext context) {
     return MainLayout(
       title: '모임원 목록',
-      isHomePage: false, // 서브 화면이므로 뒤로가기 버튼 표시
+      isHomePage: true, // 🎯 메인 기능이므로 사이드바 버튼 표시
+      // 🎯 HomeService를 통한 메뉴 및 로그아웃 처리
+      onMenuTap: (menu) => _homeService.handleMenuTap(context, menu),
+      onLogoutTap: () => _handleLogout(),
       body: Stack(
         children: [
           // 메인 콘텐츠
@@ -165,6 +171,12 @@ class _MemberListScreenState extends State<MemberListScreen>
         canShowDeletedFilter: canShowCurrentDeletedFilter,
       ),
     );
+  }
+
+  /// 로그아웃 처리 (HomeService 활용)
+  Future<void> _handleLogout() async {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    await _homeService.handleLogout(context, authProvider);
   }
 
   /// 모임원 카드 탭 처리

--- a/geulnamu_frontend/lib/screens/member/member_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/member/member_list_screen.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../widgets/common/main_layout.dart';
+import '../../core/theme.dart';
+import '../../models/member/member_list_model.dart';
+import 'mixins/member_logic_mixin.dart';
+import 'widgets/member_widgets.dart';
+
+/// 모임원 목록 화면
+/// 
+/// 임원진 이상 권한을 가진 사용자가 모임원 목록을 조회하고 관리할 수 있는 화면
+/// - 카드 리스트 방식으로 모임원 정보 표시
+/// - 플로팅 필터 버튼으로 필터링 및 정렬
+/// - 페이지네이션으로 목록 탐색
+/// - 비활성 계정은 음영 처리
+class MemberListScreen extends StatefulWidget {
+  const MemberListScreen({super.key});
+
+  @override
+  State<MemberListScreen> createState() => _MemberListScreenState();
+}
+
+class _MemberListScreenState extends State<MemberListScreen> 
+    with MemberLogicMixin {
+
+  @override
+  void initState() {
+    super.initState();
+    // 화면 로드 후 초기 데이터 로드
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _initializeScreen();
+    });
+  }
+
+  /// 화면 초기화
+  Future<void> _initializeScreen() async {
+    // 권한 확인
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    if (!authProvider.isStaffLevel) {
+      // 권한 없음 - 이전 화면으로 돌아가기
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('모임원 목록은 임원진 이상만 볼 수 있습니다.'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+      return;
+    }
+
+    // 초기 데이터 로드
+    await initializeMemberList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return MainLayout(
+      title: '모임원 목록',
+      isHomePage: false, // 서브 화면이므로 뒤로가기 버튼 표시
+      body: Stack(
+        children: [
+          // 메인 콘텐츠
+          _buildMainContent(),
+          
+          // 플로팅 필터 버튼
+          Positioned(
+            bottom: 16,
+            right: 16,
+            child: MemberWidgets.buildFilterFab(
+              context,
+              _showFilterBottomSheet,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 메인 콘텐츠 빌드
+  Widget _buildMainContent() {
+    // 로딩 상태
+    if (isLoading) {
+      return MemberWidgets.buildLoading(context);
+    }
+
+    // 에러 상태
+    if (errorMessage != null) {
+      return MemberWidgets.buildError(
+        context,
+        message: errorMessage!,
+        onRetry: refreshMemberList,
+      );
+    }
+
+    // 빈 목록
+    if (memberList.isEmpty) {
+      return MemberWidgets.buildEmptyList(context);
+    }
+
+    // 정상 목록
+    return Column(
+      children: [
+        // 목록 정보 헤더
+        MemberWidgets.buildListHeader(
+          context,
+          totalElements: totalElements,
+          currentFilter: currentFilter,
+        ),
+        
+        // 구분선
+        Divider(
+          height: 1,
+          color: context.colors.outline.withOpacity(0.2),
+        ),
+        
+        // 모임원 목록
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: refreshMemberList,
+            child: ListView.builder(
+              padding: const EdgeInsets.only(
+                top: 8,
+                bottom: 80, // FAB 공간 확보
+              ),
+              itemCount: memberList.length,
+              itemBuilder: (context, index) {
+                final member = memberList[index];
+                return MemberWidgets.buildMemberCard(
+                  context,
+                  member,
+                  onTap: () => _handleMemberTap(member),
+                );
+              },
+            ),
+          ),
+        ),
+        
+        // 페이지네이션
+        if (totalPages > 1)
+          MemberWidgets.buildPagination(
+            context,
+            currentPage: currentPage,
+            totalPages: totalPages,
+            onPageChanged: goToPage,
+          ),
+      ],
+    );
+  }
+
+  /// 필터 바텀시트 표시
+  void _showFilterBottomSheet() {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => MemberWidgets.buildFilterBottomSheet(
+        context,
+        currentFilter: currentFilter,
+        onFilterChanged: applyFilter,
+        canShowDeletedFilter: canShowCurrentDeletedFilter,
+      ),
+    );
+  }
+
+  /// 모임원 카드 탭 처리
+  void _handleMemberTap(MemberListItem member) {
+    // TODO: 향후 모임원 상세보기 기능 구현
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text('${member.displayName} 상세보기 (향후 구현 예정)'),
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+}

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -1,0 +1,268 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../core/config/app_config.dart';
+import '../../../providers/auth_provider.dart';
+import '../../../services/member/member_service.dart';
+import '../../../models/member/member_list_model.dart';
+
+/// 모임원 목록 화면 로직 Mixin
+/// 
+/// 모임원 목록 조회, 필터링, 정렬, 페이지네이션 등의 비즈니스 로직 담당
+mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
+  final MemberService _memberService = MemberService();
+
+  // 상태 변수들
+  bool _isLoading = false;
+  bool _isLoadingMore = false;
+  String? _errorMessage;
+  MemberListResponse? _memberListResponse;
+  MemberListFilter _currentFilter = const MemberListFilter();
+
+  // Getters
+  bool get isLoading => _isLoading;
+  bool get isLoadingMore => _isLoadingMore;
+  String? get errorMessage => _errorMessage;
+  List<MemberListItem> get memberList => _memberListResponse?.memberList ?? [];
+  PagingResponse? get pagingInfo => _memberListResponse?.pagingResponse;
+  MemberListFilter get currentFilter => _currentFilter;
+
+  // 페이지네이션 정보
+  bool get hasNextPage {
+    final paging = pagingInfo;
+    if (paging == null) return false;
+    return paging.pageNumber < paging.totalPages;
+  }
+
+  bool get hasPreviousPage {
+    final paging = pagingInfo;
+    if (paging == null) return false;
+    return paging.pageNumber > 1;
+  }
+
+  int get currentPage => pagingInfo?.pageNumber ?? 1;
+  int get totalPages => pagingInfo?.totalPages ?? 1;
+  int get totalElements => pagingInfo?.totalElements ?? 0;
+
+  /// 초기 데이터 로드
+  Future<void> initializeMemberList() async {
+    if (AppConfig.debugMode) {
+      print('🚀 [MemberLogicMixin] 모임원 목록 초기화 시작');
+    }
+
+    await loadMemberList(isInitial: true);
+  }
+
+  /// 모임원 목록 조회
+  /// 
+  /// [isInitial] 초기 로드 여부 (true면 첫 페이지부터)
+  /// [showLoading] 로딩 표시 여부
+  Future<void> loadMemberList({
+    bool isInitial = false,
+    bool showLoading = true,
+  }) async {
+    try {
+      if (showLoading) {
+        _setLoading(true);
+      }
+      _clearError();
+
+      // 초기 로드 시 첫 페이지로 설정
+      final filter = isInitial 
+          ? _currentFilter.copyWith(page: 1)
+          : _currentFilter;
+
+      final accessToken = await _getAccessToken();
+      if (accessToken == null) {
+        throw Exception('인증 토큰을 가져올 수 없습니다.');
+      }
+
+      final response = await _memberService.getMemberList(
+        filter: filter,
+        accessToken: accessToken,
+      );
+
+      _memberListResponse = response;
+      _currentFilter = filter;
+
+      if (AppConfig.debugMode) {
+        print('✅ [MemberLogicMixin] 모임원 목록 조회 성공: ${response.memberList.length}명');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MemberLogicMixin] 모임원 목록 조회 실패: $e');
+      }
+      _setError(_getErrorMessage(e));
+    } finally {
+      if (showLoading) {
+        _setLoading(false);
+      }
+    }
+  }
+
+  /// 필터 적용
+  /// 
+  /// [newFilter] 새로운 필터 설정
+  Future<void> applyFilter(MemberListFilter newFilter) async {
+    if (AppConfig.debugMode) {
+      print('🔍 [MemberLogicMixin] 필터 적용: $newFilter');
+    }
+
+    // 필터 변경 시 첫 페이지로 이동
+    final filterWithFirstPage = newFilter.copyWith(page: 1);
+    _currentFilter = filterWithFirstPage;
+
+    await loadMemberList();
+  }
+
+  /// 특정 페이지로 이동
+  /// 
+  /// [page] 이동할 페이지 번호
+  Future<void> goToPage(int page) async {
+    if (page < 1 || page > totalPages) {
+      if (AppConfig.debugMode) {
+        print('⚠️ [MemberLogicMixin] 잘못된 페이지: $page (총 ${totalPages}페이지)');
+      }
+      return;
+    }
+
+    if (AppConfig.debugMode) {
+      print('📄 [MemberLogicMixin] 페이지 이동: $page');
+    }
+
+    _currentFilter = _currentFilter.copyWith(page: page);
+    await loadMemberList();
+  }
+
+  /// 다음 페이지로 이동
+  Future<void> goToNextPage() async {
+    if (hasNextPage) {
+      await goToPage(currentPage + 1);
+    }
+  }
+
+  /// 이전 페이지로 이동
+  Future<void> goToPreviousPage() async {
+    if (hasPreviousPage) {
+      await goToPage(currentPage - 1);
+    }
+  }
+
+  /// 첫 페이지로 이동
+  Future<void> goToFirstPage() async {
+    if (currentPage != 1) {
+      await goToPage(1);
+    }
+  }
+
+  /// 마지막 페이지로 이동
+  Future<void> goToLastPage() async {
+    if (currentPage != totalPages) {
+      await goToPage(totalPages);
+    }
+  }
+
+  /// 새로고침
+  Future<void> refreshMemberList() async {
+    if (AppConfig.debugMode) {
+      print('🔄 [MemberLogicMixin] 모임원 목록 새로고침');
+    }
+
+    await loadMemberList();
+  }
+
+  /// 필터 초기화
+  Future<void> resetFilter() async {
+    if (AppConfig.debugMode) {
+      print('🔄 [MemberLogicMixin] 필터 초기화');
+    }
+
+    final resetFilter = _currentFilter.reset();
+    await applyFilter(resetFilter);
+  }
+
+  /// 특정 권한의 필터링 가능 여부 확인
+  /// 
+  /// 준운영진, 운영진은 비활성 계정 필터 옵션 제공 안함
+  bool canShowDeletedFilter(String? selectedRole) {
+    final roleOption = RoleOption.fromValue(selectedRole);
+    return !roleOption.forceActiveOnly;
+  }
+
+  /// 현재 필터에 비활성 계정 필터가 적용 가능한지 확인
+  bool get canShowCurrentDeletedFilter {
+    return canShowDeletedFilter(_currentFilter.role);
+  }
+
+  // Private methods
+
+  /// 액세스 토큰 가져오기
+  Future<String?> _getAccessToken() async {
+    try {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      return await authProvider.accessToken;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MemberLogicMixin] 액세스 토큰 가져오기 실패: $e');
+      }
+      return null;
+    }
+  }
+
+  /// 로딩 상태 설정
+  void _setLoading(bool loading) {
+    if (_isLoading != loading) {
+      _isLoading = loading;
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  /// 에러 메시지 설정
+  void _setError(String message) {
+    _errorMessage = message;
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  /// 에러 메시지 초기화
+  void _clearError() {
+    if (_errorMessage != null) {
+      _errorMessage = null;
+      if (mounted) {
+        setState(() {});
+      }
+    }
+  }
+
+  /// 에러 메시지 변환
+  String _getErrorMessage(dynamic error) {
+    final errorString = error.toString().toLowerCase();
+
+    if (errorString.contains('network') || errorString.contains('connection')) {
+      return '네트워크 오류가 발생했습니다. 인터넷 연결을 확인해주세요.';
+    } else if (errorString.contains('timeout')) {
+      return '연결 시간이 초과되었습니다. 다시 시도해주세요.';
+    } else if (errorString.contains('401') || errorString.contains('unauthorized')) {
+      return '인증이 필요합니다. 다시 로그인해주세요.';
+    } else if (errorString.contains('403') || errorString.contains('forbidden')) {
+      return '권한이 없습니다. 임원진 이상 권한이 필요합니다.';
+    } else {
+      return '모임원 목록을 불러오는 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.';
+    }
+  }
+
+  /// 디버그용 - 현재 상태 출력
+  void printCurrentState() {
+    if (AppConfig.debugMode) {
+      print('📊 === MemberLogicMixin 상태 ===');
+      print('로딩: $_isLoading');
+      print('에러: $_errorMessage');
+      print('필터: $_currentFilter');
+      print('페이징: $pagingInfo');
+      print('멤버 수: ${memberList.length}');
+      print('==============================');
+    }
+  }
+}

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -182,10 +182,9 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
 
   /// 특정 권한의 필터링 가능 여부 확인
   /// 
-  /// 준운영진, 운영진은 비활성 계정 필터 옵션 제공 안함
+  /// 모든 권한에 대해 계정 상태 선택 가능
   bool canShowDeletedFilter(String? selectedRole) {
-    final roleOption = RoleOption.fromValue(selectedRole);
-    return !roleOption.forceActiveOnly;
+    return true; // 모든 권한에 대해 계정 상태 선택 가능
   }
 
   /// 현재 필터에 비활성 계정 필터가 적용 가능한지 확인

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -49,7 +49,21 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
       print('🚀 [MemberLogicMixin] 모임원 목록 초기화 시작');
     }
 
+    // 🎯 사용자 권한에 따른 필터 표시 가능 여부 설정
+    await _updateDeletedFilterPermission();
+
     await loadMemberList(isInitial: true);
+  }
+
+  /// 비활성 계정 필터 표시 권한 업데이트
+  Future<void> _updateDeletedFilterPermission() async {
+    final userRole = await _getUserRole();
+    _canShowDeletedFilterSync = MemberService.canUseDeletedFilter(userRole);
+    
+    if (AppConfig.debugMode) {
+      print('🔍 [MemberLogicMixin] 사용자 권한: $userRole');
+      print('🔍 [MemberLogicMixin] 비활성 계정 필터 사용 가능: $_canShowDeletedFilterSync');
+    }
   }
 
   /// 모임원 목록 조회
@@ -76,9 +90,13 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
         throw Exception('인증 토큰을 가져올 수 없습니다.');
       }
 
+      // 🎯 사용자 권한 정보 가져오기
+      final userRole = await _getUserRole();
+      
       final response = await _memberService.getMemberList(
         filter: filter,
         accessToken: accessToken,
+        userRole: userRole,
       );
 
       _memberListResponse = response;
@@ -180,17 +198,23 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
     await applyFilter(resetFilter);
   }
 
-  /// 특정 권한의 필터링 가능 여부 확인
+  /// 현재 사용자가 비활성 계정 필터를 사용할 수 있는지 확인
   /// 
-  /// 모든 권한에 대해 계정 상태 선택 가능
-  bool canShowDeletedFilter(String? selectedRole) {
-    return true; // 모든 권한에 대해 계정 상태 선택 가능
+  /// 운영진·준운영진은 비활성 계정 필터 사용 불가
+  Future<bool> get canShowDeletedFilter async {
+    final userRole = await _getUserRole();
+    return MemberService.canUseDeletedFilter(userRole);
   }
 
-  /// 현재 필터에 비활성 계정 필터가 적용 가능한지 확인
+  /// 현재 필터에 비활성 계정 필터가 적용 가능한지 확인 (동기 버전)
   bool get canShowCurrentDeletedFilter {
-    return canShowDeletedFilter(_currentFilter.role);
+    // 🎯 이 메서드는 UI에서 즉시 사용되므로 임시로 true 반환
+    // 실제 확인은 _canShowDeletedFilterSync에서 수행
+    return _canShowDeletedFilterSync;
   }
+  
+  /// 동기적으로 비활성 계정 필터 표시 가능 여부 저장
+  bool _canShowDeletedFilterSync = true;
 
   // Private methods
 
@@ -202,6 +226,19 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
     } catch (e) {
       if (AppConfig.debugMode) {
         print('❌ [MemberLogicMixin] 액세스 토큰 가져오기 실패: $e');
+      }
+      return null;
+    }
+  }
+
+  /// 사용자 권한 가져오기
+  Future<String?> _getUserRole() async {
+    try {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      return authProvider.userRole;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MemberLogicMixin] 사용자 권한 가져오기 실패: $e');
       }
       return null;
     }

--- a/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
+++ b/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
@@ -19,16 +19,15 @@ class MemberWidgets {
     final isActive = member.isActive;
     
     return Card(
-      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4), // 세로 간격 줄임
-      elevation: isActive ? null : 0, // 비활성 계정은 그림자 제거
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      elevation: isActive ? null : 0,
       child: InkWell(
         onTap: onTap,
         borderRadius: BorderRadius.circular(12),
         child: Container(
-          padding: const EdgeInsets.all(12), // 패딩 줄임 (16 → 12)
+          padding: const EdgeInsets.all(12),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(12),
-            // 🎯 비활성 계정 강화된 시각적 구분
             color: isActive 
                 ? null 
                 : context.colors.surfaceVariant.withOpacity(0.3),
@@ -41,14 +40,15 @@ class MemberWidgets {
           ),
           child: Row(
             children: [
+              // 🎯 첫 번째 열: 이름, 닉네임, 성별, 생년월일
               Expanded(
+                flex: 3,
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    // 🎯 이름 + 닉네임 (한 줄로 슬림화)
+                    // 이름 + 닉네임
                     Row(
                       children: [
-                        // 이름 (메인)
                         Text(
                           member.displayName,
                           style: context.textStyles.titleMedium?.copyWith(
@@ -59,7 +59,6 @@ class MemberWidgets {
                           ),
                         ),
                         const SizedBox(width: 6),
-                        // 🎯 닉네임 (소괄호로 이름 옆에)
                         Text(
                           '(${member.nickname})',
                           style: context.textStyles.bodySmall?.copyWith(
@@ -71,19 +70,18 @@ class MemberWidgets {
                       ],
                     ),
                     
-                    const SizedBox(height: 6), // 간격 줄임 (12 → 6)
+                    const SizedBox(height: 6),
                     
-                    // 🎯 성별 + 생년월일 + ID (한 줄로 압축)
+                    // 성별 + 생년월일
                     Row(
                       children: [
-                        // 성별 아이콘
                         Icon(
                           member.gender == 'MALE' 
                               ? Icons.male 
                               : member.gender == 'FEMALE'
                                   ? Icons.female
                                   : Icons.help_outline,
-                          size: 14, // 아이콘 크기 줄임
+                          size: 14,
                           color: isActive
                               ? context.colors.onSurfaceVariant
                               : context.colors.onSurfaceVariant.withOpacity(0.5),
@@ -100,10 +98,9 @@ class MemberWidgets {
                         
                         const SizedBox(width: 12),
                         
-                        // 생년월일 아이콘
                         Icon(
                           Icons.cake_outlined,
-                          size: 14, // 아이콘 크기 줄임
+                          size: 14,
                           color: isActive
                               ? context.colors.onSurfaceVariant
                               : context.colors.onSurfaceVariant.withOpacity(0.5),
@@ -119,27 +116,55 @@ class MemberWidgets {
                             ),
                           ),
                         ),
-                        
-                        // ID 표시 (우측 끝)
-                        Text(
-                          '#${member.memberId}',
-                          style: context.textStyles.bodySmall?.copyWith(
-                            color: isActive
-                                ? context.colors.outline
-                                : context.colors.outline.withOpacity(0.5),
-                            fontFamily: 'monospace',
-                          ),
-                        ),
                       ],
                     ),
                   ],
                 ),
               ),
               
-              const SizedBox(width: 8),
+              const SizedBox(width: 12),
               
-              // 🎯 권한 배지 (우측)
-              _buildRoleBadge(context, member.roleDisplayName, isActive),
+              // 🎯 두 번째 열: 권한 배지 + 모임원 ID (정밀한 정렬)
+              Expanded(
+                flex: 2,
+                child: Padding(
+                  padding: const EdgeInsets.only(right: 3), // 🎯 우측 여백 4 → 3으로 수정
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      // 🎯 권한 배지 (이름/닉네임과 정확히 같은 높이)
+                      SizedBox(
+                        height: 26, // 🎯 높이 증가: 20 → 26 (배지가 짤리지 않도록)
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: _buildRoleBadge(context, member.roleDisplayName, isActive),
+                        ),
+                      ),
+                      
+                      const SizedBox(height: 10), // 🎯 간격 증가: 6 → 10
+                      
+                      // 🎯 모임원 ID (성별/생년월일과 같은 높이, 추가 패딩)
+                      Padding(
+                        padding: const EdgeInsets.only(right: 3), // 🎯 ID만 추가 패딩 3
+                        child: Align(
+                          alignment: Alignment.centerRight,
+                          child: Text(
+                            '#${member.memberId}',
+                            style: context.textStyles.bodySmall?.copyWith(
+                              color: isActive
+                                  ? context.colors.outline
+                                  : context.colors.outline.withOpacity(0.5),
+                              fontFamily: 'monospace',
+                              fontSize: 11,
+                              height: 1.0, // 라인 높이 조정
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ],
           ),
         ),
@@ -172,18 +197,17 @@ class MemberWidgets {
         badgeColor = Colors.grey;
     }
 
-    // 🎯 비활성 계정 색상 강화된 대비
     if (!isActive) {
-      badgeColor = badgeColor.withOpacity(0.3); // 더 연한 색상
+      badgeColor = badgeColor.withOpacity(0.3);
     }
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3), // 크기 아주 조금 줄임
+      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 4), // 🎯 패딩 조정: 원래 6,3에서 살짝만 증가
       decoration: BoxDecoration(
         color: badgeColor.withOpacity(0.1),
-        borderRadius: BorderRadius.circular(10), // 더 작은 보던
+        borderRadius: BorderRadius.circular(11), // 🎯 둥근 모서리 조정: 10에서 살짝만 증가
         border: Border.all(
-          color: badgeColor.withOpacity(isActive ? 0.3 : 0.2), // 비활성 시 더 연한 테두리
+          color: badgeColor.withOpacity(isActive ? 0.3 : 0.2),
           width: 1,
         ),
       ),
@@ -192,15 +216,13 @@ class MemberWidgets {
         style: context.textStyles.labelSmall?.copyWith(
           color: badgeColor,
           fontWeight: FontWeight.w600,
-          fontSize: 10, // 택스트 크기 조금 줄임
+          fontSize: 10,
         ),
       ),
     );
   }
 
   /// 플로팅 필터 버튼
-  /// 
-  /// [onPressed] 필터 버튼 탭 콜백
   static Widget buildFilterFab(BuildContext context, VoidCallback onPressed) {
     return FloatingActionButton(
       onPressed: onPressed,
@@ -211,253 +233,16 @@ class MemberWidgets {
   }
 
   /// 필터 바텀시트
-  /// 
-  /// [currentFilter] 현재 필터 설정
-  /// [onFilterChanged] 필터 변경 콜백
-  /// [canShowDeletedFilter] 비활성 계정 필터 표시 여부
   static Widget buildFilterBottomSheet(
     BuildContext context, {
     required MemberListFilter currentFilter,
     required Function(MemberListFilter) onFilterChanged,
     required bool canShowDeletedFilter,
   }) {
-    return StatefulBuilder(
-      builder: (context, setModalState) {
-        // 지역 상태 변수들
-        GenderOption selectedGender = GenderOption.fromValue(currentFilter.gender);
-        RoleOption selectedRole = RoleOption.fromValue(currentFilter.role);
-        bool? selectedDeleted = currentFilter.isDeleted;
-        SortOption selectedSort = SortOption.fromValue(currentFilter.sortBy);
-        bool isAscending = currentFilter.isAsc;
-
-        return Container(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // 헤더
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  Text(
-                    '필터 및 정렬',
-                    style: context.textStyles.headlineSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  TextButton(
-                    onPressed: () {
-                      // 필터 초기화
-                      setModalState(() {
-                        selectedGender = GenderOption.all;
-                        selectedRole = RoleOption.all;
-                        selectedDeleted = null;
-                        selectedSort = SortOption.role;
-                        isAscending = false;
-                      });
-                    },
-                    child: Text(
-                      '초기화',
-                      style: TextStyle(color: context.colors.primary),
-                    ),
-                  ),
-                ],
-              ),
-              
-              const SizedBox(height: 20),
-              
-              // 성별 필터
-              _buildFilterSection(
-                context,
-                title: '성별',
-                child: Wrap(
-                  spacing: 8,
-                  children: GenderOption.values.map((option) {
-                    final isSelected = selectedGender == option;
-                    return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
-                      label: Text(option.displayName),
-                      selected: isSelected,
-                      onSelected: (selected) {
-                        if (selected) {
-                          setModalState(() {
-                            selectedGender = option;
-                          });
-                        }
-                      },
-                    );
-                  }).toList(),
-                ),
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // 권한 필터
-              _buildFilterSection(
-                context,
-                title: '권한',
-                child: Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: RoleOption.values.map((option) {
-                    final isSelected = selectedRole == option;
-                    return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
-                      label: Text(option.displayName),
-                      selected: isSelected,
-                      onSelected: (selected) {
-                        if (selected) {
-                          setModalState(() {
-                            selectedRole = option;
-                            // 권한 변경 시 비활성 필터 옵션 확인
-                            if (option.forceActiveOnly) {
-                              selectedDeleted = false;
-                            }
-                          });
-                        }
-                      },
-                    );
-                  }).toList(),
-                ),
-              ),
-              
-              const SizedBox(height: 16),
-              
-              // 활성/비활성 필터 (조건부 표시)
-              if (canShowDeletedFilter && !selectedRole.forceActiveOnly) ...[
-                _buildFilterSection(
-                  context,
-                  title: '계정 상태',
-                  child: Wrap(
-                    spacing: 8,
-                    children: [
-                      ChoiceChip( // FilterChip 대신 ChoiceChip 사용
-                        label: const Text('전체'),
-                        selected: selectedDeleted == null,
-                        onSelected: (selected) {
-                          if (selected) {
-                            setModalState(() {
-                              selectedDeleted = null;
-                            });
-                          }
-                        },
-                      ),
-                      ChoiceChip(
-                        label: const Text('활성만'),
-                        selected: selectedDeleted == false,
-                        onSelected: (selected) {
-                          if (selected) {
-                            setModalState(() {
-                              selectedDeleted = false;
-                            });
-                          }
-                        },
-                      ),
-                      ChoiceChip(
-                        label: const Text('비활성만'),
-                        selected: selectedDeleted == true,
-                        onSelected: (selected) {
-                          if (selected) {
-                            setModalState(() {
-                              selectedDeleted = true;
-                            });
-                          }
-                        },
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 16),
-              ],
-              
-              // 정렬
-              _buildFilterSection(
-                context,
-                title: '정렬',
-                child: Column(
-                  children: [
-                    // 정렬 기준
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: SortOption.values.map((option) {
-                        final isSelected = selectedSort == option;
-                        return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
-                          label: Text(option.displayName),
-                          selected: isSelected,
-                          onSelected: (selected) {
-                            if (selected) {
-                              setModalState(() {
-                                selectedSort = option;
-                              });
-                            }
-                          },
-                        );
-                      }).toList(),
-                    ),
-                    
-                    const SizedBox(height: 8),
-                    
-                    // 정렬 순서
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        ChoiceChip( // FilterChip 대신 ChoiceChip 사용
-                          label: const Text('오름차순'),
-                          selected: isAscending,
-                          onSelected: (selected) {
-                            if (selected) {
-                              setModalState(() {
-                                isAscending = true;
-                              });
-                            }
-                          },
-                        ),
-                        const SizedBox(width: 8),
-                        ChoiceChip(
-                          label: const Text('내림차순'),
-                          selected: !isAscending,
-                          onSelected: (selected) {
-                            if (selected) {
-                              setModalState(() {
-                                isAscending = false;
-                              });
-                            }
-                          },
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
-              
-              const SizedBox(height: 24),
-              
-              // 적용 버튼
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  onPressed: () {
-                    final newFilter = MemberListFilter(
-                      gender: selectedGender.value,
-                      role: selectedRole.value,
-                      isDeleted: selectedDeleted,
-                      sortBy: selectedSort.value,
-                      isAsc: isAscending,
-                    );
-                    
-                    Navigator.pop(context);
-                    onFilterChanged(newFilter);
-                  },
-                  child: const Text('적용'),
-                ),
-              ),
-              
-              // 하단 여백 (키보드 대응)
-              SizedBox(height: MediaQuery.of(context).viewInsets.bottom),
-            ],
-          ),
-        );
-      },
+    return _FilterBottomSheetContent(
+      currentFilter: currentFilter,
+      onFilterChanged: onFilterChanged,
+      canShowDeletedFilter: canShowDeletedFilter,
     );
   }
 
@@ -484,10 +269,6 @@ class MemberWidgets {
   }
 
   /// 페이지네이션 위젯
-  /// 
-  /// [currentPage] 현재 페이지
-  /// [totalPages] 전체 페이지 수
-  /// [onPageChanged] 페이지 변경 콜백
   static Widget buildPagination(
     BuildContext context, {
     required int currentPage,
@@ -621,9 +402,6 @@ class MemberWidgets {
   }
 
   /// 에러 위젯
-  /// 
-  /// [message] 에러 메시지
-  /// [onRetry] 재시도 콜백
   static Widget buildError(
     BuildContext context, {
     required String message,
@@ -698,9 +476,6 @@ class MemberWidgets {
   }
 
   /// 목록 정보 헤더
-  /// 
-  /// [totalElements] 전체 요소 수
-  /// [currentFilter] 현재 필터
   static Widget buildListHeader(
     BuildContext context, {
     required int totalElements,
@@ -715,12 +490,15 @@ class MemberWidgets {
             '총 ${totalElements}명',
             style: context.textStyles.titleSmall?.copyWith(
               fontWeight: FontWeight.w600,
+              // 🎯 다크모드 대비 강화: 더 밝은 텍스트 색상 사용
+              color: context.colors.onBackground,
             ),
           ),
           Text(
             _getFilterSummary(currentFilter),
             style: context.textStyles.bodySmall?.copyWith(
-              color: context.colors.onSurfaceVariant,
+              // 🎯 다크모드 대비 강화: onSurfaceVariant 대신 onBackground 사용
+              color: context.colors.onBackground.withOpacity(0.7),
             ),
           ),
         ],
@@ -757,5 +535,281 @@ class MemberWidgets {
     filterParts.add('${sort.displayName}$order');
 
     return filterParts.join(' · ');
+  }
+}
+
+/// 🎯 필터 바텀시트 콘텐츠 위젯 (StatefulWidget으로 분리)
+class _FilterBottomSheetContent extends StatefulWidget {
+  final MemberListFilter currentFilter;
+  final Function(MemberListFilter) onFilterChanged;
+  final bool canShowDeletedFilter;
+
+  const _FilterBottomSheetContent({
+    required this.currentFilter,
+    required this.onFilterChanged,
+    required this.canShowDeletedFilter,
+  });
+
+  @override
+  State<_FilterBottomSheetContent> createState() => _FilterBottomSheetContentState();
+}
+
+class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
+  late GenderOption selectedGender;
+  late RoleOption selectedRole;
+  late bool? selectedDeleted;
+  late SortOption selectedSort;
+  late bool isAscending;
+
+  @override
+  void initState() {
+    super.initState();
+    // 🎯 초기값 설정 - ID순, 내림차순으로 변경
+    selectedGender = GenderOption.fromValue(widget.currentFilter.gender);
+    selectedRole = RoleOption.fromValue(widget.currentFilter.role);
+    selectedDeleted = widget.currentFilter.isDeleted;
+    selectedSort = SortOption.fromValue(widget.currentFilter.sortBy);
+    isAscending = widget.currentFilter.isAsc;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 헤더
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                '필터 및 정렬',
+                style: context.textStyles.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              TextButton(
+                onPressed: () {
+                  // 필터 초기화 - ID순, 내림차순으로 설정
+                  setState(() {
+                    selectedGender = GenderOption.all;
+                    selectedRole = RoleOption.all;
+                    selectedDeleted = null;
+                    selectedSort = SortOption.id; // ID순으로 초기화
+                    isAscending = false; // 내림차순으로 초기화
+                  });
+                },
+                child: Text(
+                  '초기화',
+                  style: TextStyle(color: context.colors.primary),
+                ),
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 20),
+          
+          // 성별 필터
+          MemberWidgets._buildFilterSection(
+            context,
+            title: '성별',
+            child: Wrap(
+              spacing: 8,
+              children: GenderOption.values.map((option) {
+                final isSelected = selectedGender == option;
+                return FilterChip(
+                  label: Text(option.displayName),
+                  selected: isSelected,
+                  onSelected: (selected) {
+                    setState(() {
+                      selectedGender = selected ? option : GenderOption.all;
+                    });
+                  },
+                  selectedColor: context.colors.primary.withOpacity(0.2),
+                  checkmarkColor: context.colors.primary,
+                  backgroundColor: context.colors.surfaceVariant,
+                );
+              }).toList(),
+            ),
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // 권한 필터
+          MemberWidgets._buildFilterSection(
+            context,
+            title: '권한',
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: RoleOption.values.map((option) {
+                final isSelected = selectedRole == option;
+                return FilterChip(
+                  label: Text(option.displayName),
+                  selected: isSelected,
+                  onSelected: (selected) {
+                    setState(() {
+                      selectedRole = selected ? option : RoleOption.all;
+                      // 권한 변경 시 비활성 필터 옵션 확인
+                      if (selected && option.forceActiveOnly) {
+                        selectedDeleted = false;
+                      }
+                    });
+                  },
+                  selectedColor: context.colors.primary.withOpacity(0.2),
+                  checkmarkColor: context.colors.primary,
+                  backgroundColor: context.colors.surfaceVariant,
+                );
+              }).toList(),
+            ),
+          ),
+          
+          const SizedBox(height: 16),
+          
+          // 활성/비활성 필터 (조건부 표시)
+          if (widget.canShowDeletedFilter && !selectedRole.forceActiveOnly) ...[
+            MemberWidgets._buildFilterSection(
+              context,
+              title: '계정 상태',
+              child: Wrap(
+                spacing: 8,
+                children: [
+                  FilterChip(
+                    label: const Text('전체'),
+                    selected: selectedDeleted == null,
+                    onSelected: (selected) {
+                      setState(() {
+                        selectedDeleted = selected ? null : false;
+                      });
+                    },
+                    selectedColor: context.colors.primary.withOpacity(0.2),
+                    checkmarkColor: context.colors.primary,
+                    backgroundColor: context.colors.surfaceVariant,
+                  ),
+                  FilterChip(
+                    label: const Text('활성만'),
+                    selected: selectedDeleted == false,
+                    onSelected: (selected) {
+                      setState(() {
+                        selectedDeleted = selected ? false : null;
+                      });
+                    },
+                    selectedColor: context.colors.primary.withOpacity(0.2),
+                    checkmarkColor: context.colors.primary,
+                    backgroundColor: context.colors.surfaceVariant,
+                  ),
+                  FilterChip(
+                    label: const Text('비활성만'),
+                    selected: selectedDeleted == true,
+                    onSelected: (selected) {
+                      setState(() {
+                        selectedDeleted = selected ? true : null;
+                      });
+                    },
+                    selectedColor: context.colors.primary.withOpacity(0.2),
+                    checkmarkColor: context.colors.primary,
+                    backgroundColor: context.colors.surfaceVariant,
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 16),
+          ],
+          
+          // 정렬
+          MemberWidgets._buildFilterSection(
+            context,
+            title: '정렬',
+            child: Column(
+              children: [
+                // 정렬 기준
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: SortOption.values.map((option) {
+                    final isSelected = selectedSort == option;
+                    return FilterChip(
+                      label: Text(option.displayName),
+                      selected: isSelected,
+                      onSelected: (selected) {
+                        setState(() {
+                        selectedSort = selected ? option : SortOption.id; // 기본값을 ID순으로
+                        });
+                      },
+                      selectedColor: context.colors.primary.withOpacity(0.2),
+                      checkmarkColor: context.colors.primary,
+                      backgroundColor: context.colors.surfaceVariant,
+                    );
+                  }).toList(),
+                ),
+                
+                const SizedBox(height: 8),
+                
+                // 정렬 순서 (ChoiceChip 유지 - 단일 선택)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    ChoiceChip(
+                      label: const Text('오름차순'),
+                      selected: isAscending,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setState(() {
+                            isAscending = true;
+                          });
+                        }
+                      },
+                      selectedColor: context.colors.primary.withOpacity(0.2),
+                      backgroundColor: context.colors.surfaceVariant,
+                    ),
+                    const SizedBox(width: 8),
+                    ChoiceChip(
+                      label: const Text('내림차순'),
+                      selected: !isAscending,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setState(() {
+                            isAscending = false;
+                          });
+                        }
+                      },
+                      selectedColor: context.colors.primary.withOpacity(0.2),
+                      backgroundColor: context.colors.surfaceVariant,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          
+          const SizedBox(height: 24),
+          
+          // 적용 버튼
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: () {
+                final newFilter = MemberListFilter(
+                  gender: selectedGender.value,
+                  role: selectedRole.value,
+                  isDeleted: selectedDeleted,
+                  sortBy: selectedSort.value,
+                  isAsc: isAscending,
+                );
+                
+                Navigator.pop(context);
+                widget.onFilterChanged(newFilter);
+              },
+              child: const Text('적용'),
+            ),
+          ),
+          
+          // 하단 여백 (키보드 대응)
+          SizedBox(height: MediaQuery.of(context).viewInsets.bottom),
+        ],
+      ),
+    );
   }
 }

--- a/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
+++ b/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
@@ -1,0 +1,761 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme.dart';
+import '../../../models/member/member_list_model.dart';
+
+/// 모임원 목록 화면 UI 위젯들
+/// 
+/// Static Methods로 구현하여 재사용성 극대화
+class MemberWidgets {
+  
+  /// 모임원 카드 위젯
+  /// 
+  /// [member] 모임원 정보
+  /// [onTap] 카드 탭 콜백 (향후 상세보기 기능)
+  static Widget buildMemberCard(
+    BuildContext context,
+    MemberListItem member, {
+    VoidCallback? onTap,
+  }) {
+    final isActive = member.isActive;
+    
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 4), // 세로 간격 줄임
+      elevation: isActive ? null : 0, // 비활성 계정은 그림자 제거
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          padding: const EdgeInsets.all(12), // 패딩 줄임 (16 → 12)
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            // 🎯 비활성 계정 강화된 시각적 구분
+            color: isActive 
+                ? null 
+                : context.colors.surfaceVariant.withOpacity(0.3),
+            border: isActive
+                ? null
+                : Border.all(
+                    color: context.colors.outline.withOpacity(0.3),
+                    width: 1,
+                  ),
+          ),
+          child: Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // 🎯 이름 + 닉네임 (한 줄로 슬림화)
+                    Row(
+                      children: [
+                        // 이름 (메인)
+                        Text(
+                          member.displayName,
+                          style: context.textStyles.titleMedium?.copyWith(
+                            fontWeight: FontWeight.bold,
+                            color: isActive 
+                                ? context.colors.onSurface
+                                : context.colors.onSurface.withOpacity(0.5),
+                          ),
+                        ),
+                        const SizedBox(width: 6),
+                        // 🎯 닉네임 (소괄호로 이름 옆에)
+                        Text(
+                          '(${member.nickname})',
+                          style: context.textStyles.bodySmall?.copyWith(
+                            color: isActive
+                                ? context.colors.onSurfaceVariant
+                                : context.colors.onSurfaceVariant.withOpacity(0.5),
+                          ),
+                        ),
+                      ],
+                    ),
+                    
+                    const SizedBox(height: 6), // 간격 줄임 (12 → 6)
+                    
+                    // 🎯 성별 + 생년월일 + ID (한 줄로 압축)
+                    Row(
+                      children: [
+                        // 성별 아이콘
+                        Icon(
+                          member.gender == 'MALE' 
+                              ? Icons.male 
+                              : member.gender == 'FEMALE'
+                                  ? Icons.female
+                                  : Icons.help_outline,
+                          size: 14, // 아이콘 크기 줄임
+                          color: isActive
+                              ? context.colors.onSurfaceVariant
+                              : context.colors.onSurfaceVariant.withOpacity(0.5),
+                        ),
+                        const SizedBox(width: 3),
+                        Text(
+                          member.genderDisplayName,
+                          style: context.textStyles.bodySmall?.copyWith(
+                            color: isActive
+                                ? context.colors.onSurfaceVariant
+                                : context.colors.onSurfaceVariant.withOpacity(0.5),
+                          ),
+                        ),
+                        
+                        const SizedBox(width: 12),
+                        
+                        // 생년월일 아이콘
+                        Icon(
+                          Icons.cake_outlined,
+                          size: 14, // 아이콘 크기 줄임
+                          color: isActive
+                              ? context.colors.onSurfaceVariant
+                              : context.colors.onSurfaceVariant.withOpacity(0.5),
+                        ),
+                        const SizedBox(width: 3),
+                        Expanded(
+                          child: Text(
+                            member.displayBirthDate,
+                            style: context.textStyles.bodySmall?.copyWith(
+                              color: isActive
+                                  ? context.colors.onSurfaceVariant
+                                  : context.colors.onSurfaceVariant.withOpacity(0.5),
+                            ),
+                          ),
+                        ),
+                        
+                        // ID 표시 (우측 끝)
+                        Text(
+                          '#${member.memberId}',
+                          style: context.textStyles.bodySmall?.copyWith(
+                            color: isActive
+                                ? context.colors.outline
+                                : context.colors.outline.withOpacity(0.5),
+                            fontFamily: 'monospace',
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              
+              const SizedBox(width: 8),
+              
+              // 🎯 권한 배지 (우측)
+              _buildRoleBadge(context, member.roleDisplayName, isActive),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 권한 배지 위젯
+  static Widget _buildRoleBadge(BuildContext context, String role, bool isActive) {
+    Color badgeColor;
+    
+    // 권한별 색상 설정
+    switch (role) {
+      case '모임장':
+        badgeColor = Colors.purple;
+        break;
+      case '부모임장':
+        badgeColor = Colors.indigo;
+        break;
+      case '관리자':
+        badgeColor = Colors.red;
+        break;
+      case '운영진':
+        badgeColor = Colors.orange;
+        break;
+      case '준운영진':
+        badgeColor = Colors.blue;
+        break;
+      default:
+        badgeColor = Colors.grey;
+    }
+
+    // 🎯 비활성 계정 색상 강화된 대비
+    if (!isActive) {
+      badgeColor = badgeColor.withOpacity(0.3); // 더 연한 색상
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3), // 크기 아주 조금 줄임
+      decoration: BoxDecoration(
+        color: badgeColor.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(10), // 더 작은 보던
+        border: Border.all(
+          color: badgeColor.withOpacity(isActive ? 0.3 : 0.2), // 비활성 시 더 연한 테두리
+          width: 1,
+        ),
+      ),
+      child: Text(
+        role,
+        style: context.textStyles.labelSmall?.copyWith(
+          color: badgeColor,
+          fontWeight: FontWeight.w600,
+          fontSize: 10, // 택스트 크기 조금 줄임
+        ),
+      ),
+    );
+  }
+
+  /// 플로팅 필터 버튼
+  /// 
+  /// [onPressed] 필터 버튼 탭 콜백
+  static Widget buildFilterFab(BuildContext context, VoidCallback onPressed) {
+    return FloatingActionButton(
+      onPressed: onPressed,
+      backgroundColor: context.colors.primary,
+      foregroundColor: context.colors.onPrimary,
+      child: const Icon(Icons.tune),
+    );
+  }
+
+  /// 필터 바텀시트
+  /// 
+  /// [currentFilter] 현재 필터 설정
+  /// [onFilterChanged] 필터 변경 콜백
+  /// [canShowDeletedFilter] 비활성 계정 필터 표시 여부
+  static Widget buildFilterBottomSheet(
+    BuildContext context, {
+    required MemberListFilter currentFilter,
+    required Function(MemberListFilter) onFilterChanged,
+    required bool canShowDeletedFilter,
+  }) {
+    return StatefulBuilder(
+      builder: (context, setModalState) {
+        // 지역 상태 변수들
+        GenderOption selectedGender = GenderOption.fromValue(currentFilter.gender);
+        RoleOption selectedRole = RoleOption.fromValue(currentFilter.role);
+        bool? selectedDeleted = currentFilter.isDeleted;
+        SortOption selectedSort = SortOption.fromValue(currentFilter.sortBy);
+        bool isAscending = currentFilter.isAsc;
+
+        return Container(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // 헤더
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Text(
+                    '필터 및 정렬',
+                    style: context.textStyles.headlineSmall?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () {
+                      // 필터 초기화
+                      setModalState(() {
+                        selectedGender = GenderOption.all;
+                        selectedRole = RoleOption.all;
+                        selectedDeleted = null;
+                        selectedSort = SortOption.role;
+                        isAscending = false;
+                      });
+                    },
+                    child: Text(
+                      '초기화',
+                      style: TextStyle(color: context.colors.primary),
+                    ),
+                  ),
+                ],
+              ),
+              
+              const SizedBox(height: 20),
+              
+              // 성별 필터
+              _buildFilterSection(
+                context,
+                title: '성별',
+                child: Wrap(
+                  spacing: 8,
+                  children: GenderOption.values.map((option) {
+                    final isSelected = selectedGender == option;
+                    return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
+                      label: Text(option.displayName),
+                      selected: isSelected,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setModalState(() {
+                            selectedGender = option;
+                          });
+                        }
+                      },
+                    );
+                  }).toList(),
+                ),
+              ),
+              
+              const SizedBox(height: 16),
+              
+              // 권한 필터
+              _buildFilterSection(
+                context,
+                title: '권한',
+                child: Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: RoleOption.values.map((option) {
+                    final isSelected = selectedRole == option;
+                    return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
+                      label: Text(option.displayName),
+                      selected: isSelected,
+                      onSelected: (selected) {
+                        if (selected) {
+                          setModalState(() {
+                            selectedRole = option;
+                            // 권한 변경 시 비활성 필터 옵션 확인
+                            if (option.forceActiveOnly) {
+                              selectedDeleted = false;
+                            }
+                          });
+                        }
+                      },
+                    );
+                  }).toList(),
+                ),
+              ),
+              
+              const SizedBox(height: 16),
+              
+              // 활성/비활성 필터 (조건부 표시)
+              if (canShowDeletedFilter && !selectedRole.forceActiveOnly) ...[
+                _buildFilterSection(
+                  context,
+                  title: '계정 상태',
+                  child: Wrap(
+                    spacing: 8,
+                    children: [
+                      ChoiceChip( // FilterChip 대신 ChoiceChip 사용
+                        label: const Text('전체'),
+                        selected: selectedDeleted == null,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setModalState(() {
+                              selectedDeleted = null;
+                            });
+                          }
+                        },
+                      ),
+                      ChoiceChip(
+                        label: const Text('활성만'),
+                        selected: selectedDeleted == false,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setModalState(() {
+                              selectedDeleted = false;
+                            });
+                          }
+                        },
+                      ),
+                      ChoiceChip(
+                        label: const Text('비활성만'),
+                        selected: selectedDeleted == true,
+                        onSelected: (selected) {
+                          if (selected) {
+                            setModalState(() {
+                              selectedDeleted = true;
+                            });
+                          }
+                        },
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(height: 16),
+              ],
+              
+              // 정렬
+              _buildFilterSection(
+                context,
+                title: '정렬',
+                child: Column(
+                  children: [
+                    // 정렬 기준
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: SortOption.values.map((option) {
+                        final isSelected = selectedSort == option;
+                        return ChoiceChip( // FilterChip 대신 ChoiceChip 사용
+                          label: Text(option.displayName),
+                          selected: isSelected,
+                          onSelected: (selected) {
+                            if (selected) {
+                              setModalState(() {
+                                selectedSort = option;
+                              });
+                            }
+                          },
+                        );
+                      }).toList(),
+                    ),
+                    
+                    const SizedBox(height: 8),
+                    
+                    // 정렬 순서
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        ChoiceChip( // FilterChip 대신 ChoiceChip 사용
+                          label: const Text('오름차순'),
+                          selected: isAscending,
+                          onSelected: (selected) {
+                            if (selected) {
+                              setModalState(() {
+                                isAscending = true;
+                              });
+                            }
+                          },
+                        ),
+                        const SizedBox(width: 8),
+                        ChoiceChip(
+                          label: const Text('내림차순'),
+                          selected: !isAscending,
+                          onSelected: (selected) {
+                            if (selected) {
+                              setModalState(() {
+                                isAscending = false;
+                              });
+                            }
+                          },
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+              
+              const SizedBox(height: 24),
+              
+              // 적용 버튼
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    final newFilter = MemberListFilter(
+                      gender: selectedGender.value,
+                      role: selectedRole.value,
+                      isDeleted: selectedDeleted,
+                      sortBy: selectedSort.value,
+                      isAsc: isAscending,
+                    );
+                    
+                    Navigator.pop(context);
+                    onFilterChanged(newFilter);
+                  },
+                  child: const Text('적용'),
+                ),
+              ),
+              
+              // 하단 여백 (키보드 대응)
+              SizedBox(height: MediaQuery.of(context).viewInsets.bottom),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 필터 섹션 빌더
+  static Widget _buildFilterSection(
+    BuildContext context, {
+    required String title,
+    required Widget child,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: context.textStyles.titleSmall?.copyWith(
+            fontWeight: FontWeight.w600,
+            color: context.colors.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 8),
+        child,
+      ],
+    );
+  }
+
+  /// 페이지네이션 위젯
+  /// 
+  /// [currentPage] 현재 페이지
+  /// [totalPages] 전체 페이지 수
+  /// [onPageChanged] 페이지 변경 콜백
+  static Widget buildPagination(
+    BuildContext context, {
+    required int currentPage,
+    required int totalPages,
+    required Function(int) onPageChanged,
+  }) {
+    if (totalPages <= 1) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          // 첫 페이지
+          IconButton(
+            onPressed: currentPage > 1 
+                ? () => onPageChanged(1)
+                : null,
+            icon: const Icon(Icons.first_page),
+          ),
+          
+          // 이전 페이지
+          IconButton(
+            onPressed: currentPage > 1
+                ? () => onPageChanged(currentPage - 1)
+                : null,
+            icon: const Icon(Icons.chevron_left),
+          ),
+          
+          // 페이지 번호들
+          ...buildPageNumbers(context, currentPage, totalPages, onPageChanged),
+          
+          // 다음 페이지
+          IconButton(
+            onPressed: currentPage < totalPages
+                ? () => onPageChanged(currentPage + 1)
+                : null,
+            icon: const Icon(Icons.chevron_right),
+          ),
+          
+          // 마지막 페이지
+          IconButton(
+            onPressed: currentPage < totalPages
+                ? () => onPageChanged(totalPages)
+                : null,
+            icon: const Icon(Icons.last_page),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 페이지 번호 버튼들 생성
+  static List<Widget> buildPageNumbers(
+    BuildContext context,
+    int currentPage,
+    int totalPages,
+    Function(int) onPageChanged,
+  ) {
+    final List<Widget> pageButtons = [];
+    
+    // 표시할 페이지 범위 계산 (최대 5개)
+    int startPage = (currentPage - 2).clamp(1, totalPages);
+    int endPage = (startPage + 4).clamp(1, totalPages);
+    
+    // startPage 조정 (endPage가 마지막에 도달했을 때)
+    if (endPage == totalPages) {
+      startPage = (endPage - 4).clamp(1, totalPages);
+    }
+
+    for (int i = startPage; i <= endPage; i++) {
+      pageButtons.add(
+        Container(
+          margin: const EdgeInsets.symmetric(horizontal: 2),
+          child: Material(
+            borderRadius: BorderRadius.circular(8),
+            color: i == currentPage 
+                ? context.colors.primary
+                : Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(8),
+              onTap: i != currentPage 
+                  ? () => onPageChanged(i)
+                  : null,
+              child: Container(
+                width: 40,
+                height: 40,
+                alignment: Alignment.center,
+                child: Text(
+                  '$i',
+                  style: context.textStyles.bodyMedium?.copyWith(
+                    color: i == currentPage 
+                        ? context.colors.onPrimary
+                        : context.colors.onSurface,
+                    fontWeight: i == currentPage 
+                        ? FontWeight.bold
+                        : FontWeight.normal,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return pageButtons;
+  }
+
+  /// 로딩 위젯
+  static Widget buildLoading(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(
+            color: context.colors.primary,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            '모임원 목록을 불러오는 중...',
+            style: context.textStyles.bodyMedium?.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 에러 위젯
+  /// 
+  /// [message] 에러 메시지
+  /// [onRetry] 재시도 콜백
+  static Widget buildError(
+    BuildContext context, {
+    required String message,
+    VoidCallback? onRetry,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: context.colors.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: context.textStyles.bodyLarge?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh),
+                label: const Text('다시 시도'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 빈 목록 위젯
+  static Widget buildEmptyList(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.people_outline,
+              size: 64,
+              color: context.colors.onSurfaceVariant,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '조건에 맞는 모임원이 없습니다',
+              textAlign: TextAlign.center,
+              style: context.textStyles.titleMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '필터 조건을 변경해보세요',
+              textAlign: TextAlign.center,
+              style: context.textStyles.bodyMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 목록 정보 헤더
+  /// 
+  /// [totalElements] 전체 요소 수
+  /// [currentFilter] 현재 필터
+  static Widget buildListHeader(
+    BuildContext context, {
+    required int totalElements,
+    required MemberListFilter currentFilter,
+  }) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          Text(
+            '총 ${totalElements}명',
+            style: context.textStyles.titleSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          Text(
+            _getFilterSummary(currentFilter),
+            style: context.textStyles.bodySmall?.copyWith(
+              color: context.colors.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 필터 요약 텍스트 생성
+  static String _getFilterSummary(MemberListFilter filter) {
+    final List<String> filterParts = [];
+
+    // 성별 필터
+    final gender = GenderOption.fromValue(filter.gender);
+    if (gender != GenderOption.all) {
+      filterParts.add(gender.displayName);
+    }
+
+    // 권한 필터
+    final role = RoleOption.fromValue(filter.role);
+    if (role != RoleOption.all) {
+      filterParts.add(role.displayName);
+    }
+
+    // 상태 필터
+    if (filter.isDeleted == true) {
+      filterParts.add('비활성');
+    } else if (filter.isDeleted == false) {
+      filterParts.add('활성');
+    }
+
+    // 정렬 정보
+    final sort = SortOption.fromValue(filter.sortBy);
+    final order = filter.isAsc ? '↑' : '↓';
+    filterParts.add('${sort.displayName}$order');
+
+    return filterParts.join(' · ');
+  }
+}

--- a/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
+++ b/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
@@ -652,10 +652,6 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
                   onSelected: (selected) {
                     setState(() {
                       selectedRole = selected ? option : RoleOption.all;
-                      // 권한 변경 시 비활성 필터 옵션 확인
-                      if (selected && option.forceActiveOnly) {
-                        selectedDeleted = false;
-                      }
                     });
                   },
                   selectedColor: context.colors.primary.withOpacity(0.2),
@@ -668,8 +664,8 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
           
           const SizedBox(height: 16),
           
-          // 활성/비활성 필터 (조건부 표시)
-          if (widget.canShowDeletedFilter && !selectedRole.forceActiveOnly) ...[
+          // 활성/비활성 필터 (조건부 표시) - 🎯 운영진·준운영진은 표시하지 않음
+          if (widget.canShowDeletedFilter) ...[
             MemberWidgets._buildFilterSection(
               context,
               title: '계정 상태',

--- a/geulnamu_frontend/lib/services/home/home_service.dart
+++ b/geulnamu_frontend/lib/services/home/home_service.dart
@@ -174,6 +174,9 @@ class HomeService {
         // 🌿 글나무 소개 화면으로 이동 (로그인 무관)
         Navigator.pushNamed(context, '/introduction');
         break;
+      case '모임원 목록':
+        Navigator.pushNamed(context, '/member-list');
+        break;
       case '모임 목록':
         _showSnackBar(context, '모임 목록 기능은 개발 중입니다.');
         break;
@@ -230,6 +233,7 @@ class HomeService {
       '출석 이력',
       '발제 작성',
       '내 발제',
+      '모임원 목록', // 임원진 이상 기능
     ];
 
     if (loginRequiredFeatures.contains(featureName)) {
@@ -242,7 +246,12 @@ class HomeService {
 
   /// 역할 권한 체크
   bool hasRolePermission(String featureName, AuthProvider authProvider) {
-    // 임시로 모든 기능에 대해 true 반환
+    // 모임원 목록은 임원진 이상 권한 필요
+    if (featureName == '모임원 목록') {
+      return authProvider.isStaffLevel;
+    }
+    
+    // 다른 기능들은 임시로 모두 접근 가능
     return true;
   }
 

--- a/geulnamu_frontend/lib/services/home/home_service.dart
+++ b/geulnamu_frontend/lib/services/home/home_service.dart
@@ -70,7 +70,24 @@ class HomeService {
 
     if (confirmed == true) {
       await authProvider.logout(context: context);
-      _showSnackBar(context, '로그아웃되었습니다.');
+      
+      // 🎯 로그아웃 후 자동으로 홈으로 이동 (모든 이전 라우트 제거)
+      if (context.mounted) {
+        Navigator.pushNamedAndRemoveUntil(
+          context,
+          '/home',
+          (route) => false, // 모든 이전 라우트 제거
+        );
+      }
+      
+      // 🎯 홈 이동 후 스낵바 표시 (약간의 딜레이)
+      if (context.mounted) {
+        Future.delayed(const Duration(milliseconds: 300), () {
+          if (context.mounted) {
+            _showSnackBar(context, '로그아웃되었습니다.');
+          }
+        });
+      }
     }
   }
 

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -17,10 +17,6 @@ class MemberService {
   /// 
   /// [filter] 필터 및 정렬 옵션
   /// [accessToken] 인증 토큰 (임원진 이상 권한 필요)
-  /// 
-  /// 권한별 비활성 계정 필터링:
-  /// - 준운영진, 운영진: 항상 활성 계정만 조회
-  /// - 기타 권한: 필터 옵션에 따라 조회
   Future<MemberListResponse> getMemberList({
     required MemberListFilter filter,
     required String accessToken,
@@ -31,12 +27,9 @@ class MemberService {
         print('🔍 [모임원 목록 조회] 필터: $filter');
       }
 
-      // 🎯 특별 처리: 준운영진/운영진 선택 시 강제로 활성 계정만 조회
-      final adjustedFilter = _adjustFilterForStaffRoles(filter);
-
       final response = await _dio.get(
         AppConfig.getApiEndpoint('members/list'),
-        queryParameters: adjustedFilter.toQueryParameters(),
+        queryParameters: filter.toQueryParameters(),
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
@@ -56,6 +49,7 @@ class MemberService {
         if (AppConfig.debugMode) {
           print('✅ [모임원 목록 조회] 성공: ${memberListResponse.memberList.length}명');
           print('📄 [모임원 목록 조회] 페이지: ${memberListResponse.pagingResponse.pageNumber}/${memberListResponse.pagingResponse.totalPages}');
+          print('📄 [모임원 목록 조회] 전체 인원: ${memberListResponse.pagingResponse.totalElements}명');
         }
 
         return memberListResponse;
@@ -68,23 +62,6 @@ class MemberService {
       }
       rethrow;
     }
-  }
-
-  /// 준운영진/운영진 선택 시 필터 조정
-  /// 
-  /// 해당 권한들은 항상 활성 계정만 보여야 함
-  MemberListFilter _adjustFilterForStaffRoles(MemberListFilter filter) {
-    final selectedRole = RoleOption.fromValue(filter.role);
-    
-    // 준운영진 또는 운영진 선택 시 강제로 활성 계정만 조회
-    if (selectedRole.forceActiveOnly) {
-      if (AppConfig.debugMode) {
-        print('🔒 [모임원 목록 조회] ${selectedRole.displayName} 선택 - 활성 계정만 조회');
-      }
-      return filter.copyWith(isDeleted: false);
-    }
-
-    return filter;
   }
 
   /// 특정 모임원 상세 조회 (관리자급 이상)

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -17,19 +17,26 @@ class MemberService {
   /// 
   /// [filter] 필터 및 정렬 옵션
   /// [accessToken] 인증 토큰 (임원진 이상 권한 필요)
+  /// [userRole] 사용자 권한 (운영진·준운영진은 활성 계정만 조회)
   Future<MemberListResponse> getMemberList({
     required MemberListFilter filter,
     required String accessToken,
+    required String? userRole,
   }) async {
     try {
+      // 🎯 운영진·준운영진은 자동으로 활성 계정만 조회
+      final adjustedFilter = _adjustFilterForUserRole(filter, userRole);
+      
       if (AppConfig.debugMode) {
         print('🚀 [모임원 목록 조회] API 요청 시작...');
-        print('🔍 [모임원 목록 조회] 필터: $filter');
+        print('🔍 [모임원 목록 조회] 사용자 권한: $userRole');
+        print('🔍 [모임원 목록 조회] 원본 필터: $filter');
+        print('🔍 [모임원 목록 조회] 조정된 필터: $adjustedFilter');
       }
 
       final response = await _dio.get(
         AppConfig.getApiEndpoint('members/list'),
-        queryParameters: filter.toQueryParameters(),
+        queryParameters: adjustedFilter.toQueryParameters(),
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
@@ -126,13 +133,42 @@ class MemberService {
     throw UnimplementedError('모임원 상태 변경 기능은 향후 구현 예정입니다.');
   }
 
+  /// 사용자 권한에 따른 필터 조정
+  /// 
+  /// 운영진·준운영진은 자동으로 활성 계정만 조회하도록 필터 조정
+  MemberListFilter _adjustFilterForUserRole(MemberListFilter filter, String? userRole) {
+    // 🎯 운영진·준운영진은 항상 활성 계정만 조회
+    if (userRole == 'STAFF' || userRole == 'VICE_STAFF') {
+      return filter.copyWith(isDeleted: false);
+    }
+    
+    // 다른 권한(관리자, 부모임장, 모임장)은 원본 필터 그대로 사용
+    return filter;
+  }
+
+  /// 사용자 권한이 비활성 계정 필터를 사용할 수 있는지 확인
+  /// 
+  /// 운영진·준운영진은 비활성 계정 필터 사용 불가
+  static bool canUseDeletedFilter(String? userRole) {
+    if (userRole == null) return false;
+    
+    // 🎯 운영진·준운영진은 비활성 계정 필터 사용 불가
+    if (userRole == 'STAFF' || userRole == 'VICE_STAFF') {
+      return false;
+    }
+    
+    // 관리자, 부모임장, 모임장은 비활성 계정 필터 사용 가능
+    return true;
+  }
+
   /// 디버그용 - 서비스 상태 출력
   void printServiceInfo() {
     print('📊 === MemberService 정보 ===');
     print('서비스: 모임원 관리');
     print('권한: STAFF 이상 (임원진 이상)');
     print('주요 기능: 모임원 목록 조회, 필터링, 정렬');
-    print('특별 규칙: 준운영진/운영진은 활성 계정만 표시');
+    print('🆕 특별 규칙: 운영진·준운영진은 활성 계정만 조회');
+    print('🆕 필터 제한: 운영진·준운영진은 비활성 계정 필터 사용 불가');
     print('==========================');
   }
 }

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -1,0 +1,161 @@
+import 'package:dio/dio.dart';
+import '../../core/config/app_config.dart';
+import '../../core/utils/api_utils.dart';
+import '../../models/member/member_list_model.dart';
+
+/// 모임원 관련 API 서비스
+/// 
+/// 임원진 이상 권한이 필요한 모임원 관리 기능 제공
+class MemberService {
+  static final MemberService _instance = MemberService._internal();
+  factory MemberService() => _instance;
+  MemberService._internal();
+
+  final Dio _dio = Dio();
+
+  /// 모임원 목록 조회
+  /// 
+  /// [filter] 필터 및 정렬 옵션
+  /// [accessToken] 인증 토큰 (임원진 이상 권한 필요)
+  /// 
+  /// 권한별 비활성 계정 필터링:
+  /// - 준운영진, 운영진: 항상 활성 계정만 조회
+  /// - 기타 권한: 필터 옵션에 따라 조회
+  Future<MemberListResponse> getMemberList({
+    required MemberListFilter filter,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 목록 조회] API 요청 시작...');
+        print('🔍 [모임원 목록 조회] 필터: $filter');
+      }
+
+      // 🎯 특별 처리: 준운영진/운영진 선택 시 강제로 활성 계정만 조회
+      final adjustedFilter = _adjustFilterForStaffRoles(filter);
+
+      final response = await _dio.get(
+        AppConfig.getApiEndpoint('members/list'),
+        queryParameters: adjustedFilter.toQueryParameters(),
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 목록 조회',
+        );
+
+        final memberListResponse = MemberListResponse.fromJson(processedResponse['data']);
+
+        if (AppConfig.debugMode) {
+          print('✅ [모임원 목록 조회] 성공: ${memberListResponse.memberList.length}명');
+          print('📄 [모임원 목록 조회] 페이지: ${memberListResponse.pagingResponse.pageNumber}/${memberListResponse.pagingResponse.totalPages}');
+        }
+
+        return memberListResponse;
+      } else {
+        throw Exception('[모임원 목록 조회] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임원 목록 조회');
+      }
+      rethrow;
+    }
+  }
+
+  /// 준운영진/운영진 선택 시 필터 조정
+  /// 
+  /// 해당 권한들은 항상 활성 계정만 보여야 함
+  MemberListFilter _adjustFilterForStaffRoles(MemberListFilter filter) {
+    final selectedRole = RoleOption.fromValue(filter.role);
+    
+    // 준운영진 또는 운영진 선택 시 강제로 활성 계정만 조회
+    if (selectedRole.forceActiveOnly) {
+      if (AppConfig.debugMode) {
+        print('🔒 [모임원 목록 조회] ${selectedRole.displayName} 선택 - 활성 계정만 조회');
+      }
+      return filter.copyWith(isDeleted: false);
+    }
+
+    return filter;
+  }
+
+  /// 특정 모임원 상세 조회 (관리자급 이상)
+  /// 
+  /// [memberId] 조회할 모임원 ID
+  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
+  /// 
+  /// 향후 구현 예정
+  Future<Map<String, dynamic>> getMemberDetail({
+    required int memberId,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 구현
+    throw UnimplementedError('모임원 상세 조회 기능은 향후 구현 예정입니다.');
+  }
+
+  /// 모임원 권한 변경 (관리자급 이상)
+  /// 
+  /// [memberId] 대상 모임원 ID
+  /// [newRole] 새로운 권한
+  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
+  /// 
+  /// 향후 구현 예정
+  Future<void> updateMemberRole({
+    required int memberId,
+    required String newRole,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 구현
+    throw UnimplementedError('모임원 권한 변경 기능은 향후 구현 예정입니다.');
+  }
+
+  /// 모임원 이름 변경 (관리자급 이상)
+  /// 
+  /// [memberId] 대상 모임원 ID
+  /// [newName] 새로운 이름
+  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
+  /// 
+  /// 향후 구현 예정
+  Future<void> updateMemberName({
+    required int memberId,
+    required String newName,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 구현
+    throw UnimplementedError('모임원 이름 변경 기능은 향후 구현 예정입니다.');
+  }
+
+  /// 모임원 활성화/비활성화 (관리자급 이상)
+  /// 
+  /// [memberId] 대상 모임원 ID
+  /// [activate] true: 활성화, false: 비활성화
+  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
+  /// 
+  /// 향후 구현 예정
+  Future<void> updateMemberStatus({
+    required int memberId,
+    required bool activate,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 구현
+    throw UnimplementedError('모임원 상태 변경 기능은 향후 구현 예정입니다.');
+  }
+
+  /// 디버그용 - 서비스 상태 출력
+  void printServiceInfo() {
+    print('📊 === MemberService 정보 ===');
+    print('서비스: 모임원 관리');
+    print('권한: STAFF 이상 (임원진 이상)');
+    print('주요 기능: 모임원 목록 조회, 필터링, 정렬');
+    print('특별 규칙: 준운영진/운영진은 활성 계정만 표시');
+    print('==========================');
+  }
+}

--- a/geulnamu_frontend/lib/widgets/common/app_drawer.dart
+++ b/geulnamu_frontend/lib/widgets/common/app_drawer.dart
@@ -54,6 +54,18 @@ class AppDrawer extends StatelessWidget {
                       ),
                     ]),
 
+                    // 👥 모임원 섹션 (임원진 이상만)
+                    if (authProvider.isAuthenticated &&
+                        authProvider.isStaffLevel)
+                      _buildMenuSection(context, '모임원', [
+                        _DrawerMenuItem(
+                          icon: Icons.people_outlined,
+                          title: '모임원 목록',
+                          subtitle: '전체 모임원 보기',
+                          onTap: () => _handleMenuTap(context, '모임원 목록'),
+                        ),
+                      ]),
+
                     // 📚 모임 섹션 (로그인 후에만)
                     if (authProvider.isAuthenticated) ...[
                       _buildMenuSection(context, '모임', [


### PR DESCRIPTION
# 변경 내역
## 페이지 구현
### 사이드바 섹션 및 항목 추가
- 사이드바에서 '모임원' 섹션 및 '모임원' 항목 추가 (해당 섹션 및 항목은 운영진, 준운영진에게만 보이도록 권한 설정)
### 모임원 목록 페이지
- 준운영진 이상만 사이드바에서 보이고 접근 가능하도록 권한 처리
- 준운영진, 운영진 등급의 경우, 비활성화 계정 보이지 않도록 미리 filtering 처리
- 필터링, 정렬 설정 FAB 처리
- 모임원 목록 페이지에서도 '사이드바' 표시되도록 설정 변경
- 사용자 메뉴의 '로그아웃' 기능 사용할 수 있도록 설정 수정
## 백엔드 수정
### 모임원 목록 조회 기능 수정
- 페이지네이션에서 전체 항목 갯수 및 전체 패이지 수 잘못 나오던 것 수정
- name, gender 가 null 값이더라도 조회되도록 queryDSL 코드 수정
- 등급(role)로 정렬 시, abc순서가 아닌, 등급 나열 순(ordinal)값으로 정렬되도록 `EnumOrderUtil` 클래스 생성 및 적용
### 페이지네이션 목록 조회 기능들 수정
- 모임원 목록 조회 기능처럼, 페이지네이션에서 전체 항목 갯수 및 전체 페이지 수 잘못 나오던 것 수정