### PR TITLE
[Feat/FE] 모임원 상세 조회 페이지

### DIFF
--- a/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
@@ -532,7 +532,7 @@ Host: docs.api.com
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 01:39:48 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 17:32:38 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -697,7 +697,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 01:39:48 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 13 Jan 2026 17:32:38 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
@@ -884,21 +884,21 @@ Content-Type: application/json;charset=UTF-8
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.name</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이름</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.gender</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.birthDate</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">생년월일</p></td>
 </tr>

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/member/MemberControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/member/MemberControllerTest.java
@@ -175,9 +175,9 @@ public class MemberControllerTest extends ControllerTest {
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),
                     fieldWithPath("message").type(JsonFieldType.STRING).description("결과 메세지"),
                     fieldWithPath("data.memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
-                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름"),
-                    fieldWithPath("data.gender").type(JsonFieldType.STRING).description("성별"),
-                    fieldWithPath("data.birthDate").type(JsonFieldType.STRING).description("생년월일"),
+                    fieldWithPath("data.name").type(JsonFieldType.STRING).description("이름").optional(),
+                    fieldWithPath("data.gender").type(JsonFieldType.STRING).description("성별").optional(),
+                    fieldWithPath("data.birthDate").type(JsonFieldType.STRING).description("생년월일").optional(),
                     fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("닉네임(카카오 닉네임)"),
                     fieldWithPath("data.role").type(JsonFieldType.STRING).description("권한 등급"),
                     fieldWithPath("data.deletedAt").type(JsonFieldType.STRING).optional().description("삭제일자 (삭제되지 않은 경우 null)")

--- a/geulnamu_frontend/lib/core/utils/api_utils.dart
+++ b/geulnamu_frontend/lib/core/utils/api_utils.dart
@@ -122,6 +122,45 @@ class ApiUtils {
           print('Response Data: $responseData');
         }
         
+        // 🛡️ 403 금지된 접근 특별 처리
+        if (statusCode == 403) {
+          message = '접근 권한이 없습니다.';
+          
+          if (AppConfig.debugMode) {
+            print('🛡️ [$apiName] 403 금지된 접근 - 권한 없음');
+          }
+          
+          // 🛡️ 관리자 모드 관련 API인 경우 특별 처리
+          if (apiName.contains('모임원') && context != null && showDialog) {
+            // 비동기로 홈으로 리다이렉트
+            Future.microtask(() {
+              Navigator.pushNamedAndRemoveUntil(
+                context,
+                '/home',
+                (route) => false,
+              );
+              
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: const Row(
+                    children: [
+                      Icon(Icons.security, color: Colors.white),
+                      SizedBox(width: 8),
+                      Text('모임원 관리 권한이 없습니다.'),
+                    ],
+                  ),
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                  behavior: SnackBarBehavior.floating,
+                  duration: const Duration(seconds: 4),
+                ),
+              );
+            });
+            
+            resultException = Exception('[$apiName] 권한 없음 (403): $message');
+            break;
+          }
+        }
+        
         if (responseData != null && responseData is Map) {
           final backendCode = responseData['code'];
           final backendMessage = responseData['message']?.toString();
@@ -143,7 +182,8 @@ class ApiUtils {
           resultException = Exception('[$apiName] 서버 오류 ($statusCode): $message');
         }
         
-        if (context != null && showDialog) {
+        // 🛡️ 403 에러가 아닌 경우에만 다이얼로그 표시
+        if (context != null && showDialog && statusCode != 403) {
           ErrorDialog.showServerError(
             context,
             customMessage: message,

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -95,15 +95,41 @@ class _GeulnamuAppState extends State<GeulnamuApp> {
         // 라우트 설정 + RouteObserver 등록
         navigatorObservers: [HomeRouteService.routeObserver], // 🎯 RouteObserver 등록
         initialRoute: '/splash',
-        routes: {
-          '/splash': (context) => const SplashScreen(),
-          '/login': (context) => const LoginScreen(),
-          // '/auth/callback': (context) => const OAuthCallbackScreen(), // 주석 처리 - HTML에서 처리
-          '/home': (context) => const HomeScreen(),
-          '/profile': (context) => const ProfileScreen(), // 프로필 화면
-          '/introduction': (context) => const IntroductionScreen(), // 글나무 소개 화면
-          '/member-list': (context) => const MemberListScreen(), // 모임원 목록 화면
-          '/settings': (context) => const SettingsScreen(), // 설정 화면
+        onGenerateRoute: (settings) {
+          // 🎯 프로필 화면 라우트 처리 (쿼리 파라미터 지원)
+          if (settings.name != null && settings.name!.startsWith('/profile')) {
+            final uri = Uri.parse(settings.name!);
+            final memberId = uri.queryParameters['memberId'];
+            final mode = uri.queryParameters['mode'];
+            final returnPage = uri.queryParameters['returnPage'];
+            
+            return MaterialPageRoute(
+              builder: (context) => ProfileScreen(
+                memberId: memberId != null ? int.tryParse(memberId) : null,
+                mode: mode ?? 'self',
+                returnPage: returnPage != null ? int.tryParse(returnPage) : null,
+              ),
+              settings: settings,
+            );
+          }
+          
+          // 기본 라우트들
+          final routeMap = {
+            '/splash': (context) => const SplashScreen(),
+            '/login': (context) => const LoginScreen(),
+            '/home': (context) => const HomeScreen(),
+            '/profile': (context) => const ProfileScreen(), // 기본 프로필 (본인)
+            '/introduction': (context) => const IntroductionScreen(),
+            '/member-list': (context) => const MemberListScreen(),
+            '/settings': (context) => const SettingsScreen(),
+          };
+          
+          final builder = routeMap[settings.name];
+          if (builder != null) {
+            return MaterialPageRoute(builder: builder, settings: settings);
+          }
+          
+          return null;
         },
 
             // 404 처리

--- a/geulnamu_frontend/lib/screens/member/member_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/member/member_list_screen.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../widgets/common/main_layout.dart';
 import '../../core/theme.dart';
+import '../../core/config/app_config.dart'; // 🎯 AppConfig import 추가
 import '../../models/member/member_list_model.dart';
 import '../../services/home/home_service.dart'; // 🎯 HomeService import 추가
 import 'mixins/member_logic_mixin.dart';
@@ -181,12 +182,31 @@ class _MemberListScreenState extends State<MemberListScreen>
 
   /// 모임원 카드 탭 처리
   void _handleMemberTap(MemberListItem member) {
-    // TODO: 향후 모임원 상세보기 기능 구현
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text('${member.displayName} 상세보기 (향후 구현 예정)'),
-        duration: const Duration(seconds: 1),
-      ),
+    // 🎯 권한 체크: 관리자 이상만 접근 가능
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    
+    // ADMIN, LEADER, VICE_LEADER 만 접근 가능
+    final userRole = authProvider.userInfo?['role'] as String?;
+    final isAdminLevel = userRole != null && ['ADMIN', 'LEADER', 'VICE_LEADER'].contains(userRole);
+    
+    if (!isAdminLevel) {
+      // 권한 없음 - 아무 반응 없음 (사용자가 요청한 대로)
+      if (AppConfig.debugMode) {
+        print('🚫 [MemberListScreen] 모임원 카드 클릭 - 권한 없음 (역할: $userRole)');
+      }
+      return; // 아무 동작 안 함
+    }
+    
+    // 권한 있음 - 관리자 모드로 모임원 상세 페이지로 이동
+    if (AppConfig.debugMode) {
+      print('✅ [MemberListScreen] 모임원 카드 클릭 - 관리자 모드 접근 (ID: ${member.memberId})');
+    }
+    
+    final currentPageNum = currentPage;
+    
+    Navigator.pushNamed(
+      context,
+      '/profile?memberId=${member.memberId}&mode=admin&returnPage=$currentPageNum',
     );
   }
 }

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -55,6 +55,9 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
     // 🎯 사용자 권한에 따른 필터 표시 가능 여부 설정
     await _updateDeletedFilterPermission();
 
+    // 🎯 초기 필터 설정 (비관리자급은 활성 계정만)
+    await _setInitialFilter();
+
     await loadMemberList(isInitial: true);
   }
 
@@ -66,6 +69,25 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
     if (AppConfig.debugMode) {
       print('🔍 [MemberLogicMixin] 사용자 권한: $userRole');
       print('🔍 [MemberLogicMixin] 비활성 계정 필터 사용 가능: $_canShowDeletedFilterSync');
+    }
+  }
+
+  /// 🎯 초기 필터 설정 (비관리자급은 활성 계정만)
+  Future<void> _setInitialFilter() async {
+    final userRole = await _getUserRole();
+    final isAdminLevel = userRole != null && ['ADMIN', 'LEADER', 'VICE_LEADER'].contains(userRole);
+    
+    if (!isAdminLevel) {
+      // 비관리자급은 초기 필터에 활성 계정만 조회로 설정
+      _currentFilter = _currentFilter.copyWith(isDeleted: false);
+      
+      if (AppConfig.debugMode) {
+        print('🎨 [MemberLogicMixin] 초기 필터 설정: 비관리자급($userRole) - 활성 계정만 조회');
+      }
+    } else {
+      if (AppConfig.debugMode) {
+        print('🎨 [MemberLogicMixin] 초기 필터 설정: 관리자급($userRole) - 모든 계정 조회 가능');
+      }
     }
   }
 
@@ -84,17 +106,32 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
       _clearError();
 
       // 초기 로드 시 첫 페이지로 설정
-      final filter = isInitial 
+      var filter = isInitial 
           ? _currentFilter.copyWith(page: 1)
           : _currentFilter;
+
+      // 🎯 사용자 권한 정보 가져오기
+      final userRole = await _getUserRole();
+      
+      // 🎯 관리자급이 아닌 경우 활성 계정만 조회하도록 필터 강제 설정
+      final isAdminLevel = userRole != null && ['ADMIN', 'LEADER', 'VICE_LEADER'].contains(userRole);
+      if (!isAdminLevel) {
+        // 비관리자급은 활성 계정만 볼 수 있음
+        filter = filter.copyWith(isDeleted: false);
+        
+        if (AppConfig.debugMode) {
+          print('🚫 [MemberLogicMixin] 비관리자급 ($userRole) - 활성 계정만 조회로 제한');
+        }
+      } else {
+        if (AppConfig.debugMode) {
+          print('✅ [MemberLogicMixin] 관리자급 ($userRole) - 모든 계정 조회 가능');
+        }
+      }
 
       final accessToken = await _getAccessToken();
       if (accessToken == null) {
         throw Exception('인증 토큰을 가져올 수 없습니다.');
       }
-
-      // 🎯 사용자 권한 정보 가져오기
-      final userRole = await _getUserRole();
       
       final response = await _memberService.getMemberList(
         filter: filter,

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -49,6 +49,9 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
       print('🚀 [MemberLogicMixin] 모임원 목록 초기화 시작');
     }
 
+    // 🎯 MemberService 초기화
+    _memberService.initialize();
+
     // 🎯 사용자 권한에 따른 필터 표시 가능 여부 설정
     await _updateDeletedFilterPermission();
 

--- a/geulnamu_frontend/lib/screens/profile/mixins/profile_logic_mixin_debug.dart
+++ b/geulnamu_frontend/lib/screens/profile/mixins/profile_logic_mixin_debug.dart
@@ -2,27 +2,35 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../providers/auth_provider.dart';
 import '../../../services/profile/profile_service.dart';
+import '../../../services/member/member_service.dart'; // 🎯 MemberService 추가
 import '../../../models/profile/profile_model.dart';
 import '../../../core/utils/date_utils.dart' as app_date_utils;
 import '../../../core/config/app_config.dart';
+import '../widgets/profile_widgets.dart'; // 🎯 다이얼로그를 위해 추가
 
-/// 프로필 화면 비즈니스 로직 Mixin (디버그 강화 버전)
+/// 프로필 화면 비즈니스 로직 Mixin (디버그 강화 + 관리자 모드 지원)
 ///
 /// 제공 기능:
+/// - 본인/관리자 모드 지원
 /// - 프로필 데이터 로드/저장
-/// - 편집 모드 토글
+/// - 편집 모드 토글 (본인 모드만)
+/// - 관리자 기능: 등급/이름/상태 수정
 /// - 폼 데이터 관리 및 유효성 검증
 /// - 에러 처리
 /// - 🔍 상세 디버깅 로깅 (캐시 문제 진단용)
 mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
   // 🎯 Service 클래스 사용
   final ProfileService _profileService = ProfileService();
+  final MemberService _memberService = MemberService(); // 🎯 추가
 
   // 🎯 상태 관리
   ProfileModel? _profile;
   bool _isEditMode = false;
   bool _isLoading = false;
   bool _isSaving = false;
+  
+  // 🎯 관리자 모드 전용 상태
+  bool _isProcessingAdmin = false; // 관리자 작업 진행 중
 
   // 🎯 수정 폼 데이터
   String _editingName = '';
@@ -40,6 +48,7 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
   bool get isEditMode => _isEditMode;
   bool get isLoading => _isLoading;
   bool get isSaving => _isSaving;
+  bool get isProcessingAdmin => _isProcessingAdmin; // 🎯 추가
   String get editingName => _editingName;
   String get editingGender => _editingGender;
   DateTime? get editingBirthDate => _editingBirthDate;
@@ -47,11 +56,92 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
   TextEditingController get nameController =>
       _nameController; // 🎯 Controller getter 추가
 
+  // 🎯 위젯 속성 접근을 위한 추상 메서드들 (ProfileScreen에서 구현)
+  bool get isAdminMode;
+  bool get isSelfMode;
+  int? get targetMemberId;
+  int? get returnPage;
+
   @override
   void initState() {
     super.initState();
     _nameController = TextEditingController(); // 🎯 Controller 초기화
-    _loadProfile(); // 🎯 초기 데이터 로드
+    
+    // 🎯 MemberService 초기화
+    _memberService.initialize();
+    
+    // 🛡️ 관리자 모드 권한 검증
+    if (isAdminMode) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        _checkAdminPermission();
+      });
+    } else {
+      _loadProfile(); // 🎯 본인 모드는 바로 로드
+    }
+  }
+
+  /// 🛡️ 관리자 모드 권한 검증
+  Future<void> _checkAdminPermission() async {
+    if (!mounted) return;
+
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    
+    // 권한 검증: 임원진 이상 (STAFF, ADMIN, VICE_LEADER, LEADER)
+    if (!authProvider.isStaffLevel) {
+      if (AppConfig.debugMode) {
+        print('❌ [ProfileLogicMixinDebug] 관리자 모드 접근 권한 없음 - 홈으로 리다이렉트');
+      }
+      
+      // 권한 없음 - 홈으로 리다이렉트
+      Navigator.pushNamedAndRemoveUntil(
+        context,
+        '/home',
+        (route) => false,
+      );
+      
+      // 에러 메시지 표시
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Row(
+            children: [
+              Icon(Icons.security, color: Colors.white),
+              SizedBox(width: 8),
+              Text('모임원 관리 권한이 없습니다.'),
+            ],
+          ),
+          backgroundColor: Theme.of(context).colorScheme.error,
+          behavior: SnackBarBehavior.floating,
+          duration: const Duration(seconds: 4),
+        ),
+      );
+      
+      return;
+    }
+    
+    // 권한 있음 - 정상 로드 진행
+    if (AppConfig.debugMode) {
+      print('✅ [ProfileLogicMixinDebug] 관리자 모드 접근 권한 확인 - 데이터 로드 시작');
+    }
+    
+    if (targetMemberId != null) {
+      await _loadMemberProfile(targetMemberId!);
+    } else {
+      // targetMemberId가 null이면 잘못된 접근
+      if (mounted) {
+        Navigator.pushNamedAndRemoveUntil(
+          context,
+          '/home',
+          (route) => false,
+        );
+        
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('잘못된 접근입니다.'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
   }
 
   /// 🎯 화면에 다시 들어올 때 호출되는 메서드
@@ -59,24 +149,26 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
   /// ProfileScreen에서 RouteAware로 호출하거나,
   /// 수동으로 호출할 수 있음
   Future<void> refreshProfileData() async {
-    print('🔄 [ProfileLogicMixinDebug] refreshProfileData() 호출 - 데이터 새로고침 시작');
-
     if (AppConfig.debugMode) {
+      print('🔄 [ProfileLogicMixinDebug] refreshProfileData() 호출 - 데이터 새로고침 시작');
       print('🔄 [ProfileLogicMixinDebug] 화면 재진입 - 프로필 데이터 새로고침');
       print(
         '🔄 [ProfileLogicMixinDebug] 기존 _profile 데이터: ${_profile?.toString() ?? "null"}',
       );
     }
 
-    await _loadProfile();
+    if (isAdminMode && targetMemberId != null) {
+      await _loadMemberProfile(targetMemberId!);
+    } else {
+      await _loadProfile();
+    }
 
     if (AppConfig.debugMode) {
       print(
         '🔄 [ProfileLogicMixinDebug] 새로고침 후 _profile 데이터: ${_profile?.toString() ?? "null"}',
       );
+      print('✅ [ProfileLogicMixinDebug] refreshProfileData() 완료');
     }
-
-    print('✅ [ProfileLogicMixinDebug] refreshProfileData() 완료');
   }
 
   @override
@@ -101,8 +193,8 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
         throw Exception('로그인이 필요합니다.');
       }
 
-      final accessToken = await authProvider.accessToken; // 수정: async getter 사용
-      if (accessToken == null) {
+      final accessToken = await authProvider.accessToken; // accessToken은 async getter
+      if (accessToken == null || accessToken.isEmpty) {
         throw Exception('인증 토큰이 없습니다.');
       }
 
@@ -261,8 +353,8 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
         throw Exception('로그인이 필요합니다.');
       }
 
-      final accessToken = await authProvider.accessToken; // 수정: async getter 사용
-      if (accessToken == null) {
+      final accessToken = await authProvider.accessToken; // accessToken은 async getter
+      if (accessToken == null || accessToken.isEmpty) {
         throw Exception('인증 토큰이 없습니다.');
       }
 
@@ -405,5 +497,261 @@ mixin ProfileLogicMixinDebug<T extends StatefulWidget> on State<T> {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     authProvider.logout();
     Navigator.of(context).pushNamedAndRemoveUntil('/login', (route) => false);
+  }
+
+  // 🎯 관리자 모드 전용 메서드들
+
+  /// 특정 모임원 프로필 로드 (관리자용)
+  Future<void> _loadMemberProfile(int memberId) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = true;
+      _errors.clear();
+    });
+
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileLogicMixinDebug] 모임원 프로필 로드 시작... (ID: $memberId)');
+      }
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+
+      if (accessToken == null || accessToken.isEmpty) {
+        throw Exception('인증 토큰이 없습니다. 다시 로그인해주세요.');
+      }
+
+      final profile = await _profileService.getMemberProfile(accessToken, memberId);
+
+      if (mounted) {
+        setState(() {
+          _profile = profile;
+          _isLoading = false;
+          // 관리자 모드에서는 편집 모드 비활성화
+          _isEditMode = false;
+        });
+
+        _initializeEditingData(profile);
+
+        if (AppConfig.debugMode) {
+          print('✅ [ProfileLogicMixinDebug] 모임원 프로필 로드 성공: ${profile.displayName}');
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _profile = null;
+          _isLoading = false;
+        });
+
+        if (AppConfig.debugMode) {
+          print('❌ [ProfileLogicMixinDebug] 모임원 프로필 로드 실패: $e');
+        }
+      }
+    }
+  }
+
+  /// 모임원 이름 수정 (관리자용)
+  Future<void> handleNameEdit(String currentName) async {
+    if (!isAdminMode || targetMemberId == null) return;
+
+    final newName = await ProfileWidgets.showNameEditDialog(context, currentName);
+    if (newName == null || newName == currentName) return;
+
+    await _updateMemberName(targetMemberId!, newName);
+  }
+
+  /// 모임원 권한 변경 (관리자용)
+  Future<void> handleRoleEdit(String currentRole) async {
+    if (!isAdminMode || targetMemberId == null) return;
+
+    final newRole = await ProfileWidgets.showRoleEditDialog(context, currentRole);
+    if (newRole == null || newRole == currentRole) return;
+
+    await _updateMemberRole(targetMemberId!, newRole);
+  }
+
+  /// 모임원 상태 토글 (관리자용)
+  Future<void> handleStatusToggle(bool newStatus) async {
+    if (!isAdminMode || targetMemberId == null || _profile == null) return;
+
+    final confirmed = await ProfileWidgets.showStatusToggleDialog(
+      context,
+      _profile!,
+      newStatus,
+    );
+
+    if (confirmed != true) return;
+
+    if (newStatus) {
+      await _activateMember(targetMemberId!);
+    } else {
+      await _deactivateMember(targetMemberId!);
+    }
+  }
+
+  /// 모임원 이름 변경 API 호출
+  Future<void> _updateMemberName(int memberId, String newName) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessingAdmin = true;
+    });
+
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileLogicMixinDebug] 모임원 이름 변경 시작... (ID: $memberId, 새 이름: $newName)');
+      }
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+      
+      await _memberService.updateMemberName(memberId, newName, accessToken: accessToken);
+
+      if (mounted) {
+        // 성공 후 프로필 재로드
+        await _loadMemberProfile(memberId);
+        _showSuccessSnackBar('이름이 성공적으로 변경되었습니다.');
+
+        if (AppConfig.debugMode) {
+          print('✅ [ProfileLogicMixinDebug] 모임원 이름 변경 성공');
+        }
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [ProfileLogicMixinDebug] 모임원 이름 변경 실패: $e');
+      }
+      _showErrorDialog('이름 변경 실패', e.toString());
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessingAdmin = false;
+        });
+      }
+    }
+  }
+
+  /// 모임원 권한 변경 API 호출
+  Future<void> _updateMemberRole(int memberId, String newRole) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessingAdmin = true;
+    });
+
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileLogicMixinDebug] 모임원 권한 변경 시작... (ID: $memberId, 새 권한: $newRole)');
+      }
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+      
+      await _memberService.updateMemberRole(memberId, newRole, accessToken: accessToken);
+
+      if (mounted) {
+        // 성공 후 프로필 재로드
+        await _loadMemberProfile(memberId);
+        _showSuccessSnackBar('권한이 성공적으로 변경되었습니다.');
+
+        if (AppConfig.debugMode) {
+          print('✅ [ProfileLogicMixinDebug] 모임원 권한 변경 성공');
+        }
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [ProfileLogicMixinDebug] 모임원 권한 변경 실패: $e');
+      }
+      _showErrorDialog('권한 변경 실패', e.toString());
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessingAdmin = false;
+        });
+      }
+    }
+  }
+
+  /// 모임원 활성화 API 호출
+  Future<void> _activateMember(int memberId) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessingAdmin = true;
+    });
+
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileLogicMixinDebug] 모임원 활성화 시작... (ID: $memberId)');
+      }
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+      
+      await _memberService.activateMember(memberId, accessToken: accessToken);
+
+      if (mounted) {
+        // 성공 후 프로필 재로드
+        await _loadMemberProfile(memberId);
+        _showSuccessSnackBar('계정이 성공적으로 활성화되었습니다.');
+
+        if (AppConfig.debugMode) {
+          print('✅ [ProfileLogicMixinDebug] 모임원 활성화 성공');
+        }
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [ProfileLogicMixinDebug] 모임원 활성화 실패: $e');
+      }
+      _showErrorDialog('활성화 실패', e.toString());
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessingAdmin = false;
+        });
+      }
+    }
+  }
+
+  /// 모임원 비활성화 API 호출
+  Future<void> _deactivateMember(int memberId) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isProcessingAdmin = true;
+    });
+
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileLogicMixinDebug] 모임원 비활성화 시작... (ID: $memberId)');
+      }
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+      
+      await _memberService.deactivateMember(memberId, accessToken: accessToken);
+
+      if (mounted) {
+        // 성공 후 프로필 재로드
+        await _loadMemberProfile(memberId);
+        _showSuccessSnackBar('계정이 성공적으로 비활성화되었습니다.');
+
+        if (AppConfig.debugMode) {
+          print('✅ [ProfileLogicMixinDebug] 모임원 비활성화 성공');
+        }
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [ProfileLogicMixinDebug] 모임원 비활성화 실패: $e');
+      }
+      _showErrorDialog('비활성화 실패', e.toString());
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessingAdmin = false;
+        });
+      }
+    }
   }
 }

--- a/geulnamu_frontend/lib/screens/profile/profile_screen.dart
+++ b/geulnamu_frontend/lib/screens/profile/profile_screen.dart
@@ -24,7 +24,21 @@ import 'widgets/profile_widgets.dart';
 /// - 에러 처리 및 로딩 상태 관리
 /// - 통일된 네비게이션 및 사용자 메뉴
 class ProfileScreen extends StatefulWidget {
-  const ProfileScreen({super.key});
+  /// 조회할 모임원 ID (null이면 본인)
+  final int? memberId;
+  
+  /// 화면 모드 ('self': 본인, 'admin': 관리자)
+  final String mode;
+  
+  /// 돌아갈 페이지 번호 (모임원 목록에서 온 경우)
+  final int? returnPage;
+  
+  const ProfileScreen({
+    super.key,
+    this.memberId,
+    this.mode = 'self',
+    this.returnPage,
+  });
 
   @override
   State<ProfileScreen> createState() => _ProfileScreenState();
@@ -75,10 +89,33 @@ class _ProfileScreenState extends State<ProfileScreen>
     print('🚜 [ProfileScreen] didPop - 화면 종료');
   }
   
+  // 🎯 관리자 모드 관련 getter들
+  
+  /// 관리자 모드인지 확인
+  bool get isAdminMode => widget.mode == 'admin';
+  
+  /// 본인 모드인지 확인
+  bool get isSelfMode => widget.mode == 'self';
+  
+  /// 조회할 모임원 ID (본인 모드일 때 null)
+  int? get targetMemberId => widget.memberId;
+  
+  /// 돌아갈 페이지 번호
+  int? get returnPage => widget.returnPage;
+  
+  /// 화면 제목 결정
+  String _getScreenTitle() {
+    if (isAdminMode) {
+      return '모임원 상세';
+    } else {
+      return isEditMode ? '프로필 편집' : '프로필';
+    }
+  }
+  
   @override
   Widget build(BuildContext context) {
     return MainLayoutHelpers.sub(
-      title: isEditMode ? '프로필 편집' : '프로필',
+      title: _getScreenTitle(),
       body: _buildBody(),
       showProfileMenu: false, // 프로필 페이지에서는 사용자 메뉴 숨김
       // 🎯 편집 모드에 따른 액션 버튼들
@@ -116,7 +153,7 @@ class _ProfileScreenState extends State<ProfileScreen>
     }
     
     // ✏️ 편집/저장/취소 버튼
-    if (!isLoading && profile != null) {
+    if (!isLoading && profile != null && isSelfMode) {
       if (isEditMode) {
         // 편집 모드: 취소 + 저장 버튼
         actions.addAll([
@@ -164,13 +201,23 @@ class _ProfileScreenState extends State<ProfileScreen>
     homeService.handleLogout(context, authProvider);
   }
 
-  /// 로고 탭 핸들러 (홈으로 이동)
+  /// 로고 탭 핸들러 (모드에 따라 다른 이동)
   void _handleLogoTap() {
-    Navigator.pushNamedAndRemoveUntil(
-      context,
-      '/home',
-      (route) => false,
-    );
+    if (isAdminMode && returnPage != null) {
+      // 🎯 관리자 모드: 모임원 목록으로 돌아가기 (페이지 상태 복원)
+      Navigator.pushNamedAndRemoveUntil(
+        context,
+        '/member-list',
+        (route) => false,
+      );
+    } else {
+      // 🎯 본인 모드: 홈으로 이동
+      Navigator.pushNamedAndRemoveUntil(
+        context,
+        '/home',
+        (route) => false,
+      );
+    }
   }
 
   /// 메인 바디 빌드
@@ -185,7 +232,7 @@ class _ProfileScreenState extends State<ProfileScreen>
       return ProfileWidgets.buildErrorWidget(
         context,
         '프로필 정보를 불러올 수 없습니다.',
-        refreshProfile,
+        refreshProfileData,
       );
     }
 
@@ -247,12 +294,51 @@ class _ProfileScreenState extends State<ProfileScreen>
 
         const SizedBox(height: 24),
 
+        // 🎯 모드별 위젯 분기
+        if (isAdminMode) 
+          _buildAdminModeWidgets()
+        else
+          _buildSelfModeWidgets(),
+      ],
+    );
+  }
+
+  /// 관리자 모드 위젯들
+  Widget _buildAdminModeWidgets() {
+    return Column(
+      children: [
+        // 🎯 기본 정보 섹션 (관리자용 - 이름 수정 가능)
+        ProfileWidgets.buildAdminBasicInfoSection(
+          context,
+          profile!,
+          onNameEdit: handleNameEdit,
+          isProcessing: isProcessingAdmin,
+        ),
+
+        const SizedBox(height: 16),
+
+        // 🎯 계정 관리 섹션 (권한 및 상태 수정)
+        ProfileWidgets.buildAdminAccountInfoSection(
+          context,
+          profile!,
+          onRoleEdit: handleRoleEdit,
+          onNameEdit: handleNameEdit,
+          onStatusToggle: handleStatusToggle,
+          isProcessing: isProcessingAdmin,
+        ),
+      ],
+    );
+  }
+
+  /// 본인 모드 위젯들
+  Widget _buildSelfModeWidgets() {
+    return Column(
+      children: [
         // 🎯 기본 정보 섹션 (수정 가능)
         ProfileWidgets.buildBasicInfoSection(context, profile!),
 
         const SizedBox(height: 16),
 
-        // 🎯 계정 정보 섹션 (읽기 전용)
         ProfileWidgets.buildAccountInfoSection(context, profile!),
       ],
     );

--- a/geulnamu_frontend/lib/screens/profile/widgets/profile_widgets.dart
+++ b/geulnamu_frontend/lib/screens/profile/widgets/profile_widgets.dart
@@ -124,6 +124,228 @@ class ProfileWidgets {
     );
   }
 
+  // 🎯 관리자 모드 다이얼로그들
+
+  /// 모임원 이름 수정 다이얼로그
+  static Future<String?> showNameEditDialog(
+    BuildContext context,
+    String currentName,
+  ) async {
+    String newName = currentName;
+    final controller = TextEditingController(text: currentName);
+    String? errorText;
+
+    return showDialog<String>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('이름 수정'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: controller,
+                decoration: InputDecoration(
+                  labelText: '새로운 이름',
+                  errorText: errorText,
+                  helperText: '2-10자, 특수문자 제외',
+                  border: const OutlineInputBorder(),
+                ),
+                maxLength: 10,
+                onChanged: (value) {
+                  newName = value;
+                  // 실시간 유효성 검증
+                  setState(() {
+                    if (value.trim().isEmpty) {
+                      errorText = '이름을 입력해주세요.';
+                    } else if (value.length < 2) {
+                      errorText = '이름은 2자 이상이어야 합니다.';
+                    } else if (RegExp(r'[!@#$%^&*(),.?":{}|<>]').hasMatch(value)) {
+                      errorText = '특수문자를 사용할 수 없습니다.';
+                    } else {
+                      errorText = null;
+                    }
+                  });
+                },
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('취소'),
+            ),
+            ElevatedButton(
+              onPressed: errorText == null && newName.trim().isNotEmpty
+                  ? () => Navigator.pop(context, newName.trim())
+                  : null,
+              child: const Text('수정'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 모임원 권한 수정 다이얼로그
+  static Future<String?> showRoleEditDialog(
+    BuildContext context,
+    String currentRole,
+  ) async {
+    String selectedRole = currentRole;
+    
+    final roleOptions = [
+      {'value': 'MEMBER', 'label': '일반 회원'},
+      {'value': 'VICE_STAFF', 'label': '준운영진'},
+      {'value': 'STAFF', 'label': '운영진'},
+      {'value': 'ADMIN', 'label': '관리자'},
+      {'value': 'VICE_LEADER', 'label': '부모임장'},
+      {'value': 'LEADER', 'label': '모임장'},
+    ];
+
+    return showDialog<String>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('권한 변경'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('새로운 권한을 선택해주세요.'),
+              const SizedBox(height: 16),
+              ...roleOptions.map((role) => RadioListTile<String>(
+                title: Text(role['label']!),
+                value: role['value']!,
+                groupValue: selectedRole,
+                onChanged: (value) {
+                  setState(() {
+                    selectedRole = value!;
+                  });
+                },
+              )),
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.info_outline,
+                      size: 16,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: Text(
+                        '권한 변경 시 해당 모임원은 재로그인이 필요합니다.',
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: Theme.of(context).colorScheme.primary,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('취소'),
+            ),
+            ElevatedButton(
+              onPressed: selectedRole != currentRole
+                  ? () => Navigator.pop(context, selectedRole)
+                  : null,
+              child: const Text('변경'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 계정 상태 변경 확인 다이얼로그
+  static Future<bool?> showStatusToggleDialog(
+    BuildContext context,
+    ProfileModel profile,
+    bool newStatus, // true: 활성화, false: 비활성화
+  ) async {
+    final actionText = newStatus ? '활성화' : '비활성화';
+    final warningText = newStatus
+        ? '이 계정이 다시 활성화되어 로그인 및 모임 참여가 가능해집니다.'
+        : '이 계정이 비활성화되어 로그인 및 모임 참여가 제한됩니다.';
+
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text('$actionText 확인'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('모임원: ${profile.displayName}'),
+            const SizedBox(height: 8),
+            Text('현재 상태: ${profile.isActive ? "활성" : "비활성"}'),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: newStatus
+                    ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
+                    : Theme.of(context).colorScheme.errorContainer.withOpacity(0.3),
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    newStatus ? Icons.info_outline : Icons.warning_outlined,
+                    size: 16,
+                    color: newStatus
+                        ? Theme.of(context).colorScheme.primary
+                        : Theme.of(context).colorScheme.error,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      warningText,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: newStatus
+                            ? Theme.of(context).colorScheme.primary
+                            : Theme.of(context).colorScheme.error,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: newStatus
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.error,
+              foregroundColor: newStatus
+                  ? Theme.of(context).colorScheme.onPrimary
+                  : Theme.of(context).colorScheme.onError,
+            ),
+            child: Text(actionText),
+          ),
+        ],
+      ),
+    );
+  }
+
   /// 계정 정보 섹션 (읽기 전용)
   /// 
   /// 닉네임, 권한 표시 (수정 불가능한 필드들)
@@ -502,6 +724,315 @@ class ProfileWidgets {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  // 🎯 관리자 모드 전용 위젯들
+
+  /// 관리자용 계정 정보 섹션
+  /// 
+  /// 비활성화 계정 표시 및 인라인 수정 버튼 포함
+  static Widget buildAdminAccountInfoSection(
+    BuildContext context,
+    ProfileModel profile, {
+    required Function(String) onRoleEdit,
+    required Function(String) onNameEdit,
+    required Function(bool) onStatusToggle,
+    bool isProcessing = false,
+  }) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 섹션 제목
+            Row(
+              children: [
+                Icon(
+                  Icons.admin_panel_settings,
+                  color: Theme.of(context).colorScheme.secondary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '계정 관리',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // 닉네임 (읽기 전용)
+            _buildAdminInfoRow(
+              context,
+              label: '닉네임',
+              value: profile.nickname,
+              icon: Icons.alternate_email,
+              isReadOnly: true,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 권한 (수정 가능)
+            _buildAdminInfoRow(
+              context,
+              label: '권한',
+              value: profile.roleDisplayName,
+              icon: Icons.security,
+              onEdit: () => onRoleEdit(profile.role),
+              isProcessing: isProcessing,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 활성화 상태
+            _buildStatusSection(
+              context,
+              profile: profile,
+              onStatusToggle: onStatusToggle,
+              isProcessing: isProcessing,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 관리자용 기본 정보 섹션 (이름 수정 가능)
+  static Widget buildAdminBasicInfoSection(
+    BuildContext context,
+    ProfileModel profile, {
+    required Function(String) onNameEdit,
+    bool isProcessing = false,
+  }) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 8),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 섹션 제목
+            Row(
+              children: [
+                Icon(
+                  Icons.person,
+                  color: Theme.of(context).colorScheme.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '기본 정보',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // 이름 (수정 가능)
+            _buildAdminInfoRow(
+              context,
+              label: '이름',
+              value: profile.displayName,
+              icon: Icons.badge,
+              onEdit: () => onNameEdit(profile.name ?? ''),
+              isProcessing: isProcessing,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 성별 (읽기 전용)
+            _buildAdminInfoRow(
+              context,
+              label: '성별',
+              value: profile.genderDisplayName,
+              icon: Icons.wc,
+              isReadOnly: true,
+            ),
+
+            const SizedBox(height: 12),
+
+            // 생년월일 (읽기 전용)
+            _buildAdminInfoRow(
+              context,
+              label: '생년월일',
+              value: profile.hasBirthDate 
+                ? '${profile.displayBirthDate} (만 ${DateTime.now().year - int.parse(profile.birthDate!.substring(0, 4))}세)'
+                : '생년월일 미입력',
+              icon: Icons.cake,
+              isReadOnly: true,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 관리자용 정보 행
+  static Widget _buildAdminInfoRow(
+    BuildContext context, {
+    required String label,
+    required String value,
+    required IconData icon,
+    VoidCallback? onEdit,
+    bool isReadOnly = false,
+    bool isProcessing = false,
+  }) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        // 아이콘
+        Icon(
+          icon,
+          size: 18,
+          color: isReadOnly 
+            ? Theme.of(context).colorScheme.outline
+            : Theme.of(context).colorScheme.primary,
+        ),
+        const SizedBox(width: 12),
+
+        // 라벨
+        SizedBox(
+          width: 80,
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+
+        const SizedBox(width: 16),
+
+        // 값
+        Expanded(
+          child: Text(
+            value,
+            style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+              color: isReadOnly 
+                ? Theme.of(context).colorScheme.onSurfaceVariant
+                : Theme.of(context).colorScheme.onSurface,
+            ),
+          ),
+        ),
+
+        // 수정 버튼 또는 잠금 아이콘
+        if (isReadOnly)
+          Icon(
+            Icons.lock_outline,
+            size: 16,
+            color: Theme.of(context).colorScheme.outline,
+          )
+        else if (onEdit != null)
+          TextButton(
+            onPressed: isProcessing ? null : onEdit,
+            child: isProcessing
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('수정'),
+          ),
+      ],
+    );
+  }
+
+  /// 활성화 상태 섹션
+  static Widget _buildStatusSection(
+    BuildContext context, {
+    required ProfileModel profile,
+    required Function(bool) onStatusToggle,
+    bool isProcessing = false,
+  }) {
+    final isActive = profile.isActive;
+    
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: isActive 
+          ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
+          : Theme.of(context).colorScheme.errorContainer.withOpacity(0.3),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isActive 
+            ? Theme.of(context).colorScheme.primary.withOpacity(0.3)
+            : Theme.of(context).colorScheme.error.withOpacity(0.3),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 상태 표시
+          Row(
+            children: [
+              Icon(
+                isActive ? Icons.check_circle : Icons.warning,
+                color: isActive 
+                  ? Theme.of(context).colorScheme.primary
+                  : Theme.of(context).colorScheme.error,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isActive ? '활성 계정' : '비활성 계정',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: isActive 
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ],
+          ),
+          
+          if (!isActive) ...[
+            const SizedBox(height: 8),
+            Text(
+              '비활성화된 계정입니다. 이 계정은 로그인 및 모임 참여가 제한됩니다.',
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
+          
+          const SizedBox(height: 12),
+          
+          // 토글 버튼
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: isProcessing ? null : () => onStatusToggle(!isActive),
+              icon: isProcessing
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(isActive ? Icons.block : Icons.check_circle),
+              label: Text(isActive ? '비활성화' : '활성화'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: isActive 
+                  ? Theme.of(context).colorScheme.error
+                  : Theme.of(context).colorScheme.primary,
+                foregroundColor: isActive 
+                  ? Theme.of(context).colorScheme.onError
+                  : Theme.of(context).colorScheme.onPrimary,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -1,42 +1,258 @@
 import 'package:dio/dio.dart';
 import '../../core/config/app_config.dart';
 import '../../core/utils/api_utils.dart';
+import '../../models/profile/profile_model.dart';
 import '../../models/member/member_list_model.dart';
 
-/// 모임원 관련 API 서비스
+/// 모임원 관리 서비스 (Singleton)
 /// 
-/// 임원진 이상 권한이 필요한 모임원 관리 기능 제공
+/// 제공 기능:
+/// - 개별 모임원 조회 (관리자용)
+/// - 모임원 등급 변경
+/// - 모임원 이름 변경  
+/// - 모임원 활성화/비활성화
+/// - 모임원 목록 조회 (기존 기능 통합)
 class MemberService {
   static final MemberService _instance = MemberService._internal();
   factory MemberService() => _instance;
   MemberService._internal();
 
-  final Dio _dio = Dio();
+  final Dio _dio = Dio(); // late 제거하고 즉시 초기화
 
-  /// 모임원 목록 조회
+  /// 서비스 초기화
+  void initialize() {
+    // 기본 설정 적용
+    _dio.options.baseUrl = AppConfig.apiBaseUrl;
+    _dio.options.connectTimeout = const Duration(seconds: 5);
+    _dio.options.receiveTimeout = const Duration(seconds: 3);
+    
+    if (AppConfig.debugMode) {
+      print('🔧 [MemberService] 서비스 초기화 완료');
+    }
+  }
+
+  /// 🎯 개별 모임원 상세 조회 (관리자용)
   /// 
-  /// [filter] 필터 및 정렬 옵션
-  /// [accessToken] 인증 토큰 (임원진 이상 권한 필요)
-  /// [userRole] 사용자 권한 (운영진·준운영진은 활성 계정만 조회)
-  Future<MemberListResponse> getMemberList({
-    required MemberListFilter filter,
-    required String accessToken,
-    required String? userRole,
-  }) async {
+  /// API: GET /api/members/{memberId}
+  /// 권한: ADMIN 이상
+  Future<ProfileModel> getMemberDetail(int memberId, {String? accessToken}) async {
     try {
-      // 🎯 운영진·준운영진은 자동으로 활성 계정만 조회
-      final adjustedFilter = _adjustFilterForUserRole(filter, userRole);
-      
       if (AppConfig.debugMode) {
-        print('🚀 [모임원 목록 조회] API 요청 시작...');
-        print('🔍 [모임원 목록 조회] 사용자 권한: $userRole');
-        print('🔍 [모임원 목록 조회] 원본 필터: $filter');
-        print('🔍 [모임원 목록 조회] 조정된 필터: $adjustedFilter');
+        print('🚀 [모임원 상세 조회] API 요청 시작... (ID: $memberId)');
       }
 
       final response = await _dio.get(
-        AppConfig.getApiEndpoint('members/list'),
-        queryParameters: adjustedFilter.toQueryParameters(),
+        '/members/$memberId',
+        options: Options(
+          headers: accessToken != null ? {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          } : null,
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 상세 조회',
+        );
+
+        return ProfileModel.fromJson(processedResponse['data']);
+      } else {
+        throw Exception('[모임원 상세 조회] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        // 🛡️ context 없이 호출하나 ApiUtils에서 403 처리 안함
+        throw ApiUtils.processDioException(e, '모임원 상세 조회', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// 🎯 모임원 등급 변경
+  /// 
+  /// API: PATCH /api/members/{memberId}/role
+  /// 권한: ADMIN 이상
+  Future<void> updateMemberRole(int memberId, String newRole, {String? accessToken}) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 등급 변경] API 요청 시작... (ID: $memberId, 새 등급: $newRole)');
+      }
+
+      final response = await _dio.patch(
+        '/members/$memberId/role',
+        data: {'role': newRole},
+        options: Options(
+          headers: accessToken != null ? {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          } : null,
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 등급 변경',
+          expectData: false, // 성공 응답에 data가 없을 수 있음
+        );
+
+        if (AppConfig.debugMode) {
+          print('✅ [모임원 등급 변경] 성공: ${processedResponse['message']}');
+        }
+      } else {
+        throw Exception('[모임원 등급 변경] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임원 등급 변경', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// 🎯 모임원 이름 변경
+  /// 
+  /// API: PATCH /api/members/{memberId}/name
+  /// 권한: ADMIN 이상
+  Future<void> updateMemberName(int memberId, String newName, {String? accessToken}) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 이름 변경] API 요청 시작... (ID: $memberId, 새 이름: $newName)');
+      }
+
+      final response = await _dio.patch(
+        '/members/$memberId/name',
+        data: {'name': newName},
+        options: Options(
+          headers: accessToken != null ? {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          } : null,
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 이름 변경',
+          expectData: false,
+        );
+
+        if (AppConfig.debugMode) {
+          print('✅ [모임원 이름 변경] 성공: ${processedResponse['message']}');
+        }
+      } else {
+        throw Exception('[모임원 이름 변경] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임원 이름 변경', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// 🎯 모임원 활성화
+  /// 
+  /// API: PATCH /api/members/{memberId}/activate
+  /// 권한: ADMIN 이상
+  Future<void> activateMember(int memberId, {String? accessToken}) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 활성화] API 요청 시작... (ID: $memberId)');
+      }
+
+      final response = await _dio.patch(
+        '/members/$memberId/activate',
+        options: Options(
+          headers: accessToken != null ? {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          } : null,
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 활성화',
+          expectData: false,
+        );
+
+        if (AppConfig.debugMode) {
+          print('✅ [모임원 활성화] 성공: ${processedResponse['message']}');
+        }
+      } else {
+        throw Exception('[모임원 활성화] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임원 활성화', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// 🎯 모임원 비활성화
+  /// 
+  /// API: PATCH /api/members/{memberId}/deactivate
+  /// 권한: ADMIN 이상
+  Future<void> deactivateMember(int memberId, {String? accessToken}) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 비활성화] API 요청 시작... (ID: $memberId)');
+      }
+
+      final response = await _dio.patch(
+        '/members/$memberId/deactivate',
+        options: Options(
+          headers: accessToken != null ? {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          } : null,
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 비활성화',
+          expectData: false,
+        );
+
+        if (AppConfig.debugMode) {
+          print('✅ [모임원 비활성화] 성공: ${processedResponse['message']}');
+        }
+      } else {
+        throw Exception('[모임원 비활성화] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임원 비활성화', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
+  /// 🎯 모임원 목록 조회 (기존 기능 통합)
+  /// 
+  /// API: GET /api/members/list
+  /// 권한: STAFF 이상
+  Future<MemberListResponse> getMemberList({
+    required MemberListFilter filter,
+    required String accessToken,
+    String? userRole,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임원 목록 조회] API 요청 시작... 필터: $filter');
+      }
+
+      final response = await _dio.get(
+        '/members/list',
+        queryParameters: filter.toQueryParameters(),
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
@@ -51,15 +267,7 @@ class MemberService {
           '모임원 목록 조회',
         );
 
-        final memberListResponse = MemberListResponse.fromJson(processedResponse['data']);
-
-        if (AppConfig.debugMode) {
-          print('✅ [모임원 목록 조회] 성공: ${memberListResponse.memberList.length}명');
-          print('📄 [모임원 목록 조회] 페이지: ${memberListResponse.pagingResponse.pageNumber}/${memberListResponse.pagingResponse.totalPages}');
-          print('📄 [모임원 목록 조회] 전체 인원: ${memberListResponse.pagingResponse.totalElements}명');
-        }
-
-        return memberListResponse;
+        return MemberListResponse.fromJson(processedResponse['data']);
       } else {
         throw Exception('[모임원 목록 조회] HTTP 오류: ${response.statusCode}');
       }
@@ -71,104 +279,15 @@ class MemberService {
     }
   }
 
-  /// 특정 모임원 상세 조회 (관리자급 이상)
-  /// 
-  /// [memberId] 조회할 모임원 ID
-  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
-  /// 
-  /// 향후 구현 예정
-  Future<Map<String, dynamic>> getMemberDetail({
-    required int memberId,
-    required String accessToken,
-  }) async {
-    // TODO: 향후 구현
-    throw UnimplementedError('모임원 상세 조회 기능은 향후 구현 예정입니다.');
-  }
-
-  /// 모임원 권한 변경 (관리자급 이상)
-  /// 
-  /// [memberId] 대상 모임원 ID
-  /// [newRole] 새로운 권한
-  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
-  /// 
-  /// 향후 구현 예정
-  Future<void> updateMemberRole({
-    required int memberId,
-    required String newRole,
-    required String accessToken,
-  }) async {
-    // TODO: 향후 구현
-    throw UnimplementedError('모임원 권한 변경 기능은 향후 구현 예정입니다.');
-  }
-
-  /// 모임원 이름 변경 (관리자급 이상)
-  /// 
-  /// [memberId] 대상 모임원 ID
-  /// [newName] 새로운 이름
-  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
-  /// 
-  /// 향후 구현 예정
-  Future<void> updateMemberName({
-    required int memberId,
-    required String newName,
-    required String accessToken,
-  }) async {
-    // TODO: 향후 구현
-    throw UnimplementedError('모임원 이름 변경 기능은 향후 구현 예정입니다.');
-  }
-
-  /// 모임원 활성화/비활성화 (관리자급 이상)
-  /// 
-  /// [memberId] 대상 모임원 ID
-  /// [activate] true: 활성화, false: 비활성화
-  /// [accessToken] 인증 토큰 (관리자급 이상 권한 필요)
-  /// 
-  /// 향후 구현 예정
-  Future<void> updateMemberStatus({
-    required int memberId,
-    required bool activate,
-    required String accessToken,
-  }) async {
-    // TODO: 향후 구현
-    throw UnimplementedError('모임원 상태 변경 기능은 향후 구현 예정입니다.');
-  }
-
-  /// 사용자 권한에 따른 필터 조정
-  /// 
-  /// 운영진·준운영진은 자동으로 활성 계정만 조회하도록 필터 조정
-  MemberListFilter _adjustFilterForUserRole(MemberListFilter filter, String? userRole) {
-    // 🎯 운영진·준운영진은 항상 활성 계정만 조회
-    if (userRole == 'STAFF' || userRole == 'VICE_STAFF') {
-      return filter.copyWith(isDeleted: false);
-    }
-    
-    // 다른 권한(관리자, 부모임장, 모임장)은 원본 필터 그대로 사용
-    return filter;
-  }
-
-  /// 사용자 권한이 비활성 계정 필터를 사용할 수 있는지 확인
-  /// 
+  /// 🛡️ 비활성 계정 필터 사용 가능 여부 확인
+  ///
   /// 운영진·준운영진은 비활성 계정 필터 사용 불가
+  /// 관리자 이상만 사용 가능
   static bool canUseDeletedFilter(String? userRole) {
     if (userRole == null) return false;
     
-    // 🎯 운영진·준운영진은 비활성 계정 필터 사용 불가
-    if (userRole == 'STAFF' || userRole == 'VICE_STAFF') {
-      return false;
-    }
-    
-    // 관리자, 부모임장, 모임장은 비활성 계정 필터 사용 가능
-    return true;
-  }
-
-  /// 디버그용 - 서비스 상태 출력
-  void printServiceInfo() {
-    print('📊 === MemberService 정보 ===');
-    print('서비스: 모임원 관리');
-    print('권한: STAFF 이상 (임원진 이상)');
-    print('주요 기능: 모임원 목록 조회, 필터링, 정렬');
-    print('🆕 특별 규칙: 운영진·준운영진은 활성 계정만 조회');
-    print('🆕 필터 제한: 운영진·준운영진은 비활성 계정 필터 사용 불가');
-    print('==========================');
+    // 관리자 이상만 사용 가능
+    const adminRoles = ['ADMIN', 'VICE_LEADER', 'LEADER'];
+    return adminRoles.contains(userRole);
   }
 }

--- a/geulnamu_frontend/lib/services/profile/profile_service.dart
+++ b/geulnamu_frontend/lib/services/profile/profile_service.dart
@@ -148,6 +148,68 @@ class ProfileService {
     }
   }
 
+  /// 🎯 관리자를 위한 모임원 정보 조회
+  /// 
+  /// API: GET /api/members/{memberId}
+  /// 권한: ADMIN 이상
+  Future<ProfileModel> getMemberProfile(String accessToken, int memberId) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [ProfileService] 모임원 정보 조회 시작... (ID: $memberId)');
+      }
+
+      // 🚫 캐시 방지 전용 Dio 인스턴스 사용
+      final noCacheDio = _createNoCacheDio();
+      
+      final response = await noCacheDio.get(
+        AppConfig.getApiEndpoint('members/$memberId'),
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+            // 🚫 강력한 캐시 방지 헤더 추가
+            'Cache-Control': 'no-cache, no-store, must-revalidate',
+            'Pragma': 'no-cache',
+            'Expires': '0',
+            // 🔄 매번 다른 요청으로 인식하도록 타임스탬프 추가
+            'X-Request-Time': DateTime.now().millisecondsSinceEpoch.toString(),
+          },
+        ),
+        // 🚫 쿼리 파라미터로도 캐싱 방지
+        queryParameters: {'_t': DateTime.now().millisecondsSinceEpoch},
+      );
+
+      if (response.statusCode == 200) {
+        // ✅ ApiUtils 사용하여 백엔드 커스텀 응답 처리
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임원 정보 조회',
+        );
+
+        if (processedResponse['success']) {
+          final profileData = processedResponse['data'];
+          final profile = ProfileModel.fromJson(profileData);
+          
+          if (AppConfig.debugMode) {
+            print('✅ [ProfileService] 모임원 정보 조회 성공: ${profile.displayName}');
+          }
+          
+          return profile;
+        } else {
+          throw Exception('[모임원 정보 조회] ${processedResponse['message']}');
+        }
+      } else {
+        throw Exception('[모임원 정보 조회] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (e is DioException) {
+        // ✅ ApiUtils 사용하여 통합 에러 처리
+        throw ApiUtils.processDioException(e, '모임원 정보 조회', showDialog: false);
+      }
+      rethrow;
+    }
+  }
+
   /// 프로필 수정 데이터 유효성 검증
   /// 
   /// 백엔드 제약조건에 맞춰 검증:


### PR DESCRIPTION
# 변경 내역
## 페이지 구현
### 모임원 상세 조회 페이지 (관리자용)
- 해당 페이지 관리자급 등급(관리자, 모임장, 부모임장)만 조회 가능하도록 설정
## 기능 연동
### 모임원 상세 조회 페이지
- 모임원 이름 변경: 백엔드 API와 연동
- 모임원 등급 변경: 백엔드 API와 연동
- 모임원 활성화/비활성화: 백엔드 API와 연동