### PR TITLE
[Feat/FE] meeting detail page

### DIFF
--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AttendanceNoteRequest.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/request/AttendanceNoteRequest.java
@@ -11,7 +11,7 @@ public class AttendanceNoteRequest {
 
     @NotBlank(message = "비고 필수 입력")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_!?.,;-]{1,255}$",
-        message = "비고는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+        message = "비고는 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ ! ? . , ; -)만 1자 이상, 255자 이하로 입력해주세요.")
     private String note;
 
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingCreateRequest.java
@@ -21,7 +21,7 @@ public class MeetingCreateRequest {
 
     @NotBlank(message = "모임 제목 필수 입력")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,70}$",
-        message = "모임 제목은 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 70자 이하로 입력해주세요.")
+        message = "모임 제목은 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만 1자 이상, 70자 이하로 입력해주세요.")
     private String meetingName;    // 모임 제목
 
     @NotNull(message = "모임 개최일자 필수 입력")
@@ -35,7 +35,7 @@ public class MeetingCreateRequest {
 
     @NotBlank(message = "모임 장소 필수 입력")
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,255}$",
-        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
     private String meetingPlace;
 
     private String description;    // 상세 내용

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/request/MeetingUpdateRequest.java
@@ -17,7 +17,7 @@ public class MeetingUpdateRequest {
     private String meetingType;    // 모임 종류
 
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,70}$",
-        message = "모임 제목은 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 70자 이하로 입력해주세요.")
+        message = "모임 제목은 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만 1자 이상, 70자 이하로 입력해주세요.")
     private String meetingName;    // 모임 제목
 
     @Future(message = "모임 개최일자는 미래의 시간이어야 합니다.")
@@ -29,7 +29,7 @@ public class MeetingUpdateRequest {
     private LocalDateTime lateThresholdTime;    // 지각 기준 시간
 
     @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_-]{1,30}$",
-        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
+        message = "모임 장소는 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만 1자 이상, 255자 이하로 입력해주세요.")
     private String meetingPlace;
 
     private String description;    // 상세 내용

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingDetailResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingDetailResponse.java
@@ -1,11 +1,14 @@
 package com.geulnamu.controller.meeting.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.MeetingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -36,5 +39,10 @@ public class MeetingDetailResponse {
     private LocalDateTime discussionTime;
     private String alarmMessage;
     private Boolean wantDiscussion;
+    private DiscussionGroup discussionGroup;
+    private List<MemberIdAndNameResponse> groupMemberList;
 
+    public void updateGroupMemberList(List<MemberIdAndNameResponse> groupMemberList) {
+        this.groupMemberList = groupMemberList;
+    }
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryCustom.java
@@ -1,7 +1,6 @@
 package com.geulnamu.repository.attendance;
 
 import com.geulnamu.controller.attendance.dto.MemberInfoWithGroup;
-import com.geulnamu.controller.attendance.dto.response.DiscussionGroupResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceStatusResponse;
 import com.geulnamu.controller.attendance.dto.response.MeetingAttendanceSummaryResponse;
 import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryCustom.java
@@ -10,6 +10,6 @@ import java.util.List;
 
 public interface MeetingQueryRepositoryCustom {
     List<MemberIdAndNameResponse> findStaffList();
-    Page<MeetingInfoResponse> findMeetingsWithPagingNew(MeetingListRequest request, Long myMemberId);
+    Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId);
     MeetingDetailResponse findMeeting(Long meetingId, Long memberId);
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -95,7 +95,8 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
                 meeting.meetingDate, meeting.lateThresholdTime, meeting.meetingPlace, meeting.description,
                 meeting.createdAt,
                 attendance.id, attendanceStatusExpression(), attendance.note,
-                meeting.discussionTime, meeting.alarmMessage, attendance.wantDiscussion)
+                meeting.discussionTime, meeting.alarmMessage, attendance.wantDiscussion,
+                attendance.discussionGroup, Expressions.nullExpression(List.class))
             )
             .from(meeting)
             .leftJoin(attendance).on(meeting.id.eq(attendance.meeting.id)
@@ -145,7 +146,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
         else if(attendanceStatus.equals(AttendanceStatus.NOT_STARTED.getValue())) return meeting.meetingDate.after(LocalDateTime.now());
         else if(attendanceStatus.equals(AttendanceStatus.ATTEND.getValue())) return attendance.id.isNotNull();
         else if(attendanceStatus.equals(AttendanceStatus.ATTEND_LATE.getValue())) return attendance.createdAt.after(meeting.lateThresholdTime);
-        else return attendance.id.isNull();
+        else return meeting.meetingDate.before(LocalDateTime.now()).and(attendance.id.isNull());
     }
 
     // 기본 정렬 기준은 모임 고유번호 내림차순, 다른 정렬 기준을 사용하더라도 2차 정렬 기준은 다신 모임 고유번호 내림차순

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/meeting/MeetingQueryRepositoryImpl.java
@@ -47,7 +47,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
     }
 
     @Override
-    public Page<MeetingInfoResponse> findMeetingsWithPagingNew(MeetingListRequest request, Long myMemberId) {
+    public Page<MeetingInfoResponse> findMeetingsWithPaging(MeetingListRequest request, Long myMemberId) {
         Pageable pageable = request.toPageable();
 
         final Long totalCount = queryFactory
@@ -109,7 +109,7 @@ public class MeetingQueryRepositoryImpl implements MeetingQueryRepositoryCustom 
 
     private StringExpression attendanceStatusExpression() {
         return new CaseBuilder()
-            .when(meeting.meetingDate.after(LocalDateTime.now()))
+            .when(meeting.meetingDate.after(LocalDateTime.now()).and(attendance.id.isNull()))
             .then(AttendanceStatus.NOT_STARTED.getValue())
             .when(attendance.id.isNull())
             .then(AttendanceStatus.NOT_ATTEND.getValue())

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -80,8 +80,7 @@ public class AttendanceService {
     @Transactional(readOnly = true)
     public List<MemberIdAndNameResponse> getMyDiscussionMemberList(Long attendanceId, Long memberId) {
         Attendance attendance = getValidateAttendance(attendanceId, memberId);
-        return attendanceQueryRepository.findMyDiscussionMemberList(attendance.getMeeting().getId(),
-            attendance.getDiscussionGroup());
+        return getDiscussionGroupMembers(attendance);
     }
 
     @Transactional(readOnly = true)

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -3,6 +3,7 @@ package com.geulnamu.service.meeting;
 import com.geulnamu.controller.meeting.dto.request.*;
 import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
+import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.enums.DomainType;
@@ -11,6 +12,7 @@ import com.geulnamu.infrastructure.exception.BadRequestException;
 import com.geulnamu.infrastructure.exception.NotFoundDataException;
 import com.geulnamu.infrastructure.response.ResponseMessage;
 import com.geulnamu.infrastructure.response.paging.PagingResponse;
+import com.geulnamu.repository.attendance.AttendanceQueryRepository;
 import com.geulnamu.repository.meeting.MeetingQueryRepository;
 import com.geulnamu.repository.meeting.MeetingCommandRepository;
 import com.geulnamu.repository.member.MemberQueryRepository;
@@ -28,6 +30,7 @@ public class MeetingService {
     private final MemberQueryRepository memberQueryRepository;
     private final MeetingQueryRepository meetingQueryRepository;
     private final MeetingCommandRepository meetingCommandRepository;
+    private final AttendanceQueryRepository attendanceQueryRepository;
 
 
     @Transactional(rollbackFor = Exception.class)
@@ -56,9 +59,22 @@ public class MeetingService {
     }
 
     @Transactional(readOnly = true)
-    public MeetingDetailResponse getMeeting(Long meetingId, Long memberId) {
+    public MeetingDetailResponse getMeeting_original(Long meetingId, Long memberId) {
         Meeting meeting = findMeetingOrThrow(meetingId);
         return meetingQueryRepository.findMeeting(meeting.getId(), memberId);
+    }
+
+    // TODO: 추후 쿼리 하나로 다 뽑아내도록 개선할 것!
+    @Transactional(readOnly = true)
+    public MeetingDetailResponse getMeeting(Long meetingId, Long memberId) {
+        Meeting meeting = findMeetingOrThrow(meetingId);
+        MeetingDetailResponse meetingDetailResponse = meetingQueryRepository.findMeeting(meeting.getId(), memberId);
+        if(meetingDetailResponse.getAttendanceId() != null) {
+            List<MemberIdAndNameResponse> groupMemberList = attendanceQueryRepository.findMyDiscussionMemberList(
+                meetingDetailResponse.getMeetingId(), meetingDetailResponse.getDiscussionGroup());
+            meetingDetailResponse.updateGroupMemberList(groupMemberList);
+        }
+        return meetingDetailResponse;
     }
 
     @Transactional(readOnly = true)

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -69,7 +69,7 @@ public class MeetingService {
     public MeetingDetailResponse getMeeting(Long meetingId, Long memberId) {
         Meeting meeting = findMeetingOrThrow(meetingId);
         MeetingDetailResponse meetingDetailResponse = meetingQueryRepository.findMeeting(meeting.getId(), memberId);
-        if(meetingDetailResponse.getAttendanceId() != null) {
+        if(meetingDetailResponse.getDiscussionGroup() != null) {
             List<MemberIdAndNameResponse> groupMemberList = attendanceQueryRepository.findMyDiscussionMemberList(
                 meetingDetailResponse.getMeetingId(), meetingDetailResponse.getDiscussionGroup());
             meetingDetailResponse.updateGroupMemberList(groupMemberList);

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -3,7 +3,6 @@ package com.geulnamu.service.meeting;
 import com.geulnamu.controller.meeting.dto.request.*;
 import com.geulnamu.controller.meeting.dto.response.*;
 import com.geulnamu.controller.shared.dto.response.MemberIdAndNameResponse;
-import com.geulnamu.domain.attendance.Attendance;
 import com.geulnamu.domain.meeting.Meeting;
 import com.geulnamu.domain.member.Member;
 import com.geulnamu.domain.shared.enums.DomainType;
@@ -51,7 +50,7 @@ public class MeetingService {
 
     @Transactional(readOnly = true)
     public MeetingListResponse getMeetingList(Long myMemberId, MeetingListRequest request) {
-        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPagingNew(request, myMemberId);
+        Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(request, myMemberId);
 
         PagingResponse pagingResponse = PagingResponse.from(meetingDslList);
         List<MeetingInfoResponse> meetingList = meetingDslList.getContent();

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -251,7 +251,7 @@ public class AttendanceControllerTest extends ControllerTest {
                     headerWithName("Authorization").description("액세스 토큰")
                 ),
                 requestFields(
-                    fieldWithPath("note").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("비고(출석 관련 사유 작성)")
+                    fieldWithPath("note").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ ! ? . , ; -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("비고(출석 관련 사유 작성)")
                 ),
                 responseFields(
                     fieldWithPath("code").type(JsonFieldType.NUMBER).description("결과 코드"),

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -85,10 +85,10 @@ public class MeetingControllerTest extends ControllerTest {
                 ),
                 requestFields(
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류"),
-                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목"),
+                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하")).description("모임 제목"),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자"),
                     fieldWithPath("lateThresholdTime").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("지각 기준 시간(모임 개최일자보다 빠르면 안 됨. 입력 안 할 시 모임 개최시간과 동일값 처리)").optional(),
-                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소"),
+                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하")).description("모임 장소"),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),
                 responseFields(
@@ -397,10 +397,10 @@ public class MeetingControllerTest extends ControllerTest {
                 ),
                 requestFields(
                     fieldWithPath("meetingType").type(JsonFieldType.STRING).attributes(key("format").value("'REGULAR', 'FLASH', 'SPECIAL' 중 하나의 값")).description("모임 종류").optional(),
-                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하의 문자열")).description("모임 제목").optional(),
+                    fieldWithPath("meetingName").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 70자 이하의 문자열")).description("모임 제목").optional(),
                     fieldWithPath("meetingDate").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("모임 개최일자").optional(),
                     fieldWithPath("lateThresholdTime").type(JsonFieldType.STRING).attributes(key("format").value("yyyyMMdd HH:mm 형식으로 이뤄진 미래 시간대의 문자열")).description("지각 기준 시간(모임 개최 시간보다 빠르면 안 됨)").optional(),
-                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수분자(: / [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("모임 장소").optional(),
+                    fieldWithPath("meetingPlace").type(JsonFieldType.STRING).attributes(key("format").value("한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ -)만으로 사용한 1자 이상, 255자 이하의 문자열")).description("모임 장소").optional(),
                     fieldWithPath("description").type(JsonFieldType.STRING).attributes(key("format").value("형식, 길이 제한 없는 문자열")).description("상세 내용").optional()
                 ),
                 responseFields(

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/meeting/MeetingControllerTest.java
@@ -241,7 +241,8 @@ public class MeetingControllerTest extends ControllerTest {
             LocalDateTime.of(2025, 5, 31, 10, 45), "추후 공지 예정 (합정역 주변 카페)",
             "~~", LocalDateTime.of(2025, 5, 1, 12, 0),
             5L, "~~", "저 안 늦었어요",
-            LocalDateTime.of(2025, 5, 12, 12, 0), null, true
+            LocalDateTime.of(2025, 5, 12, 12, 0), null, true,
+            null, null
         );
 
         given(meetingService.getMeeting(any(), any())).willReturn(meetingDetailResponse_01);
@@ -288,7 +289,11 @@ public class MeetingControllerTest extends ControllerTest {
                     fieldWithPath("data.note").type(JsonFieldType.STRING).description("출석 비고").optional(),
                     fieldWithPath("data.discussionTime").type(JsonFieldType.STRING).description("토론 시간").optional(),
                     fieldWithPath("data.alarmMessage").type(JsonFieldType.STRING).description("토론 시작 알림 메세지").optional(),
-                    fieldWithPath("data.wantDiscussion").type(JsonFieldType.BOOLEAN).description("비공개 여부").optional()
+                    fieldWithPath("data.wantDiscussion").type(JsonFieldType.BOOLEAN).description("비공개 여부").optional(),
+                    fieldWithPath("data.discussionGroup").type(JsonFieldType.STRING).description("토론 조").optional(),
+                    fieldWithPath("data.groupMemberList").type(JsonFieldType.ARRAY).description("같은 토론 조 리스트").optional(),
+                    fieldWithPath("data.groupMemberList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호").optional(),
+                    fieldWithPath("data.groupMemberList[].memberName").type(JsonFieldType.STRING).description("모임원 이름").optional()
                 )
             ));
     }

--- a/geulnamu_frontend/lib/core/utils/api_utils.dart
+++ b/geulnamu_frontend/lib/core/utils/api_utils.dart
@@ -10,36 +10,43 @@ import '../../widgets/common/error_dialog.dart';
 class ApiUtils {
   // ⏰ API 타임아웃 설정 (초 단위)
   static const int connectionTimeoutSeconds = 5;
-  static const int receiveTimeoutSeconds = 3;  // 적절한 사용자 경험을 위한 3초 설정
+  static const int receiveTimeoutSeconds = 3; // 적절한 사용자 경험을 위한 3초 설정
   static const int sendTimeoutSeconds = 5;
 
-  /// 🔧 타임아웃이 설정된 Dio 인스턴스 생성
+  /// 🔧 타임아웃이 설정된 Dio 인스턴스 생성 (캐시 무효화 포함)
   static Dio createDioWithTimeout({
     String? baseUrl,
     Map<String, String>? headers,
   }) {
-    final dio = Dio(BaseOptions(
-      baseUrl: baseUrl ?? AppConfig.apiBaseUrl,
-      connectTimeout: Duration(seconds: connectionTimeoutSeconds),
-      receiveTimeout: Duration(seconds: receiveTimeoutSeconds),
-      sendTimeout: Duration(seconds: sendTimeoutSeconds),
-      headers: headers,
-    ));
+    final dio = Dio(
+      BaseOptions(
+        baseUrl: baseUrl ?? AppConfig.apiBaseUrl,
+        connectTimeout: Duration(seconds: connectionTimeoutSeconds),
+        receiveTimeout: Duration(seconds: receiveTimeoutSeconds),
+        sendTimeout: Duration(seconds: sendTimeoutSeconds),
+        headers: headers,
+      ),
+    );
 
+    // 🆕 글로벌 캐시 무효화 인터셉터 추가
+    dio.interceptors.add(_CacheControlInterceptor());
 
+    // 🆕 디버그 모드에서 요청/응답 로깅 인터셉터 추가
+    if (AppConfig.debugMode) {
+      dio.interceptors.add(_DebugLoggingInterceptor());
+    }
 
     return dio;
   }
+
   /// 🔧 백엔드 커스텀 응답 구조 통합 처리 메서드
   static Map<String, dynamic> processBackendResponse(
-    Response response, 
-    String apiName,
-    {bool expectData = true}
-  ) {
-
-
+    Response response,
+    String apiName, {
+    bool expectData = true,
+  }) {
     final data = response.data;
-    
+
     if (data is! Map) {
       throw Exception('[$apiName] 백엔드 응답 형식이 올바르지 않습니다: $data');
     }
@@ -47,12 +54,8 @@ class ApiUtils {
     final responseCode = data['code'];
     final responseMessage = data['message'] ?? '알 수 없는 오류';
     final responseData = data['data'];
-    
 
-    
     if (responseCode == 200) {
-
-      
       return {
         'success': true,
         'code': responseCode,
@@ -66,36 +69,30 @@ class ApiUtils {
 
   /// 통합 DioException 처리 메서드 (에러 다이얼로그 포함)
   static Exception processDioException(
-    DioException e, 
+    DioException e,
     String apiName, {
     BuildContext? context,
     bool showDialog = true,
   }) {
-
-
     Exception resultException;
-    
+
     switch (e.type) {
       case DioExceptionType.connectionTimeout:
       case DioExceptionType.sendTimeout:
       case DioExceptionType.receiveTimeout:
-
         resultException = Exception('[$apiName] 서버 연결 시간이 초과되었습니다.');
         if (context != null && showDialog) {
           ErrorDialog.showTimeoutError(context);
         }
         break;
-        
+
       case DioExceptionType.badResponse:
         final statusCode = e.response?.statusCode ?? 0;
         final responseData = e.response?.data;
         String message = '서버 오류가 발생했습니다.';
-        
 
-        
         // 460 비활성화 계정 특별 처리
         if (statusCode == 460) {
-          
           // 🏠 메인 화면으로 리다이렉트 후 다이얼로그 표시
           if (context != null) {
             Future.microtask(() {
@@ -105,22 +102,22 @@ class ApiUtils {
                 '/home',
                 (route) => false,
               );
-              
+
               // 짧은 딸레이 후 다이얼로그 표시 (화면 전환 완료 대기)
               Future.delayed(const Duration(milliseconds: 300), () {
                 ErrorDialog.showAccountDeactivatedError(context);
               });
             });
           }
-          
+
           resultException = Exception('[$apiName] 비활성화된 계정입니다.');
           break;
         }
-        
+
         // 403 금지된 접근 특별 처리
         if (statusCode == 403) {
           message = '접근 권한이 없습니다.';
-          
+
           // 관리자 모드 관련 API인 경우 특별 처리
           if (apiName.contains('모임원') && context != null && showDialog) {
             // 비동기로 홈으로 리다이렉트
@@ -130,7 +127,7 @@ class ApiUtils {
                 '/home',
                 (route) => false,
               );
-              
+
               ScaffoldMessenger.of(context).showSnackBar(
                 SnackBar(
                   content: const Row(
@@ -146,33 +143,39 @@ class ApiUtils {
                 ),
               );
             });
-            
+
             resultException = Exception('[$apiName] 권한 없음 (403): $message');
             break;
           }
         }
-        
+
         if (responseData != null && responseData is Map) {
           final backendCode = responseData['code'];
           final backendMessage = responseData['message']?.toString();
-          
+
           if (AppConfig.debugMode) {
             print('백엔드 코드: $backendCode');
             print('백엔드 메시지: $backendMessage');
           }
-          
+
           if (backendMessage != null && backendMessage.isNotEmpty) {
             message = backendMessage;
           }
-          
-          resultException = Exception('[$apiName] 백엔드 오류 (HTTP: $statusCode, 코드: $backendCode): $message');
+
+          resultException = Exception(
+            '[$apiName] 백엔드 오류 (HTTP: $statusCode, 코드: $backendCode): $message',
+          );
         } else if (responseData is String) {
           message = responseData;
-          resultException = Exception('[$apiName] 서버 오류 ($statusCode): $message');
+          resultException = Exception(
+            '[$apiName] 서버 오류 ($statusCode): $message',
+          );
         } else {
-          resultException = Exception('[$apiName] 서버 오류 ($statusCode): $message');
+          resultException = Exception(
+            '[$apiName] 서버 오류 ($statusCode): $message',
+          );
         }
-        
+
         // 403 에러가 아닌 경우에만 다이얼로그 표시
         if (context != null && showDialog && statusCode != 403) {
           ErrorDialog.showServerError(
@@ -182,27 +185,33 @@ class ApiUtils {
           );
         }
         break;
-        
+
       case DioExceptionType.connectionError:
         resultException = Exception('[$apiName] 서버에 연결할 수 없습니다.');
         if (context != null && showDialog) {
           ErrorDialog.showNetworkError(context);
         }
         break;
-        
+
       case DioExceptionType.cancel:
         resultException = Exception('[$apiName] 요청이 취소되었습니다.');
         // 취소는 사용자 의도이므로 다이얼로그 표시 안함
         break;
-        
+
       default:
-        resultException = Exception('[$apiName] 네트워크 오류가 발생했습니다: ${e.message ?? '알 수 없는 오류'}');
+        resultException = Exception(
+          '[$apiName] 네트워크 오류가 발생했습니다: ${e.message ?? '알 수 없는 오류'}',
+        );
         if (context != null && showDialog) {
-          ErrorDialog.showErrorFromException(context, resultException, apiName: apiName);
+          ErrorDialog.showErrorFromException(
+            context,
+            resultException,
+            apiName: apiName,
+          );
         }
         break;
     }
-    
+
     return resultException;
   }
 
@@ -213,25 +222,21 @@ class ApiUtils {
       try {
         final cookies = html.document.cookie ?? '';
         final cookieParts = cookies.split(';');
-        
+
         for (final cookiePart in cookieParts) {
           final trimmed = cookiePart.trim();
           if (trimmed.startsWith('refreshToken=')) {
             final token = trimmed.substring('refreshToken='.length);
-            
 
-            
             return token;
           }
         }
-        
-
       } catch (e) {
         // 브라우저 쿠키 읽기 오류 무시
       }
       return null;
     }
-    
+
     // 비웹 환경: Response 헤더에서 찾기
     final setCookieHeader = response.headers['set-cookie'];
     if (setCookieHeader != null) {
@@ -239,14 +244,80 @@ class ApiUtils {
         if (cookie.startsWith('refreshToken=')) {
           final tokenPart = cookie.split(';')[0];
           final token = tokenPart.split('=')[1];
-          
 
-          
           return token;
         }
       }
     }
-    
+
     return null;
+  }
+}
+
+/// 📄 캐시 제어 인터셉터
+/// 모든 GET 요청에 자동으로 캐시 무효화 헤더 추가
+class _CacheControlInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // GET 요청에만 캐시 제어 헤더 추가
+    if (options.method.toUpperCase() == 'GET') {
+      options.headers.addAll({
+        'Cache-Control': 'no-cache, no-store, must-revalidate',
+        'Pragma': 'no-cache',
+        'Expires': '0',
+        // 타임스탬프를 추가하여 URL을 고유하게 만들기
+        if (!options.queryParameters.containsKey('_t'))
+          '_t': DateTime.now().millisecondsSinceEpoch.toString(),
+      });
+
+      if (AppConfig.debugMode) {
+        print('📋 [캐시 무효화] ${options.method} ${options.path} - 캐시 제어 헤더 추가');
+      }
+    }
+
+    super.onRequest(options, handler);
+  }
+}
+
+/// 🔍 디버깅 로깅 인터셉터
+/// 디버그 모드에서 API 요청/응답 상세 로깅
+class _DebugLoggingInterceptor extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    print('[API 요청] ${options.method} ${options.uri}');
+    print('📝 [요청 헤더] ${options.headers}');
+    if (options.data != null) {
+      print('📊 [요청 데이터] ${options.data}');
+    }
+    print('──────────────────────────────');
+    super.onRequest(options, handler);
+  }
+
+  @override
+  void onResponse(Response response, ResponseInterceptorHandler handler) {
+    print('✅ [API 응답] ${response.statusCode} ${response.requestOptions.uri}');
+    print('📝 [응답 헤더] ${response.headers}');
+    if (response.data != null) {
+      final dataStr = response.data.toString();
+      if (dataStr.length > 500) {
+        print('📊 [응답 데이터] ${dataStr.substring(0, 500)}...(truncated)');
+      } else {
+        print('📊 [응답 데이터] $dataStr');
+      }
+    }
+    print('──────────────────────────────\n');
+    super.onResponse(response, handler);
+  }
+
+  @override
+  void onError(DioException err, ErrorInterceptorHandler handler) {
+    print('❌ [API 오류] ${err.requestOptions.method} ${err.requestOptions.uri}');
+    print('🛠️ [오류 타입] ${err.type}');
+    print('📝 [오류 메시지] ${err.message}');
+    if (err.response != null) {
+      print('📊 [오류 응답] ${err.response?.data}');
+    }
+    print('──────────────────────────────\n');
+    super.onError(err, handler);
   }
 }

--- a/geulnamu_frontend/lib/core/utils/api_utils.dart
+++ b/geulnamu_frontend/lib/core/utils/api_utils.dart
@@ -286,7 +286,6 @@ class _DebugLoggingInterceptor extends Interceptor {
   @override
   void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
     print('[API 요청] ${options.method} ${options.uri}');
-    print('📝 [요청 헤더] ${options.headers}');
     if (options.data != null) {
       print('📊 [요청 데이터] ${options.data}');
     }
@@ -297,7 +296,6 @@ class _DebugLoggingInterceptor extends Interceptor {
   @override
   void onResponse(Response response, ResponseInterceptorHandler handler) {
     print('✅ [API 응답] ${response.statusCode} ${response.requestOptions.uri}');
-    print('📝 [응답 헤더] ${response.headers}');
     if (response.data != null) {
       final dataStr = response.data.toString();
       if (dataStr.length > 500) {

--- a/geulnamu_frontend/lib/core/utils/api_utils.dart
+++ b/geulnamu_frontend/lib/core/utils/api_utils.dart
@@ -271,7 +271,7 @@ class _CacheControlInterceptor extends Interceptor {
       });
 
       if (AppConfig.debugMode) {
-        print('📋 [캐시 무효화] ${options.method} ${options.path} - 캐시 제어 헤더 추가');
+        print('📅 [캐시 무효화] ${options.method} ${options.path}');
       }
     }
 

--- a/geulnamu_frontend/lib/core/utils/api_utils.dart
+++ b/geulnamu_frontend/lib/core/utils/api_utils.dart
@@ -23,7 +23,8 @@ class ApiUtils {
         baseUrl: baseUrl ?? AppConfig.apiBaseUrl,
         connectTimeout: Duration(seconds: connectionTimeoutSeconds),
         receiveTimeout: Duration(seconds: receiveTimeoutSeconds),
-        sendTimeout: Duration(seconds: sendTimeoutSeconds),
+        // 🌐 Flutter Web에서 sendTimeout 경고 방지
+        sendTimeout: kIsWeb ? null : Duration(seconds: sendTimeoutSeconds),
         headers: headers,
       ),
     );

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -28,6 +28,8 @@ import 'screens/settings_screen.dart'; // 설정 화면
 import 'services/home/home_route_service.dart'; // 🎯 RouteObserver import
 import 'services/meeting/meeting_service.dart'; // 🆕 모임 서비스
 import 'services/attendance/attendance_service.dart'; // 🆕 출석 서비스
+import 'services/member/member_service.dart'; // 🆕 모임원 서비스
+import 'services/profile/profile_service.dart'; // 🆕 프로필 서비스
 
 // 🎯 Global Navigator Key - 전역에서 접근 가능
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -43,9 +45,11 @@ void main() async {
     // 카카오 SDK 초기화
     KakaoConfig.initialize();
 
-    // 서비스 초기화
-    MeetingService().initialize();
-    AttendanceService().initialize();
+    // 🎯 서비스 초기화 - Singleton 인스턴스 생성 (생성자에서 자동 초기화)
+    MeetingService(); // Singleton 인스턴스 생성
+    AttendanceService(); // Singleton 인스턴스 생성
+    MemberService(); // Singleton 인스턴스 생성
+    ProfileService(); // Singleton 인스턴스 생성
 
     // 앱 설정 정보 출력 (디버그용)
     AppConfig.printConfig();

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -23,6 +23,7 @@ import 'screens/member/member_list_screen.dart'; // 모임원 목록 화면
 import 'screens/meeting/meeting_list_screen.dart'; // 모임 목록 화면
 import 'screens/meeting/meeting_list_staff_screen.dart'; // 🆕 운영진용 모임 목록 화면
 import 'screens/meeting/meeting_create_screen.dart'; // 🆕 모임 만들기 화면
+import 'screens/meeting/meeting_detail_screen.dart'; // 🆕 모임 상세 화면
 import 'screens/settings_screen.dart'; // 설정 화면
 import 'services/home/home_route_service.dart'; // 🎯 RouteObserver import
 
@@ -106,6 +107,18 @@ class _GeulnamuAppState extends State<GeulnamuApp> {
           final uri = Uri.parse(settings.name!);
           final path = uri.path; // 쿼리 파라미터 제외한 순수 경로
           final queryParams = uri.queryParameters;
+          
+          // 🎯 동적 경로 처리 (모임 상세)
+          if (path.startsWith('/meeting/') && path.split('/').length == 3) {
+            final meetingIdStr = path.split('/')[2];
+            final meetingId = int.tryParse(meetingIdStr);
+            if (meetingId != null) {
+              return MaterialPageRoute(
+                builder: (context) => MeetingDetailScreen(meetingId: meetingId),
+                settings: settings,
+              );
+            }
+          }
           
           // 🎯 정확한 라우트 매칭 시스템
           switch (path) {

--- a/geulnamu_frontend/lib/main.dart
+++ b/geulnamu_frontend/lib/main.dart
@@ -26,6 +26,8 @@ import 'screens/meeting/meeting_create_screen.dart'; // 🆕 모임 만들기 �
 import 'screens/meeting/meeting_detail_screen.dart'; // 🆕 모임 상세 화면
 import 'screens/settings_screen.dart'; // 설정 화면
 import 'services/home/home_route_service.dart'; // 🎯 RouteObserver import
+import 'services/meeting/meeting_service.dart'; // 🆕 모임 서비스
+import 'services/attendance/attendance_service.dart'; // 🆕 출석 서비스
 
 // 🎯 Global Navigator Key - 전역에서 접근 가능
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -40,6 +42,10 @@ void main() async {
 
     // 카카오 SDK 초기화
     KakaoConfig.initialize();
+
+    // 서비스 초기화
+    MeetingService().initialize();
+    AttendanceService().initialize();
 
     // 앱 설정 정보 출력 (디버그용)
     AppConfig.printConfig();

--- a/geulnamu_frontend/lib/models/attendance/request/attendance_note_request.dart
+++ b/geulnamu_frontend/lib/models/attendance/request/attendance_note_request.dart
@@ -1,0 +1,77 @@
+/// 비고 작성 요청 모델
+/// 
+/// 백엔드 AttendanceNoteRequest와 매핑
+/// PATCH /attendances/{attendanceId}/note API 요청용
+class AttendanceNoteRequest {
+  /// 비고 내용
+  /// 
+  /// 제약조건:
+  /// - 필수 입력 (NotBlank)
+  /// - 한글, 영문, 숫자, 공백 및 일부 특수문자만 허용
+  /// - 허용 특수문자: : / @ [ ] ( ) ~ _ ! ? . , ; -
+  /// - 1자 이상 255자 이하
+  final String note;
+
+  const AttendanceNoteRequest({
+    required this.note,
+  });
+
+  /// JSON으로 변환
+  Map<String, dynamic> toJson() {
+    return {
+      'note': note,
+    };
+  }
+
+  /// JSON에서 객체 생성
+  factory AttendanceNoteRequest.fromJson(Map<String, dynamic> json) {
+    return AttendanceNoteRequest(
+      note: json['note'] as String,
+    );
+  }
+
+  /// 비고 내용 유효성 검사
+  /// 
+  /// 백엔드 Pattern 제약조건과 동일:
+  /// ^[ㄱ-ㅎ가-힣a-zA-Z0-9\\s:/@\\[\\]()~_!?.,;-]{1,255}$
+  bool isValid() {
+    if (note.trim().isEmpty) return false;
+    if (note.length > 255) return false;
+    
+    // 정규식 패턴 검사
+    final pattern = RegExp(r'^[ㄱ-ㅎ가-힣a-zA-Z0-9\s:/@\[\]()~_!?.,;-]{1,255}$');
+    return pattern.hasMatch(note);
+  }
+
+  /// 유효성 검사 에러 메시지 반환
+  String? getValidationError() {
+    if (note.trim().isEmpty) {
+      return '비고를 입력해주세요.';
+    }
+    
+    if (note.length > 255) {
+      return '비고는 255자 이하로 입력해주세요.';
+    }
+    
+    final pattern = RegExp(r'^[ㄱ-ㅎ가-힣a-zA-Z0-9\s:/@\[\]()~_!?.,;-]{1,255}$');
+    if (!pattern.hasMatch(note)) {
+      return '비고는 한글, 영문, 숫자, 공백 및 일부 특수문자(: / @ [ ] ( ) ~ _ ! ? . , ; -)만 사용할 수 있습니다.';
+    }
+    
+    return null; // 유효함
+  }
+
+  @override
+  String toString() {
+    return 'AttendanceNoteRequest{note: $note}';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is AttendanceNoteRequest && other.note == note;
+  }
+
+  @override
+  int get hashCode => note.hashCode;
+}

--- a/geulnamu_frontend/lib/models/meeting/group_member_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/group_member_model.dart
@@ -1,0 +1,44 @@
+/// 토론 조 구성원 모델
+/// 
+/// 백엔드 MemberIdAndNameResponse와 매핑
+class GroupMember {
+  final int memberId;
+  final String memberName;
+
+  const GroupMember({
+    required this.memberId,
+    required this.memberName,
+  });
+
+  /// JSON에서 객체 생성
+  factory GroupMember.fromJson(Map<String, dynamic> json) {
+    return GroupMember(
+      memberId: json['memberId'] as int,
+      memberName: json['memberName'] as String,
+    );
+  }
+
+  /// 객체를 JSON으로 변환
+  Map<String, dynamic> toJson() {
+    return {
+      'memberId': memberId,
+      'memberName': memberName,
+    };
+  }
+
+  @override
+  String toString() {
+    return 'GroupMember{memberId: $memberId, memberName: $memberName}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is GroupMember &&
+          runtimeType == other.runtimeType &&
+          memberId == other.memberId &&
+          memberName == other.memberName;
+
+  @override
+  int get hashCode => memberId.hashCode ^ memberName.hashCode;
+}

--- a/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
@@ -141,9 +141,9 @@ class MeetingDetailInfo {
     return DateFormat('HH:mm').format(meetingDateTime);
   }
 
-  /// 지각 기준 시간 표시 (HH:mm)
+  /// 지각 기준 시간 표시 (yyyy.MM.dd HH:mm)
   String get displayLateThresholdTime {
-    return DateFormat('HH:mm').format(lateThresholdTime);
+    return DateFormat('yyyy.MM.dd HH:mm').format(lateThresholdTime);
   }
 
   /// 토론 시간 표시 (HH:mm) - 시간만 표시
@@ -152,9 +152,9 @@ class MeetingDetailInfo {
     return DateFormat('HH:mm').format(discussionTime!);
   }
 
-  /// 모임 개설일자 표시 (yyyy.MM.dd)
+  /// 모임 개설일자 표시 (yyyy.MM.dd HH:mm)
   String get displayCreatedAt {
-    return DateFormat('yyyy.MM.dd').format(createdAt);
+    return DateFormat('yyyy.MM.dd HH:mm').format(createdAt);
   }
 
   /// 출석 상태 표시명

--- a/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
@@ -59,12 +59,18 @@ class MeetingDetailInfo {
       final meetingDetail = MeetingDetailInfo(
         // 모임 관련
         meetingId: _parseIntSafely(json['meetingId'], '모임ID'),
-        meetingCreatorName: _parseStringSafely(json['meetingCreatorName'], '개설자명'),
+        meetingCreatorName: _parseStringSafely(
+          json['meetingCreatorName'],
+          '개설자명',
+        ),
         meetingCreatorId: _parseIntSafely(json['meetingCreatorId'], '개설자ID'),
         meetingType: _parseStringSafely(json['meetingType'], '모임유형'),
         meetingName: _parseStringSafely(json['meetingName'], '모임제목'),
         meetingDateTime: _parseDateTimeSafely(json['meetingDateTime'], '모임일시'),
-        lateThresholdTime: _parseDateTimeSafely(json['lateThresholdTime'], '지각기준시간'),
+        lateThresholdTime: _parseDateTimeSafely(
+          json['lateThresholdTime'],
+          '지각기준시간',
+        ),
         meetingPlace: _parseStringSafely(json['meetingPlace'], '모임장소'),
         description: _parseStringSafely(json['description'], '모임설명'),
         createdAt: _parseDateTimeSafely(json['createdAt'], '모임개설일자'),
@@ -78,7 +84,7 @@ class MeetingDetailInfo {
         wantDiscussion: _parseBoolNullable(json['wantDiscussion']),
         groupMemberList: _parseGroupMemberList(json['groupMemberList']),
       );
-      
+
       return meetingDetail;
     } catch (e) {
       if (AppConfig.debugMode) {
@@ -111,7 +117,9 @@ class MeetingDetailInfo {
       'discussionTime': discussionTime?.toIso8601String(),
       'alarmMessage': alarmMessage,
       'wantDiscussion': wantDiscussion,
-      'groupMemberList': groupMemberList?.map((member) => member.toJson()).toList(),
+      'groupMemberList': groupMemberList
+          ?.map((member) => member.toJson())
+          .toList(),
     };
   }
 
@@ -197,7 +205,7 @@ class MeetingDetailInfo {
   /// 토론 참석 희망 여부 표시
   String get displayWantDiscussion {
     if (wantDiscussion == null) return '-';
-    return wantDiscussion! ? '참석 희망' : '참석 안함';
+    return wantDiscussion! ? '토론할래요' : '독서만 할래요';
   }
 
   /// 오늘 모임 여부
@@ -309,14 +317,14 @@ class MeetingDetailInfo {
 
   static List<GroupMember>? _parseGroupMemberList(dynamic value) {
     if (value == null) return null;
-    
+
     try {
       if (value is List) {
         return value
             .map((item) => GroupMember.fromJson(item as Map<String, dynamic>))
             .toList();
       }
-      
+
       return null;
     } catch (e) {
       if (AppConfig.debugMode) {

--- a/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
@@ -1,0 +1,304 @@
+import 'package:intl/intl.dart';
+import '../../core/config/app_config.dart';
+
+/// 모임 상세 정보 모델
+///
+/// 백엔드 MeetingDetailResponse와 매핑
+/// GET /meetings/{meetingId} API 응답용
+class MeetingDetailInfo {
+  // 모임 관련
+  final int meetingId;
+  final String meetingCreatorName;
+  final int meetingCreatorId;
+  final String meetingType;
+  final String meetingName;
+  final DateTime meetingDateTime;
+  final DateTime lateThresholdTime;
+  final String meetingPlace;
+  final String description;
+  final DateTime createdAt;
+
+  // 출석 관련
+  final int? attendanceId;
+  final String attendanceStatus;
+  final String? note;
+
+  // 토론 관련
+  final DateTime? discussionTime;
+  final String? alarmMessage;
+  final bool? wantDiscussion;
+
+  const MeetingDetailInfo({
+    // 모임 관련
+    required this.meetingId,
+    required this.meetingCreatorName,
+    required this.meetingCreatorId,
+    required this.meetingType,
+    required this.meetingName,
+    required this.meetingDateTime,
+    required this.lateThresholdTime,
+    required this.meetingPlace,
+    required this.description,
+    required this.createdAt,
+    // 출석 관련
+    this.attendanceId,
+    required this.attendanceStatus,
+    this.note,
+    // 토론 관련
+    this.discussionTime,
+    this.alarmMessage,
+    this.wantDiscussion,
+  });
+
+  /// JSON에서 객체 생성
+  factory MeetingDetailInfo.fromJson(Map<String, dynamic> json) {
+    try {
+      final meetingDetail = MeetingDetailInfo(
+        // 모임 관련
+        meetingId: _parseIntSafely(json['meetingId'], '모임ID'),
+        meetingCreatorName: _parseStringSafely(json['meetingCreatorName'], '개설자명'),
+        meetingCreatorId: _parseIntSafely(json['meetingCreatorId'], '개설자ID'),
+        meetingType: _parseStringSafely(json['meetingType'], '모임유형'),
+        meetingName: _parseStringSafely(json['meetingName'], '모임제목'),
+        meetingDateTime: _parseDateTimeSafely(json['meetingDateTime'], '모임일시'),
+        lateThresholdTime: _parseDateTimeSafely(json['lateThresholdTime'], '지각기준시간'),
+        meetingPlace: _parseStringSafely(json['meetingPlace'], '모임장소'),
+        description: _parseStringSafely(json['description'], '모임설명'),
+        createdAt: _parseDateTimeSafely(json['createdAt'], '모임개설일자'),
+        // 출석 관련
+        attendanceId: _parseIntNullable(json['attendanceId']),
+        attendanceStatus: _parseStringSafely(json['attendanceStatus'], '출석상태'),
+        note: _parseStringNullable(json['note']),
+        // 토론 관련
+        discussionTime: _parseDateTimeNullable(json['discussionTime']),
+        alarmMessage: _parseStringNullable(json['alarmMessage']),
+        wantDiscussion: _parseBoolNullable(json['wantDiscussion']),
+      );
+      
+      return meetingDetail;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MeetingDetailInfo.fromJson] 파싱 오류: $e');
+        print('🔍 입력 JSON: $json');
+      }
+      rethrow;
+    }
+  }
+
+  /// 객체를 JSON으로 변환
+  Map<String, dynamic> toJson() {
+    return {
+      // 모임 관련
+      'meetingId': meetingId,
+      'meetingCreatorName': meetingCreatorName,
+      'meetingCreatorId': meetingCreatorId,
+      'meetingType': meetingType,
+      'meetingName': meetingName,
+      'meetingDateTime': meetingDateTime.toIso8601String(),
+      'lateThresholdTime': lateThresholdTime.toIso8601String(),
+      'meetingPlace': meetingPlace,
+      'description': description,
+      'createdAt': createdAt.toIso8601String(),
+      // 출석 관련
+      'attendanceId': attendanceId,
+      'attendanceStatus': attendanceStatus,
+      'note': note,
+      // 토론 관련
+      'discussionTime': discussionTime?.toIso8601String(),
+      'alarmMessage': alarmMessage,
+      'wantDiscussion': wantDiscussion,
+    };
+  }
+
+  // Display 관련 getters
+
+  /// 모임 유형 표시명
+  String get meetingTypeDisplayName {
+    switch (meetingType) {
+      case 'REGULAR':
+        return '정기';
+      case 'FLASH':
+        return '번개';
+      case 'SPECIAL':
+        return '특수';
+      default:
+        return meetingType;
+    }
+  }
+
+  /// 모임 개최일자 표시 (yyyy.MM.dd HH:mm)
+  String get displayMeetingDateTime {
+    return DateFormat('yyyy.MM.dd HH:mm').format(meetingDateTime);
+  }
+
+  /// 모임 개최 날짜만 (yyyy.MM.dd)
+  String get displayMeetingDate {
+    return DateFormat('yyyy.MM.dd').format(meetingDateTime);
+  }
+
+  /// 모임 개최 시간만 (HH:mm)
+  String get displayMeetingTime {
+    return DateFormat('HH:mm').format(meetingDateTime);
+  }
+
+  /// 지각 기준 시간 표시 (HH:mm)
+  String get displayLateThresholdTime {
+    return DateFormat('HH:mm').format(lateThresholdTime);
+  }
+
+  /// 토론 시간 표시 (HH:mm) - 시간만 표시
+  String get displayDiscussionTime {
+    if (discussionTime == null) return '-';
+    return DateFormat('HH:mm').format(discussionTime!);
+  }
+
+  /// 모임 개설일자 표시 (yyyy.MM.dd)
+  String get displayCreatedAt {
+    return DateFormat('yyyy.MM.dd').format(createdAt);
+  }
+
+  /// 출석 상태 표시명
+  String get attendanceStatusDisplayName {
+    switch (attendanceStatus) {
+      case 'ATTEND':
+        return '참석';
+      case 'ATTEND_LATE':
+        return '지각';
+      case 'NOT_ATTEND':
+        return '불참';
+      case 'NOT_STARTED':
+        return '진행 전';
+      default:
+        return attendanceStatus;
+    }
+  }
+
+  /// 출석 상태 색상
+  String get attendanceStatusColorName {
+    switch (attendanceStatus) {
+      case 'ATTEND':
+        return 'green';
+      case 'ATTEND_LATE':
+        return 'orange';
+      case 'NOT_ATTEND':
+        return 'grey';
+      case 'NOT_STARTED':
+        return 'blue';
+      default:
+        return 'grey';
+    }
+  }
+
+  /// 토론 참석 희망 여부 표시
+  String get displayWantDiscussion {
+    if (wantDiscussion == null) return '-';
+    return wantDiscussion! ? '참석 희망' : '참석 안함';
+  }
+
+  /// 오늘 모임 여부
+  bool get isToday {
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final meetingDate = DateTime(
+      meetingDateTime.year,
+      meetingDateTime.month,
+      meetingDateTime.day,
+    );
+    return today == meetingDate;
+  }
+
+  @override
+  String toString() {
+    return 'MeetingDetailInfo{meetingId: $meetingId, meetingName: $meetingName, meetingType: $meetingType, meetingDateTime: $meetingDateTime}';
+  }
+
+  // 🔧 Helper 메서드들
+  static int _parseIntSafely(dynamic value, String fieldName) {
+    if (value == null) {
+      return 0;
+    }
+    if (value is int) return value;
+    if (value is String) {
+      final parsed = int.tryParse(value);
+      if (parsed != null) return parsed;
+    }
+
+    throw TypeError();
+  }
+
+  static int? _parseIntNullable(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String) {
+      return int.tryParse(value);
+    }
+    return null;
+  }
+
+  static String _parseStringSafely(dynamic value, String fieldName) {
+    if (value == null) {
+      return '';
+    }
+    return value.toString();
+  }
+
+  static String? _parseStringNullable(dynamic value) {
+    if (value == null) return null;
+    return value.toString();
+  }
+
+  static bool? _parseBoolNullable(dynamic value) {
+    if (value == null) return null;
+    if (value is bool) return value;
+    if (value is String) {
+      return value.toLowerCase() == 'true';
+    }
+    return null;
+  }
+
+  static DateTime _parseDateTimeSafely(dynamic value, String fieldName) {
+    if (value == null) {
+      return DateTime.now();
+    }
+
+    try {
+      if (value is String) {
+        // 백엔드 날짜 형식: "2025.06.26 11:12"
+        if (value.contains('.') && value.contains(' ')) {
+          // "2025.06.26 11:12" -> "2025-06-26 11:12:00"
+          final formatted = '${value.replaceAll('.', '-').trim()}:00';
+          return DateTime.parse(formatted);
+        }
+
+        // 표준 ISO 형식인 경우
+        return DateTime.parse(value);
+      }
+
+      throw TypeError();
+    } catch (e) {
+      return DateTime.now();
+    }
+  }
+
+  static DateTime? _parseDateTimeNullable(dynamic value) {
+    if (value == null) return null;
+
+    try {
+      if (value is String) {
+        // 백엔드 날짜 형식: "2025.06.26 11:12"
+        if (value.contains('.') && value.contains(' ')) {
+          // "2025.06.26 11:12" -> "2025-06-26 11:12:00"
+          final formatted = '${value.replaceAll('.', '-').trim()}:00';
+          return DateTime.parse(formatted);
+        }
+
+        // 표준 ISO 형식인 경우
+        return DateTime.parse(value);
+      }
+
+      throw TypeError();
+    } catch (e) {
+      return null;
+    }
+  }
+}

--- a/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_detail_model.dart
@@ -1,5 +1,6 @@
 import 'package:intl/intl.dart';
 import '../../core/config/app_config.dart';
+import 'group_member_model.dart';
 
 /// 모임 상세 정보 모델
 ///
@@ -27,6 +28,7 @@ class MeetingDetailInfo {
   final DateTime? discussionTime;
   final String? alarmMessage;
   final bool? wantDiscussion;
+  final List<GroupMember>? groupMemberList;
 
   const MeetingDetailInfo({
     // 모임 관련
@@ -48,6 +50,7 @@ class MeetingDetailInfo {
     this.discussionTime,
     this.alarmMessage,
     this.wantDiscussion,
+    this.groupMemberList,
   });
 
   /// JSON에서 객체 생성
@@ -73,6 +76,7 @@ class MeetingDetailInfo {
         discussionTime: _parseDateTimeNullable(json['discussionTime']),
         alarmMessage: _parseStringNullable(json['alarmMessage']),
         wantDiscussion: _parseBoolNullable(json['wantDiscussion']),
+        groupMemberList: _parseGroupMemberList(json['groupMemberList']),
       );
       
       return meetingDetail;
@@ -107,6 +111,7 @@ class MeetingDetailInfo {
       'discussionTime': discussionTime?.toIso8601String(),
       'alarmMessage': alarmMessage,
       'wantDiscussion': wantDiscussion,
+      'groupMemberList': groupMemberList?.map((member) => member.toJson()).toList(),
     };
   }
 
@@ -298,6 +303,25 @@ class MeetingDetailInfo {
 
       throw TypeError();
     } catch (e) {
+      return null;
+    }
+  }
+
+  static List<GroupMember>? _parseGroupMemberList(dynamic value) {
+    if (value == null) return null;
+    
+    try {
+      if (value is List) {
+        return value
+            .map((item) => GroupMember.fromJson(item as Map<String, dynamic>))
+            .toList();
+      }
+      
+      return null;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MeetingDetailInfo] groupMemberList 파싱 오류: $e');
+      }
       return null;
     }
   }

--- a/geulnamu_frontend/lib/screens/meeting/meeting_detail_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_detail_screen.dart
@@ -134,6 +134,9 @@ class _MeetingDetailScreenState extends State<MeetingDetailScreen>
       onEditToggle: toggleEditMode,
       onNoteSave: saveNote,
       onEditCancel: cancelEdit,
+      onToggleDiscussion: toggleDiscussionParticipation, // 🆕 토론 상태 토글 콜백 연결
+      canToggleDiscussion: canChangeDiscussionParticipation, // 🆕 토론 상태 변경 가능 여부
+      discussionTimeRemaining: discussionChangeTimeRemaining, // 🆕 남은 시간 정보 연결
     );
   }
 

--- a/geulnamu_frontend/lib/screens/meeting/meeting_detail_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_detail_screen.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../providers/auth_provider.dart';
+import '../../widgets/common/main_layout.dart';
+import '../../services/home/home_service.dart';
+import '../../services/home/home_route_service.dart';
+import 'mixins/meeting_detail_logic_mixin.dart';
+import 'widgets/meeting_detail_widgets.dart';
+
+/// 모임 상세 조회 화면
+///
+/// 특정 모임의 상세 정보를 표시하는 화면
+/// - 모임 기본 정보 (제목, 유형, 개설자, 일시 등)
+/// - 출석 정보 (상태, 비고) - 비고는 편집 가능
+/// - 토론 정보 (시간, 알림 메시지, 참석 희망 여부)
+/// - 운영진용 모임 수정 버튼 (권한별 표시)
+class MeetingDetailScreen extends StatefulWidget {
+  /// 모임 ID
+  final int meetingId;
+  
+  const MeetingDetailScreen({
+    super.key,
+    required this.meetingId,
+  });
+
+  @override
+  State<MeetingDetailScreen> createState() => _MeetingDetailScreenState();
+}
+
+class _MeetingDetailScreenState extends State<MeetingDetailScreen>
+    with MeetingDetailLogicMixin, RouteAware {
+  final HomeService _homeService = HomeService();
+
+  @override
+  void initState() {
+    super.initState();
+    // 화면 로드 후 초기 데이터 로드
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      initializeMeetingDetail(widget.meetingId);
+    });
+  }
+  
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // RouteObserver 등록
+    final route = ModalRoute.of(context);
+    if (route is PageRoute) {
+      HomeRouteService.routeObserver.subscribe(this, route);
+    }
+  }
+  
+  @override
+  void dispose() {
+    // RouteObserver 등록 해제
+    HomeRouteService.routeObserver.unsubscribe(this);
+    super.dispose();
+  }
+  
+  @override
+  void didPopNext() {
+    // 다른 화면에서 돌아왔을 때 새로고침
+    super.didPopNext();
+    print('🔄 [모임 상세] 다른 화면에서 돌아오면서 새로고침');
+    refreshMeetingDetail(widget.meetingId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<HomeService>(
+      builder: (context, homeService, child) {
+        return MainLayout(
+          title: meetingDetail?.meetingName ?? '모임 상세',
+          isHomePage: false, // 서브 페이지이므로 뒤로가기 버튼 표시
+          // HomeService를 통한 메뉴 및 로그아웃 처리
+          onMenuTap: (menu) => _homeService.handleMenuTap(context, menu),
+          onLogoutTap: () => _handleLogout(),
+          // 새로고침 액션 추가
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.refresh),
+              onPressed: () => refreshMeetingDetail(widget.meetingId),
+              tooltip: '새로고침',
+            ),
+          ],
+          body: Stack(
+            children: [
+              // 메인 콘텐츠
+              _buildMainContent(),
+
+              // 운영진용 편집 버튼
+              if (meetingDetail != null && isStaffOrAbove)
+                MeetingDetailWidgets.buildEditFab(
+                  context,
+                  onPressed: () => navigateToMeetingEdit(widget.meetingId),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 메인 콘텐츠 빌드
+  Widget _buildMainContent() {
+    // 로딩 상태
+    if (isLoading) {
+      return MeetingDetailWidgets.buildLoading(context);
+    }
+
+    // 에러 상태
+    if (errorMessage != null) {
+      return MeetingDetailWidgets.buildError(
+        context,
+        message: errorMessage!,
+        onRetry: () => refreshMeetingDetail(widget.meetingId),
+      );
+    }
+
+    // 데이터 없음
+    if (meetingDetail == null) {
+      return MeetingDetailWidgets.buildError(
+        context,
+        message: '모임 정보를 찾을 수 없습니다.',
+        onRetry: () => refreshMeetingDetail(widget.meetingId),
+      );
+    }
+
+    // 정상 콘텐츠
+    return MeetingDetailWidgets.buildMainContent(
+      context,
+      meetingDetail!,
+      isEditing: isEditing,
+      onEditToggle: toggleEditMode,
+      onNoteSave: saveNote,
+      onEditCancel: cancelEdit,
+    );
+  }
+
+  /// 로그아웃 처리 (HomeService 활용)
+  Future<void> _handleLogout() async {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    await _homeService.handleLogout(context, authProvider);
+  }
+}

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
@@ -213,10 +213,9 @@ class _MeetingListScreenState extends State<MeetingListScreen>
     await _homeService.handleLogout(context, authProvider);
   }
 
-  /// 모임 카드 탭 처리 (향후 상세보기 기능)
+  /// 모임 카드 탭 처리 - 상세 페이지로 이동
   void _handleMeetingTap(MeetingInfo meeting) {
-    // TODO: 향후 모임 상세 페이지 구현 시 아래 코드 활성화
-    // Navigator.pushNamed(context, '/meeting/${meeting.meetingId}');
+    Navigator.pushNamed(context, '/meeting/${meeting.meetingId}');
   }
 
   /// 출석현황 확인 버튼 처리 (MeetingLogicMixin에서 처리)

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
@@ -50,17 +50,27 @@ class _MeetingListScreenState extends State<MeetingListScreen>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    // RouteObserver 등록
-    final route = ModalRoute.of(context);
-    if (route is PageRoute) {
-      HomeRouteService.routeObserver.subscribe(this, route);
-    }
+    // 🎯 RouteObserver 등록 - 안전하게 처리
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final route = ModalRoute.of(context);
+      if (route is PageRoute && mounted) {
+        try {
+          HomeRouteService.routeObserver.subscribe(this, route);
+        } catch (e) {
+          print('⚠️ [MeetingListScreen] RouteObserver 등록 실패: $e');
+        }
+      }
+    });
   }
   
   @override
   void dispose() {
     // RouteObserver 등록 해제
-    HomeRouteService.routeObserver.unsubscribe(this);
+    try {
+      HomeRouteService.routeObserver.unsubscribe(this);
+    } catch (e) {
+      print('⚠️ [MeetingListScreen] RouteObserver 해제 실패: $e');
+    }
     super.dispose();
   }
   

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
@@ -78,7 +78,6 @@ class _MeetingListScreenState extends State<MeetingListScreen>
   void didPopNext() {
     // 다른 화면에서 돌아왔을 때 새로고침
     super.didPopNext();
-    print('🔄 [모임 목록] 다른 화면에서 돌아오면서 새로고침');
     refreshMeetingList();
   }
 

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
@@ -229,9 +229,9 @@ class _MeetingListStaffScreenState extends State<MeetingListStaffScreen>
     await _homeService.handleLogout(context, authProvider);
   }
 
-  /// 모임 카드 탭 처리 (향후 상세보기 기능)
+  /// 모임 카드 탭 처리 (향후 운영진용 상세보기 기능)
   void _handleMeetingTap(MeetingInfo meeting) {
-    // TODO: 향후 모임 상세 페이지 구현 시 아래 코드 활성화
-    // Navigator.pushNamed(context, '/meeting/${meeting.meetingId}');
+    // TODO: 향후 운영진용 모임 상세 페이지 구현 시 아래 코드 활성화
+    // Navigator.pushNamed(context, '/meeting/${meeting.meetingId}/staff');
   }
 }

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_create_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_create_logic_mixin.dart
@@ -276,8 +276,7 @@ mixin MeetingCreateLogicMixin<T extends StatefulWidget> on State<T> {
     });
     
     try {
-      // 🔧 MeetingService 초기화 확인
-      _meetingService.initialize();
+      // 🎯 MeetingService는 Singleton이므로 이미 초기화됨
       
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
@@ -8,7 +8,7 @@ import '../../../models/attendance/request/attendance_note_request.dart';
 import '../../../core/config/app_config.dart';
 
 /// 모임 상세 화면 로직 Mixin
-/// 
+///
 /// 모임 상세 정보 조회 및 관련 비즈니스 로직 처리
 mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
   // 서비스
@@ -43,7 +43,7 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
 
     try {
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
-      
+
       if (!authProvider.isAuthenticated) {
         throw Exception('로그인이 필요합니다.');
       }
@@ -69,7 +69,9 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
         });
 
         if (AppConfig.debugMode) {
-          print('✅ [MeetingDetailLogicMixin] 모임 상세 로드 성공: ${detail.meetingName}');
+          print(
+            '✅ [MeetingDetailLogicMixin] 모임 상세 로드 성공: ${detail.meetingName}',
+          );
         }
       }
     } catch (e) {
@@ -94,7 +96,7 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
   /// 비고 편집 모드 토글
   void toggleEditMode() {
     if (!mounted) return;
-    
+
     setState(() {
       _isEditing = !_isEditing;
     });
@@ -134,7 +136,7 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
 
       final authProvider = Provider.of<AuthProvider>(context, listen: false);
       final accessToken = await authProvider.accessToken;
-      
+
       if (accessToken == null) {
         throw Exception('인증 토큰을 가져올 수 없습니다.');
       }
@@ -165,7 +167,6 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
       if (_meetingDetail != null) {
         await refreshMeetingDetail(_meetingDetail!.meetingId);
       }
-
     } catch (e) {
       if (AppConfig.debugMode) {
         print('❌ [MeetingDetailLogicMixin] 비고 저장 실패: $e');
@@ -178,7 +179,10 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
       }
 
       // 에러 메시지 표시
-      final errorMessage = e.toString().replaceAll('Exception: ', '').replaceAll('[비고 작성] ', '');
+      final errorMessage = e
+          .toString()
+          .replaceAll('Exception: ', '')
+          .replaceAll('[비고 작성] ', '');
       _showSnackBar(errorMessage, isError: true);
     }
   }
@@ -186,7 +190,7 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
   /// 비고 편집 취소
   void cancelEdit() {
     if (!mounted) return;
-    
+
     setState(() {
       _isEditing = false;
     });
@@ -212,7 +216,7 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
             Expanded(child: Text(message)),
           ],
         ),
-        backgroundColor: isError 
+        backgroundColor: isError
             ? Theme.of(context).colorScheme.error
             : Theme.of(context).colorScheme.primary,
         behavior: SnackBarBehavior.floating,
@@ -221,15 +225,49 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
     );
   }
 
+  /// 확인 다이얼로그 표시 헬퍼 메서드
+  Future<bool> _showConfirmDialog({
+    required String title,
+    required String message,
+    String confirmText = '확인',
+    String cancelText = '취소',
+  }) async {
+    if (!mounted) return false;
+
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: Text(title),
+          content: Text(message),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: Text(cancelText),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: Text(confirmText),
+            ),
+          ],
+        );
+      },
+    );
+
+    return result ?? false;
+  }
+
   /// 모임 정보 수정 페이지로 이동 (운영진용)
   void navigateToMeetingEdit(int meetingId) {
     if (AppConfig.debugMode) {
-      print('🔧 [MeetingDetailLogicMixin] 모임 정보 수정 페이지로 이동: meetingId=$meetingId');
+      print(
+        '🔧 [MeetingDetailLogicMixin] 모임 정보 수정 페이지로 이동: meetingId=$meetingId',
+      );
     }
-    
+
     // TODO: 향후 모임 수정 페이지 구현 시 활성화
     // Navigator.pushNamed(context, '/meeting/$meetingId/edit');
-    
+
     // 임시 스낵바 표시
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
@@ -251,15 +289,200 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
   bool get isStaffOrAbove {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     if (!authProvider.isAuthenticated) return false;
-    
+
     return authProvider.isStaffLevel;
+  }
+
+  /// 토론 참여 상태 토글
+  ///
+  /// 현재 wantDiscussion 상태에 따라 반대 상태로 변경
+  /// - true(토론할래요) → false(독서만 할래요)
+  /// - false(독서만 할래요) → true(토론할래요)
+  Future<void> toggleDiscussionParticipation() async {
+    if (!mounted) return;
+
+    // 출석 ID가 없으면 변경 불가
+    if (_meetingDetail?.attendanceId == null) {
+      _showSnackBar('출석한 모임에서만 토론 참여 상태를 변경할 수 있습니다.', isError: true);
+      return;
+    }
+
+    // 토론 시간이 설정되지 않았으면 변경 불가 (🆕 추가)
+    if (_meetingDetail?.discussionTime == null) {
+      _showSnackBar('토론 시간이 설정된 모임에서만 참여 상태를 변경할 수 있습니다.', isError: true);
+      return;
+    }
+
+    // 토론 시작 30분 전까지만 변경 가능 (🆕 시간 제한 추가)
+    if (!_isDiscussionChangeAllowedByTime()) {
+      final remainingTime = discussionChangeTimeRemaining;
+      if (remainingTime != null) {
+        _showSnackBar('토론 시작 30분 전까지만 참여 의사를 변경할 수 있습니다. ($remainingTime)', isError: true);
+      } else {
+        _showSnackBar('토론 시작 30분 전까지만 참여 의사를 변경할 수 있습니다.', isError: true);
+      }
+      return;
+    }
+
+    // 현재 상태 확인
+    final currentWantDiscussion = _meetingDetail?.wantDiscussion;
+    if (currentWantDiscussion == null) {
+      _showSnackBar('토론 참여 상태를 확인할 수 없습니다.', isError: true);
+      return;
+    }
+
+    // 변경될 상태 메시지
+    final willWantDiscussion = !currentWantDiscussion;
+    final actionMessage = willWantDiscussion ? '토론에 참여하시겠어요?' : '독서만 하시겠어요?';
+    final confirmMessage = willWantDiscussion
+        ? '토론 참여로 변경하시겠습니까?'
+        : '독서만 하기로 변경하시겠습니까?';
+
+    // 확인 다이얼로그 표시
+    final confirmed = await _showConfirmDialog(
+      title: '토론 참여 상태 변경',
+      message: confirmMessage,
+      confirmText: '변경',
+      cancelText: '취소',
+    );
+
+    if (!confirmed) return;
+
+    try {
+      if (AppConfig.debugMode) {
+        print(
+          '🔄 [MeetingDetailLogicMixin] 토론 상태 변경 시작: $currentWantDiscussion → $willWantDiscussion',
+        );
+      }
+
+      // 로딩 상태 시작
+      setState(() {
+        _isLoading = true;
+      });
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+
+      if (accessToken == null) {
+        throw Exception('인증 토큰을 가져올 수 없습니다.');
+      }
+
+      // 현재 상태에 따라 적절한 API 호출
+      if (currentWantDiscussion) {
+        // 현재 토론 참여 → 독서만 하기로 변경
+        await _attendanceService.setJustRead(
+          attendanceId: _meetingDetail!.attendanceId!,
+          accessToken: accessToken,
+        );
+      } else {
+        // 현재 독서만 → 토론 참여로 변경
+        await _attendanceService.setWantDiscussion(
+          attendanceId: _meetingDetail!.attendanceId!,
+          accessToken: accessToken,
+        );
+      }
+
+      if (AppConfig.debugMode) {
+        print('✅ [MeetingDetailLogicMixin] 토론 상태 변경 성공');
+      }
+
+      // 로딩 상태 해제
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+
+      // 성공 메시지 표시
+      _showSnackBar('토론 참여 상태가 변경되었습니다.');
+
+      // 모임 상세 정보 새로고침
+      if (_meetingDetail != null) {
+        await refreshMeetingDetail(_meetingDetail!.meetingId);
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MeetingDetailLogicMixin] 토론 상태 변경 실패: $e');
+      }
+
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+
+      // 에러 메시지 표시
+      final errorMessage = e
+          .toString()
+          .replaceAll('Exception: ', '')
+          .replaceAll('[독서만 할래요] ', '')
+          .replaceAll('[토론할래요] ', '');
+      _showSnackBar(errorMessage, isError: true);
+    }
+  }
+
+  /// 토론 참여 상태 변경 가능 여부
+  bool get canChangeDiscussionParticipation {
+    // 출석ID가 있고, wantDiscussion 값이 있고, 토론 시간이 설정된 경우에만 가능
+    if (_meetingDetail?.attendanceId == null ||
+        _meetingDetail?.wantDiscussion == null ||
+        _meetingDetail?.discussionTime == null) {
+      return false;
+    }
+
+    // 토론 시작 30분 전까지만 변경 가능 (🆕 시간 제한 추가)
+    return _isDiscussionChangeAllowedByTime();
+  }
+
+  /// 토론 참여 상태 변경 시간 체크
+  /// 
+  /// 토론 시작 30분 전까지만 변경 가능
+  bool _isDiscussionChangeAllowedByTime() {
+    final discussionTime = _meetingDetail?.discussionTime;
+    if (discussionTime == null) return false;
+
+    final now = DateTime.now();
+    final changeDeadline = discussionTime.subtract(const Duration(minutes: 30));
+
+    if (AppConfig.debugMode) {
+      print('🕰️ [MeetingDetailLogicMixin] 토론 시간 체크:');
+      print('   현재 시간: ${now.toString()}');
+      print('   토론 시간: ${discussionTime.toString()}');
+      print('   변경 마감 시간: ${changeDeadline.toString()}');
+      print('   변경 가능 여부: ${now.isBefore(changeDeadline)}');
+    }
+
+    return now.isBefore(changeDeadline);
+  }
+
+  /// 토론 참여 상태 변경 마감까지 남은 시간 문자열
+  String? get discussionChangeTimeRemaining {
+    final discussionTime = _meetingDetail?.discussionTime;
+    if (discussionTime == null) return null;
+
+    final now = DateTime.now();
+    final changeDeadline = discussionTime.subtract(const Duration(minutes: 30));
+    
+    if (now.isAfter(changeDeadline)) {
+      return null; // 이미 마감
+    }
+
+    final remaining = changeDeadline.difference(now);
+    final hours = remaining.inHours;
+    final minutes = remaining.inMinutes % 60;
+
+    if (hours > 0) {
+      return '약 ${hours}시간 ${minutes}분 후 변경 불가';
+    } else {
+      return '약 ${minutes}분 후 변경 불가';
+    }
   }
 
   /// 권한 확인 - 관리자인지
   bool get isAdmin {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     if (!authProvider.isAuthenticated) return false;
-    
+
     return authProvider.isAdminLevel;
   }
 }

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../../../providers/auth_provider.dart';
 import '../../../services/meeting/meeting_service.dart';
+import '../../../services/attendance/attendance_service.dart';
 import '../../../models/meeting/meeting_detail_model.dart';
+import '../../../models/attendance/request/attendance_note_request.dart';
 import '../../../core/config/app_config.dart';
 
 /// 모임 상세 화면 로직 Mixin
@@ -11,6 +13,7 @@ import '../../../core/config/app_config.dart';
 mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
   // 서비스
   final MeetingService _meetingService = MeetingService();
+  final AttendanceService _attendanceService = AttendanceService();
 
   // 상태 관리
   MeetingDetailInfo? _meetingDetail;
@@ -101,19 +104,83 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
     }
   }
 
-  /// 비고 저장 (향후 구현)
+  /// 비고 저장
   Future<void> saveNote(String note) async {
-    // TODO: 향후 비고 수정 API 구현 시 활성화
-    if (AppConfig.debugMode) {
-      print('💾 [MeetingDetailLogicMixin] 비고 저장: $note');
+    if (!mounted) return;
+
+    // 출석 ID가 없으면 저장 불가
+    if (_meetingDetail?.attendanceId == null) {
+      _showSnackBar('출석 정보가 없어 비고를 저장할 수 없습니다.', isError: true);
+      return;
     }
-    
-    // 일단 편집 모드 종료
-    toggleEditMode();
-    
-    // 향후 실제 API 호출 후 새로고침
-    // await _updateNote(note);
-    // await refreshMeetingDetail();
+
+    // 비고 유효성 검사
+    final request = AttendanceNoteRequest(note: note.trim());
+    final validationError = request.getValidationError();
+    if (validationError != null) {
+      _showSnackBar(validationError, isError: true);
+      return;
+    }
+
+    try {
+      if (AppConfig.debugMode) {
+        print('💾 [MeetingDetailLogicMixin] 비고 저장 시작: $note');
+      }
+
+      // 로딩 상태 시작
+      setState(() {
+        _isLoading = true;
+      });
+
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      final accessToken = await authProvider.accessToken;
+      
+      if (accessToken == null) {
+        throw Exception('인증 토큰을 가져올 수 없습니다.');
+      }
+
+      // 비고 저장 API 호출
+      await _attendanceService.writeNote(
+        attendanceId: _meetingDetail!.attendanceId!,
+        note: note.trim(),
+        accessToken: accessToken,
+      );
+
+      if (AppConfig.debugMode) {
+        print('✅ [MeetingDetailLogicMixin] 비고 저장 성공');
+      }
+
+      // 편집 모드 종료 및 로딩 상태 해제
+      if (mounted) {
+        setState(() {
+          _isEditing = false;
+          _isLoading = false;
+        });
+      }
+
+      // 성공 메시지 표시
+      _showSnackBar('비고가 저장되었습니다.');
+
+      // 모임 상세 정보 새로고침
+      if (_meetingDetail != null) {
+        await refreshMeetingDetail(_meetingDetail!.meetingId);
+      }
+
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [MeetingDetailLogicMixin] 비고 저장 실패: $e');
+      }
+
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+
+      // 에러 메시지 표시
+      final errorMessage = e.toString().replaceAll('Exception: ', '').replaceAll('[비고 작성] ', '');
+      _showSnackBar(errorMessage, isError: true);
+    }
   }
 
   /// 비고 편집 취소
@@ -127,6 +194,31 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
     if (AppConfig.debugMode) {
       print('❌ [MeetingDetailLogicMixin] 편집 취소');
     }
+  }
+
+  /// 스낵바 표시 헬퍼 메서드
+  void _showSnackBar(String message, {bool isError = false}) {
+    if (!mounted) return;
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Row(
+          children: [
+            Icon(
+              isError ? Icons.error_outline : Icons.check_circle_outline,
+              color: Colors.white,
+            ),
+            const SizedBox(width: 8),
+            Expanded(child: Text(message)),
+          ],
+        ),
+        backgroundColor: isError 
+            ? Theme.of(context).colorScheme.error
+            : Theme.of(context).colorScheme.primary,
+        behavior: SnackBarBehavior.floating,
+        duration: Duration(seconds: isError ? 4 : 2),
+      ),
+    );
   }
 
   /// 모임 정보 수정 페이지로 이동 (운영진용)

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../providers/auth_provider.dart';
+import '../../../services/meeting/meeting_service.dart';
+import '../../../models/meeting/meeting_detail_model.dart';
+import '../../../core/config/app_config.dart';
+
+/// 모임 상세 화면 로직 Mixin
+/// 
+/// 모임 상세 정보 조회 및 관련 비즈니스 로직 처리
+mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
+  // 서비스
+  final MeetingService _meetingService = MeetingService();
+
+  // 상태 관리
+  MeetingDetailInfo? _meetingDetail;
+  bool _isLoading = false;
+  String? _errorMessage;
+  bool _isEditing = false; // 비고 편집 모드
+
+  // Getters
+  MeetingDetailInfo? get meetingDetail => _meetingDetail;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  bool get isEditing => _isEditing;
+
+  /// 초기화 - 모임 상세 정보 로드
+  Future<void> initializeMeetingDetail(int meetingId) async {
+    await _loadMeetingDetail(meetingId);
+  }
+
+  /// 모임 상세 정보 로드
+  Future<void> _loadMeetingDetail(int meetingId) async {
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final authProvider = Provider.of<AuthProvider>(context, listen: false);
+      
+      if (!authProvider.isAuthenticated) {
+        throw Exception('로그인이 필요합니다.');
+      }
+
+      if (AppConfig.debugMode) {
+        print('🔄 [MeetingDetailLogicMixin] 모임 상세 로드 시작: meetingId=$meetingId');
+      }
+
+      final accessToken = await authProvider.accessToken;
+      if (accessToken == null) {
+        throw Exception('인증 토큰을 가져올 수 없습니다.');
+      }
+
+      final detail = await _meetingService.getMeetingDetail(
+        meetingId: meetingId,
+        accessToken: accessToken,
+      );
+
+      if (mounted) {
+        setState(() {
+          _meetingDetail = detail;
+          _isLoading = false;
+        });
+
+        if (AppConfig.debugMode) {
+          print('✅ [MeetingDetailLogicMixin] 모임 상세 로드 성공: ${detail.meetingName}');
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+          _errorMessage = e.toString();
+        });
+
+        if (AppConfig.debugMode) {
+          print('❌ [MeetingDetailLogicMixin] 모임 상세 로드 실패: $e');
+        }
+      }
+    }
+  }
+
+  /// 새로고침
+  Future<void> refreshMeetingDetail(int meetingId) async {
+    await _loadMeetingDetail(meetingId);
+  }
+
+  /// 비고 편집 모드 토글
+  void toggleEditMode() {
+    if (!mounted) return;
+    
+    setState(() {
+      _isEditing = !_isEditing;
+    });
+
+    if (AppConfig.debugMode) {
+      print('🔄 [MeetingDetailLogicMixin] 편집 모드 변경: $_isEditing');
+    }
+  }
+
+  /// 비고 저장 (향후 구현)
+  Future<void> saveNote(String note) async {
+    // TODO: 향후 비고 수정 API 구현 시 활성화
+    if (AppConfig.debugMode) {
+      print('💾 [MeetingDetailLogicMixin] 비고 저장: $note');
+    }
+    
+    // 일단 편집 모드 종료
+    toggleEditMode();
+    
+    // 향후 실제 API 호출 후 새로고침
+    // await _updateNote(note);
+    // await refreshMeetingDetail();
+  }
+
+  /// 비고 편집 취소
+  void cancelEdit() {
+    if (!mounted) return;
+    
+    setState(() {
+      _isEditing = false;
+    });
+
+    if (AppConfig.debugMode) {
+      print('❌ [MeetingDetailLogicMixin] 편집 취소');
+    }
+  }
+
+  /// 모임 정보 수정 페이지로 이동 (운영진용)
+  void navigateToMeetingEdit(int meetingId) {
+    if (AppConfig.debugMode) {
+      print('🔧 [MeetingDetailLogicMixin] 모임 정보 수정 페이지로 이동: meetingId=$meetingId');
+    }
+    
+    // TODO: 향후 모임 수정 페이지 구현 시 활성화
+    // Navigator.pushNamed(context, '/meeting/$meetingId/edit');
+    
+    // 임시 스낵바 표시
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: const Row(
+          children: [
+            Icon(Icons.construction, color: Colors.white),
+            SizedBox(width: 8),
+            Text('모임 수정 기능은 준비 중입니다.'),
+          ],
+        ),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        behavior: SnackBarBehavior.floating,
+        duration: const Duration(seconds: 2),
+      ),
+    );
+  }
+
+  /// 권한 확인 - 운영진 이상인지
+  bool get isStaffOrAbove {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    if (!authProvider.isAuthenticated) return false;
+    
+    return authProvider.isStaffLevel;
+  }
+
+  /// 권한 확인 - 관리자인지
+  bool get isAdmin {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    if (!authProvider.isAuthenticated) return false;
+    
+    return authProvider.isAdminLevel;
+  }
+}

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_logic_mixin.dart
@@ -48,10 +48,6 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
         throw Exception('로그인이 필요합니다.');
       }
 
-      if (AppConfig.debugMode) {
-        print('🔄 [MeetingDetailLogicMixin] 모임 상세 로드 시작: meetingId=$meetingId');
-      }
-
       final accessToken = await authProvider.accessToken;
       if (accessToken == null) {
         throw Exception('인증 토큰을 가져올 수 없습니다.');
@@ -67,12 +63,6 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
           _meetingDetail = detail;
           _isLoading = false;
         });
-
-        if (AppConfig.debugMode) {
-          print(
-            '✅ [MeetingDetailLogicMixin] 모임 상세 로드 성공: ${detail.meetingName}',
-          );
-        }
       }
     } catch (e) {
       if (mounted) {
@@ -80,10 +70,6 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
           _isLoading = false;
           _errorMessage = e.toString();
         });
-
-        if (AppConfig.debugMode) {
-          print('❌ [MeetingDetailLogicMixin] 모임 상세 로드 실패: $e');
-        }
       }
     }
   }
@@ -443,14 +429,6 @@ mixin MeetingDetailLogicMixin<T extends StatefulWidget> on State<T> {
 
     final now = DateTime.now();
     final changeDeadline = discussionTime.subtract(const Duration(minutes: 30));
-
-    if (AppConfig.debugMode) {
-      print('🕰️ [MeetingDetailLogicMixin] 토론 시간 체크:');
-      print('   현재 시간: ${now.toString()}');
-      print('   토론 시간: ${discussionTime.toString()}');
-      print('   변경 마감 시간: ${changeDeadline.toString()}');
-      print('   변경 가능 여부: ${now.isBefore(changeDeadline)}');
-    }
 
     return now.isBefore(changeDeadline);
   }

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_logic_mixin.dart
@@ -48,9 +48,8 @@ mixin MeetingLogicMixin<T extends StatefulWidget> on State<T> {
   /// 
   /// [initialFilter] 초기 필터 설정 (옵션)
   Future<void> initializeMeetingList({MeetingListFilter? initialFilter}) async {
-    // MeetingService 초기화
-    _meetingService.initialize();
-
+    // 🎯 MeetingService는 Singleton이므로 이미 초기화됨
+    
     // 🎯 초기 필터 설정 (제공된 경우)
     if (initialFilter != null) {
       _currentFilter = initialFilter;

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -64,6 +64,9 @@ class MeetingDetailWidgets {
     required VoidCallback onEditToggle,
     required Function(String) onNoteSave,
     required VoidCallback onEditCancel,
+    VoidCallback? onToggleDiscussion, // 🆕 토론 상태 토글 콜백 추가
+    bool canToggleDiscussion = false, // 🆕 토론 상태 변경 가능 여부
+    String? discussionTimeRemaining, // 🆕 토론 변경 마감까지 남은 시간
   }) {
     return SingleChildScrollView(
       padding: const EdgeInsets.all(16),
@@ -86,7 +89,13 @@ class MeetingDetailWidgets {
           const SizedBox(height: 16),
 
           // 토론 정보
-          _buildDiscussionCard(context, meeting),
+          _buildDiscussionCard(
+            context,
+            meeting,
+            onToggleDiscussion: onToggleDiscussion, // 🆕 토글 콜백 전달
+            canToggle: canToggleDiscussion, // 🆕 토글 가능 여부 전달
+            timeRemaining: discussionTimeRemaining, // 🆕 남은 시간 정보 전달
+          ),
           const SizedBox(height: 80), // FAB 공간 확보
         ],
       ),
@@ -260,8 +269,11 @@ class MeetingDetailWidgets {
   /// 토론 정보 카드
   static Widget _buildDiscussionCard(
     BuildContext context,
-    MeetingDetailInfo meeting,
-  ) {
+    MeetingDetailInfo meeting, {
+    Function()? onToggleDiscussion,
+    bool canToggle = false,
+    String? timeRemaining, // 🆕 남은 시간 정보 추가
+  }) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -291,7 +303,15 @@ class MeetingDetailWidgets {
 
             // 토론 정보들
             _buildInfoRow(context, '토론 시간', meeting.displayDiscussionTime),
-            _buildInfoRow(context, '참석 희망', meeting.displayWantDiscussion),
+
+            // 토론 참여 희망 상태 (토글 버튼 포함)
+            _buildDiscussionParticipationRow(
+              context,
+              meeting,
+              onToggleDiscussion: onToggleDiscussion,
+              canToggle: canToggle,
+              timeRemaining: timeRemaining, // 🆕 남은 시간 정보 전달
+            ),
 
             // 토론 조 구성원
             if (meeting.groupMemberList != null &&
@@ -549,6 +569,98 @@ class MeetingDetailWidgets {
               .toList(),
         ),
       ],
+    );
+  }
+
+  /// 토론 참여 상태 행 (토글 버튼 포함)
+  static Widget _buildDiscussionParticipationRow(
+    BuildContext context,
+    MeetingDetailInfo meeting, {
+    Function()? onToggleDiscussion,
+    bool canToggle = false,
+    String? timeRemaining, // 🆕 남은 시간 정보 추가
+  }) {
+    // 토론 시간이 설정되지 않았으면 하이픈 표시
+    final hasDiscussionTime = meeting.discussionTime != null;
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 10),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              SizedBox(
+                width: 100,
+                child: Text(
+                  '토론 참석 여부',
+                  style: context.textStyles.labelLarge?.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+
+              // 현재 상태 표시 (토론 시간이 없으면 하이픈)
+              Expanded(
+                child: Text(
+                  hasDiscussionTime ? meeting.displayWantDiscussion : '-',
+                  style: context.textStyles.bodyLarge?.copyWith(
+                    fontSize: 16,
+                    color: hasDiscussionTime
+                        ? context.colors.onSurface
+                        : context.colors.onSurfaceVariant, // 토론 시간 없을 때 회색
+                  ),
+                ),
+              ),
+
+              // 토글 스위치 (토론 시간이 있고 출석한 모임에서만 활성화)
+              if (hasDiscussionTime && canToggle && onToggleDiscussion != null)
+                Switch(
+                  value: meeting.wantDiscussion ?? false,
+                  onChanged: (_) => onToggleDiscussion(),
+                  activeColor: context.colors.primary,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                )
+              else if (hasDiscussionTime && meeting.attendanceId != null)
+                // 토론 시간은 있지만 토글 불가능한 경우 (로딩 중, 시간 만료 등)
+                Switch(
+                  value: meeting.wantDiscussion ?? false,
+                  onChanged: null, // 비활성화
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                )
+              else if (hasDiscussionTime)
+                // 토론 시간은 있지만 출석하지 않은 모임인 경우 비활성화 스위치
+                Switch(
+                  value: false,
+                  onChanged: null,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+              // 토론 시간이 없으면 스위치 자체를 표시하지 않음
+            ],
+          ),
+
+          // 남은 시간 안내 텍스트 (🆕 추가)
+          if (timeRemaining != null &&
+              hasDiscussionTime &&
+              meeting.attendanceId != null) ...[
+            const SizedBox(height: 4),
+            Padding(
+              padding: const EdgeInsets.only(left: 116), // 라벨 너비 + 간격만큼 들여쓰기
+              child: Text(
+                timeRemaining,
+                style: context.textStyles.bodySmall?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                  fontSize: 12,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
     );
   }
 

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -36,14 +36,15 @@ class MeetingDetailWidgets {
             const SizedBox(height: 16),
             Text(
               '모임 정보를 불러올 수 없습니다',
-              style: context.textStyles.headlineSmall,
+              style: context.textStyles.headlineSmall?.copyWith(fontSize: 20),
               textAlign: TextAlign.center,
             ),
             const SizedBox(height: 8),
             Text(
               message.replaceAll('[모임 상세 조회]', '').trim(),
-              style: context.textStyles.bodyMedium?.copyWith(
+              style: context.textStyles.bodyLarge?.copyWith(
                 color: context.colors.onSurfaceVariant,
+                fontSize: 16,
               ),
               textAlign: TextAlign.center,
             ),
@@ -51,7 +52,7 @@ class MeetingDetailWidgets {
             ElevatedButton.icon(
               onPressed: onRetry,
               icon: const Icon(Icons.refresh),
-              label: const Text('다시 시도'),
+              label: const Text('다시 시도', style: TextStyle(fontSize: 16)),
             ),
           ],
         ),
@@ -113,13 +114,15 @@ class MeetingDetailWidgets {
                 Icon(
                   Icons.event,
                   color: context.colors.primary,
-                  size: 20,
+                  size: 24, // 아이콘 크기 증가
                 ),
                 const SizedBox(width: 8),
                 Text(
                   '모임 정보',
-                  style: context.textStyles.titleMedium?.copyWith(
+                  style: context.textStyles.titleLarge?.copyWith(
                     fontWeight: FontWeight.bold,
+                    fontSize: 20, // 폰트 크기 증가
+                    color: context.colors.primary, // 다크모드에서 명확한 색상
                   ),
                 ),
               ],
@@ -131,7 +134,7 @@ class MeetingDetailWidgets {
             _buildInfoRow(context, '모임 유형', meeting.meetingTypeDisplayName),
             _buildInfoRow(context, '개설자', meeting.meetingCreatorName),
             _buildInfoRow(context, '개최일시', meeting.displayMeetingDateTime),
-            _buildInfoRow(context, '지각 기준', meeting.displayLateThresholdTime),
+            _buildInfoRow(context, '지각 기준시간', meeting.displayLateThresholdTime),
             _buildInfoRow(context, '장소', meeting.meetingPlace),
             _buildInfoRow(context, '개설일', meeting.displayCreatedAt),
             
@@ -140,22 +143,23 @@ class MeetingDetailWidgets {
               const SizedBox(height: 12),
               Text(
                 '모임 상세 내용',
-                style: context.textStyles.labelMedium?.copyWith(
+                style: context.textStyles.labelLarge?.copyWith(
                   color: context.colors.onSurfaceVariant,
                   fontWeight: FontWeight.w500,
+                  fontSize: 16,
                 ),
               ),
               const SizedBox(height: 8),
               Container(
                 width: double.infinity,
-                padding: const EdgeInsets.all(12),
+                padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
                   meeting.description,
-                  style: context.textStyles.bodyMedium,
+                  style: context.textStyles.bodyLarge?.copyWith(fontSize: 16),
                 ),
               ),
             ],
@@ -186,13 +190,15 @@ class MeetingDetailWidgets {
                 Icon(
                   Icons.check_circle_outline,
                   color: context.colors.primary,
-                  size: 20,
+                  size: 24, // 아이콘 크기 증가
                 ),
                 const SizedBox(width: 8),
                 Text(
                   '출석 정보',
-                  style: context.textStyles.titleMedium?.copyWith(
+                  style: context.textStyles.titleLarge?.copyWith(
                     fontWeight: FontWeight.bold,
+                    fontSize: 20, // 폰트 크기 증가
+                    color: context.colors.primary, // 다크모드에서 명확한 색상
                   ),
                 ),
               ],
@@ -204,15 +210,16 @@ class MeetingDetailWidgets {
               children: [
                 Text(
                   '출석 상태',
-                  style: context.textStyles.labelMedium?.copyWith(
+                  style: context.textStyles.labelLarge?.copyWith(
                     color: context.colors.onSurfaceVariant,
+                    fontSize: 16,
                   ),
                 ),
                 const SizedBox(width: 16),
                 Container(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 12,
-                    vertical: 4,
+                    vertical: 6, // 패딩 증가
                   ),
                   decoration: BoxDecoration(
                     color: _getAttendanceStatusColor(context, meeting.attendanceStatusColorName),
@@ -220,25 +227,29 @@ class MeetingDetailWidgets {
                   ),
                   child: Text(
                     meeting.attendanceStatusDisplayName,
-                    style: context.textStyles.labelSmall?.copyWith(
+                    style: context.textStyles.labelMedium?.copyWith(
                       color: Colors.white,
                       fontWeight: FontWeight.w500,
+                      fontSize: 14,
                     ),
                   ),
                 ),
               ],
             ),
             
-            // 비고 (편집 가능)
+            // 비고 (편집 가능 - 출석 ID가 있을 때만)
             const SizedBox(height: 16),
-            _buildNoteSection(
-              context,
-              meeting.note ?? '',
-              isEditing: isEditing,
-              onEditToggle: onEditToggle,
-              onNoteSave: onNoteSave,
-              onEditCancel: onEditCancel,
-            ),
+            if (meeting.attendanceId != null) 
+              _buildNoteSection(
+                context,
+                meeting.note ?? '',
+                isEditing: isEditing,
+                onEditToggle: onEditToggle,
+                onNoteSave: onNoteSave,
+                onEditCancel: onEditCancel,
+              )
+            else
+              _buildReadOnlyNote(context, meeting.note ?? ''),
           ],
         ),
       ),
@@ -262,13 +273,15 @@ class MeetingDetailWidgets {
                 Icon(
                   Icons.forum_outlined,
                   color: context.colors.primary,
-                  size: 20,
+                  size: 24, // 아이콘 크기 증가
                 ),
                 const SizedBox(width: 8),
                 Text(
                   '토론 정보',
-                  style: context.textStyles.titleMedium?.copyWith(
+                  style: context.textStyles.titleLarge?.copyWith(
                     fontWeight: FontWeight.bold,
+                    fontSize: 20, // 폰트 크기 증가
+                    color: context.colors.primary, // 다크모드에서 명확한 색상
                   ),
                 ),
               ],
@@ -284,22 +297,23 @@ class MeetingDetailWidgets {
               const SizedBox(height: 12),
               Text(
                 '토론 알림 메시지',
-                style: context.textStyles.labelMedium?.copyWith(
+                style: context.textStyles.labelLarge?.copyWith(
                   color: context.colors.onSurfaceVariant,
                   fontWeight: FontWeight.w500,
+                  fontSize: 16,
                 ),
               ),
               const SizedBox(height: 8),
               Container(
                 width: double.infinity,
-                padding: const EdgeInsets.all(12),
+                padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
                   color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
                   meeting.alarmMessage!,
-                  style: context.textStyles.bodyMedium,
+                  style: context.textStyles.bodyLarge?.copyWith(fontSize: 16),
                 ),
               ),
             ],
@@ -312,16 +326,17 @@ class MeetingDetailWidgets {
   /// 정보 행 위젯
   static Widget _buildInfoRow(BuildContext context, String label, String value) {
     return Padding(
-      padding: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.only(bottom: 10), // 패딩 증가
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SizedBox(
-            width: 80,
+            width: 100, // 라벨 영역 확장
             child: Text(
               label,
-              style: context.textStyles.labelMedium?.copyWith(
+              style: context.textStyles.labelLarge?.copyWith(
                 color: context.colors.onSurfaceVariant,
+                fontSize: 16, // 폰트 크기 증가
               ),
             ),
           ),
@@ -329,11 +344,48 @@ class MeetingDetailWidgets {
           Expanded(
             child: Text(
               value,
-              style: context.textStyles.bodyMedium,
+              style: context.textStyles.bodyLarge?.copyWith(fontSize: 16), // 폰트 크기 증가
             ),
           ),
         ],
       ),
+    );
+  }
+
+  /// 읽기 전용 비고 섹션 (출석 ID가 없을 때)
+  static Widget _buildReadOnlyNote(BuildContext context, String note) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '비고',
+          style: context.textStyles.labelLarge?.copyWith(
+            color: context.colors.onSurfaceVariant,
+            fontSize: 16, // 폰트 크기 증가
+          ),
+        ),
+        const SizedBox(height: 8),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(14), // 패딩 증가
+          decoration: BoxDecoration(
+            color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Text(
+            note.isEmpty ? '비고가 없습니다.' : note,
+            style: context.textStyles.bodyLarge?.copyWith( // bodyMedium에서 bodyLarge로 변경
+              color: note.isEmpty 
+                ? context.colors.onSurfaceVariant
+                : context.colors.onSurface,
+              fontStyle: note.isEmpty 
+                ? FontStyle.italic 
+                : null,
+              fontSize: 16, // 폰트 크기 증가
+            ),
+          ),
+        ),
+      ],
     );
   }
 
@@ -355,16 +407,17 @@ class MeetingDetailWidgets {
           children: [
             Text(
               '비고',
-              style: context.textStyles.labelMedium?.copyWith(
+              style: context.textStyles.labelLarge?.copyWith(
                 color: context.colors.onSurfaceVariant,
+                fontSize: 16, // 폰트 크기 증가
               ),
             ),
             const Spacer(),
             if (!isEditing)
               TextButton.icon(
                 onPressed: onEditToggle,
-                icon: const Icon(Icons.edit, size: 16),
-                label: const Text('편집'),
+                icon: const Icon(Icons.edit, size: 18), // 아이콘 크기 증가
+                label: const Text('편집', style: TextStyle(fontSize: 16)), // 폰트 크기 증가
                 style: TextButton.styleFrom(
                   padding: const EdgeInsets.symmetric(horizontal: 8),
                 ),
@@ -378,8 +431,10 @@ class MeetingDetailWidgets {
           TextField(
             controller: noteController,
             maxLines: 3,
+            style: const TextStyle(fontSize: 16), // 입력 텍스트 크기 증가
             decoration: InputDecoration(
               hintText: '비고를 입력하세요...',
+              hintStyle: const TextStyle(fontSize: 16),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(8),
               ),
@@ -391,12 +446,12 @@ class MeetingDetailWidgets {
               const Spacer(),
               TextButton(
                 onPressed: onEditCancel,
-                child: const Text('취소'),
+                child: const Text('취소', style: TextStyle(fontSize: 16)),
               ),
               const SizedBox(width: 8),
               ElevatedButton(
                 onPressed: () => onNoteSave(noteController.text),
-                child: const Text('저장'),
+                child: const Text('저장', style: TextStyle(fontSize: 16)),
               ),
             ],
           ),
@@ -405,20 +460,21 @@ class MeetingDetailWidgets {
         else ...[
           Container(
             width: double.infinity,
-            padding: const EdgeInsets.all(12),
+            padding: const EdgeInsets.all(14), // 패딩 증가
             decoration: BoxDecoration(
               color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
               currentNote.isEmpty ? '비고가 없습니다.' : currentNote,
-              style: context.textStyles.bodyMedium?.copyWith(
+              style: context.textStyles.bodyLarge?.copyWith(
                 color: currentNote.isEmpty 
                   ? context.colors.onSurfaceVariant
-                  : null,
+                  : context.colors.onSurface,
                 fontStyle: currentNote.isEmpty 
                   ? FontStyle.italic 
                   : null,
+                fontSize: 16, // 폰트 크기 증가
               ),
             ),
           ),
@@ -438,7 +494,7 @@ class MeetingDetailWidgets {
       child: FloatingActionButton.extended(
         onPressed: onPressed,
         icon: const Icon(Icons.edit),
-        label: const Text('모임 정보 수정'),
+        label: const Text('모임 정보 수정', style: TextStyle(fontSize: 16)),
         backgroundColor: context.colors.secondary,
         foregroundColor: context.colors.onSecondary,
       ),

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -1,0 +1,462 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme.dart';
+import '../../../models/meeting/meeting_detail_model.dart';
+import '../../../widgets/common/loading_widgets.dart';
+
+/// 모임 상세 화면 UI 위젯들 (Static Methods)
+/// 
+/// 모임 상세 정보 표시를 위한 UI 컴포넌트들
+class MeetingDetailWidgets {
+  
+  /// 로딩 위젯
+  static Widget buildLoading(BuildContext context) {
+    return LoadingWidgets.buildFullScreenLoading(
+      context,
+      message: '모임 정보를 불러오는 중...',
+    );
+  }
+
+  /// 에러 위젯
+  static Widget buildError(
+    BuildContext context, {
+    required String message,
+    required VoidCallback onRetry,
+  }) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.error_outline,
+              size: 64,
+              color: context.colors.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              '모임 정보를 불러올 수 없습니다',
+              style: context.textStyles.headlineSmall,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              message.replaceAll('[모임 상세 조회]', '').trim(),
+              style: context.textStyles.bodyMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 24),
+            ElevatedButton.icon(
+              onPressed: onRetry,
+              icon: const Icon(Icons.refresh),
+              label: const Text('다시 시도'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 메인 콘텐츠 위젯
+  static Widget buildMainContent(
+    BuildContext context,
+    MeetingDetailInfo meeting, {
+    required bool isEditing,
+    required VoidCallback onEditToggle,
+    required Function(String) onNoteSave,
+    required VoidCallback onEditCancel,
+  }) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // 모임 기본 정보
+          _buildMeetingInfoCard(context, meeting),
+          const SizedBox(height: 16),
+          
+          // 출석 정보
+          _buildAttendanceCard(
+            context, 
+            meeting,
+            isEditing: isEditing,
+            onEditToggle: onEditToggle,
+            onNoteSave: onNoteSave,
+            onEditCancel: onEditCancel,
+          ),
+          const SizedBox(height: 16),
+          
+          // 토론 정보
+          _buildDiscussionCard(context, meeting),
+          const SizedBox(height: 80), // FAB 공간 확보
+        ],
+      ),
+    );
+  }
+
+  /// 모임 기본 정보 카드
+  static Widget _buildMeetingInfoCard(
+    BuildContext context,
+    MeetingDetailInfo meeting,
+  ) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 제목
+            Row(
+              children: [
+                Icon(
+                  Icons.event,
+                  color: context.colors.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '모임 정보',
+                  style: context.textStyles.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            
+            // 모임 정보들
+            _buildInfoRow(context, '모임 제목', meeting.meetingName),
+            _buildInfoRow(context, '모임 유형', meeting.meetingTypeDisplayName),
+            _buildInfoRow(context, '개설자', meeting.meetingCreatorName),
+            _buildInfoRow(context, '개최일시', meeting.displayMeetingDateTime),
+            _buildInfoRow(context, '지각 기준', meeting.displayLateThresholdTime),
+            _buildInfoRow(context, '장소', meeting.meetingPlace),
+            _buildInfoRow(context, '개설일', meeting.displayCreatedAt),
+            
+            // 모임 설명
+            if (meeting.description.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text(
+                '모임 상세 내용',
+                style: context.textStyles.labelMedium?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  meeting.description,
+                  style: context.textStyles.bodyMedium,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 출석 정보 카드
+  static Widget _buildAttendanceCard(
+    BuildContext context,
+    MeetingDetailInfo meeting, {
+    required bool isEditing,
+    required VoidCallback onEditToggle,
+    required Function(String) onNoteSave,
+    required VoidCallback onEditCancel,
+  }) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 제목
+            Row(
+              children: [
+                Icon(
+                  Icons.check_circle_outline,
+                  color: context.colors.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '출석 정보',
+                  style: context.textStyles.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            
+            // 출석 상태
+            Row(
+              children: [
+                Text(
+                  '출석 상태',
+                  style: context.textStyles.labelMedium?.copyWith(
+                    color: context.colors.onSurfaceVariant,
+                  ),
+                ),
+                const SizedBox(width: 16),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: _getAttendanceStatusColor(context, meeting.attendanceStatusColorName),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Text(
+                    meeting.attendanceStatusDisplayName,
+                    style: context.textStyles.labelSmall?.copyWith(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            
+            // 비고 (편집 가능)
+            const SizedBox(height: 16),
+            _buildNoteSection(
+              context,
+              meeting.note ?? '',
+              isEditing: isEditing,
+              onEditToggle: onEditToggle,
+              onNoteSave: onNoteSave,
+              onEditCancel: onEditCancel,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 토론 정보 카드
+  static Widget _buildDiscussionCard(
+    BuildContext context,
+    MeetingDetailInfo meeting,
+  ) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // 제목
+            Row(
+              children: [
+                Icon(
+                  Icons.forum_outlined,
+                  color: context.colors.primary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '토론 정보',
+                  style: context.textStyles.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            
+            // 토론 정보들
+            _buildInfoRow(context, '토론 시간', meeting.displayDiscussionTime),
+            _buildInfoRow(context, '참석 희망', meeting.displayWantDiscussion),
+            
+            // 알림 메시지
+            if (meeting.alarmMessage != null && meeting.alarmMessage!.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Text(
+                '토론 알림 메시지',
+                style: context.textStyles.labelMedium?.copyWith(
+                  color: context.colors.onSurfaceVariant,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  meeting.alarmMessage!,
+                  style: context.textStyles.bodyMedium,
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  /// 정보 행 위젯
+  static Widget _buildInfoRow(BuildContext context, String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              label,
+              style: context.textStyles.labelMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Text(
+              value,
+              style: context.textStyles.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  /// 비고 섹션 위젯
+  static Widget _buildNoteSection(
+    BuildContext context,
+    String currentNote, {
+    required bool isEditing,
+    required VoidCallback onEditToggle,
+    required Function(String) onNoteSave,
+    required VoidCallback onEditCancel,
+  }) {
+    final TextEditingController noteController = TextEditingController(text: currentNote);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Text(
+              '비고',
+              style: context.textStyles.labelMedium?.copyWith(
+                color: context.colors.onSurfaceVariant,
+              ),
+            ),
+            const Spacer(),
+            if (!isEditing)
+              TextButton.icon(
+                onPressed: onEditToggle,
+                icon: const Icon(Icons.edit, size: 16),
+                label: const Text('편집'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        
+        // 편집 모드
+        if (isEditing) ...[
+          TextField(
+            controller: noteController,
+            maxLines: 3,
+            decoration: InputDecoration(
+              hintText: '비고를 입력하세요...',
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(8),
+              ),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Spacer(),
+              TextButton(
+                onPressed: onEditCancel,
+                child: const Text('취소'),
+              ),
+              const SizedBox(width: 8),
+              ElevatedButton(
+                onPressed: () => onNoteSave(noteController.text),
+                child: const Text('저장'),
+              ),
+            ],
+          ),
+        ]
+        // 표시 모드
+        else ...[
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              currentNote.isEmpty ? '비고가 없습니다.' : currentNote,
+              style: context.textStyles.bodyMedium?.copyWith(
+                color: currentNote.isEmpty 
+                  ? context.colors.onSurfaceVariant
+                  : null,
+                fontStyle: currentNote.isEmpty 
+                  ? FontStyle.italic 
+                  : null,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+
+  /// 운영진용 편집 FAB
+  static Widget buildEditFab(
+    BuildContext context, {
+    required VoidCallback onPressed,
+  }) {
+    return Positioned(
+      bottom: 16,
+      left: 16,
+      child: FloatingActionButton.extended(
+        onPressed: onPressed,
+        icon: const Icon(Icons.edit),
+        label: const Text('모임 정보 수정'),
+        backgroundColor: context.colors.secondary,
+        foregroundColor: context.colors.onSecondary,
+      ),
+    );
+  }
+
+  /// 출석 상태 색상 가져오기
+  static Color _getAttendanceStatusColor(BuildContext context, String colorName) {
+    switch (colorName) {
+      case 'green':
+        return Colors.green;
+      case 'orange':
+        return Colors.orange;
+      case 'blue':
+        return Colors.blue;
+      case 'grey':
+      default:
+        return Colors.grey;
+    }
+  }
+}

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme.dart';
 import '../../../models/meeting/meeting_detail_model.dart';
+import '../../../models/meeting/group_member_model.dart';
 import '../../../widgets/common/loading_widgets.dart';
 
 /// 모임 상세 화면 UI 위젯들 (Static Methods)
-/// 
+///
 /// 모임 상세 정보 표시를 위한 UI 컴포넌트들
 class MeetingDetailWidgets {
-  
   /// 로딩 위젯
   static Widget buildLoading(BuildContext context) {
     return LoadingWidgets.buildFullScreenLoading(
@@ -28,11 +28,7 @@ class MeetingDetailWidgets {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(
-              Icons.error_outline,
-              size: 64,
-              color: context.colors.error,
-            ),
+            Icon(Icons.error_outline, size: 64, color: context.colors.error),
             const SizedBox(height: 16),
             Text(
               '모임 정보를 불러올 수 없습니다',
@@ -77,10 +73,10 @@ class MeetingDetailWidgets {
           // 모임 기본 정보
           _buildMeetingInfoCard(context, meeting),
           const SizedBox(height: 16),
-          
+
           // 출석 정보
           _buildAttendanceCard(
-            context, 
+            context,
             meeting,
             isEditing: isEditing,
             onEditToggle: onEditToggle,
@@ -88,7 +84,7 @@ class MeetingDetailWidgets {
             onEditCancel: onEditCancel,
           ),
           const SizedBox(height: 16),
-          
+
           // 토론 정보
           _buildDiscussionCard(context, meeting),
           const SizedBox(height: 80), // FAB 공간 확보
@@ -128,7 +124,7 @@ class MeetingDetailWidgets {
               ],
             ),
             const SizedBox(height: 16),
-            
+
             // 모임 정보들
             _buildInfoRow(context, '모임 제목', meeting.meetingName),
             _buildInfoRow(context, '모임 유형', meeting.meetingTypeDisplayName),
@@ -137,7 +133,7 @@ class MeetingDetailWidgets {
             _buildInfoRow(context, '지각 기준시간', meeting.displayLateThresholdTime),
             _buildInfoRow(context, '장소', meeting.meetingPlace),
             _buildInfoRow(context, '개설일', meeting.displayCreatedAt),
-            
+
             // 모임 설명
             if (meeting.description.isNotEmpty) ...[
               const SizedBox(height: 12),
@@ -154,7 +150,9 @@ class MeetingDetailWidgets {
                 width: double.infinity,
                 padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -204,7 +202,7 @@ class MeetingDetailWidgets {
               ],
             ),
             const SizedBox(height: 16),
-            
+
             // 출석 상태
             Row(
               children: [
@@ -222,7 +220,10 @@ class MeetingDetailWidgets {
                     vertical: 6, // 패딩 증가
                   ),
                   decoration: BoxDecoration(
-                    color: _getAttendanceStatusColor(context, meeting.attendanceStatusColorName),
+                    color: _getAttendanceStatusColor(
+                      context,
+                      meeting.attendanceStatusColorName,
+                    ),
                     borderRadius: BorderRadius.circular(12),
                   ),
                   child: Text(
@@ -236,10 +237,10 @@ class MeetingDetailWidgets {
                 ),
               ],
             ),
-            
+
             // 비고 (편집 가능 - 출석 ID가 있을 때만)
             const SizedBox(height: 16),
-            if (meeting.attendanceId != null) 
+            if (meeting.attendanceId != null)
               _buildNoteSection(
                 context,
                 meeting.note ?? '',
@@ -287,13 +288,21 @@ class MeetingDetailWidgets {
               ],
             ),
             const SizedBox(height: 16),
-            
+
             // 토론 정보들
             _buildInfoRow(context, '토론 시간', meeting.displayDiscussionTime),
             _buildInfoRow(context, '참석 희망', meeting.displayWantDiscussion),
-            
+
+            // 토론 조 구성원
+            if (meeting.groupMemberList != null &&
+                meeting.groupMemberList!.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              _buildGroupMembersSection(context, meeting.groupMemberList!),
+            ],
+
             // 알림 메시지
-            if (meeting.alarmMessage != null && meeting.alarmMessage!.isNotEmpty) ...[
+            if (meeting.alarmMessage != null &&
+                meeting.alarmMessage!.isNotEmpty) ...[
               const SizedBox(height: 12),
               Text(
                 '토론 알림 메시지',
@@ -308,7 +317,9 @@ class MeetingDetailWidgets {
                 width: double.infinity,
                 padding: const EdgeInsets.all(14),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Text(
@@ -324,7 +335,11 @@ class MeetingDetailWidgets {
   }
 
   /// 정보 행 위젯
-  static Widget _buildInfoRow(BuildContext context, String label, String value) {
+  static Widget _buildInfoRow(
+    BuildContext context,
+    String label,
+    String value,
+  ) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 10), // 패딩 증가
       child: Row(
@@ -344,7 +359,9 @@ class MeetingDetailWidgets {
           Expanded(
             child: Text(
               value,
-              style: context.textStyles.bodyLarge?.copyWith(fontSize: 16), // 폰트 크기 증가
+              style: context.textStyles.bodyLarge?.copyWith(
+                fontSize: 16,
+              ), // 폰트 크기 증가
             ),
           ),
         ],
@@ -369,18 +386,19 @@ class MeetingDetailWidgets {
           width: double.infinity,
           padding: const EdgeInsets.all(14), // 패딩 증가
           decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+            color: Theme.of(
+              context,
+            ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
             borderRadius: BorderRadius.circular(8),
           ),
           child: Text(
             note.isEmpty ? '비고가 없습니다.' : note,
-            style: context.textStyles.bodyLarge?.copyWith( // bodyMedium에서 bodyLarge로 변경
-              color: note.isEmpty 
-                ? context.colors.onSurfaceVariant
-                : context.colors.onSurface,
-              fontStyle: note.isEmpty 
-                ? FontStyle.italic 
-                : null,
+            style: context.textStyles.bodyLarge?.copyWith(
+              // bodyMedium에서 bodyLarge로 변경
+              color: note.isEmpty
+                  ? context.colors.onSurfaceVariant
+                  : context.colors.onSurface,
+              fontStyle: note.isEmpty ? FontStyle.italic : null,
               fontSize: 16, // 폰트 크기 증가
             ),
           ),
@@ -398,7 +416,9 @@ class MeetingDetailWidgets {
     required Function(String) onNoteSave,
     required VoidCallback onEditCancel,
   }) {
-    final TextEditingController noteController = TextEditingController(text: currentNote);
+    final TextEditingController noteController = TextEditingController(
+      text: currentNote,
+    );
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -417,7 +437,10 @@ class MeetingDetailWidgets {
               TextButton.icon(
                 onPressed: onEditToggle,
                 icon: const Icon(Icons.edit, size: 18), // 아이콘 크기 증가
-                label: const Text('편집', style: TextStyle(fontSize: 16)), // 폰트 크기 증가
+                label: const Text(
+                  '편집',
+                  style: TextStyle(fontSize: 16),
+                ), // 폰트 크기 증가
                 style: TextButton.styleFrom(
                   padding: const EdgeInsets.symmetric(horizontal: 8),
                 ),
@@ -425,7 +448,7 @@ class MeetingDetailWidgets {
           ],
         ),
         const SizedBox(height: 8),
-        
+
         // 편집 모드
         if (isEditing) ...[
           TextField(
@@ -462,18 +485,18 @@ class MeetingDetailWidgets {
             width: double.infinity,
             padding: const EdgeInsets.all(14), // 패딩 증가
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.5),
+              color: Theme.of(
+                context,
+              ).colorScheme.surfaceContainerHighest.withOpacity(0.5),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
               currentNote.isEmpty ? '비고가 없습니다.' : currentNote,
               style: context.textStyles.bodyLarge?.copyWith(
-                color: currentNote.isEmpty 
-                  ? context.colors.onSurfaceVariant
-                  : context.colors.onSurface,
-                fontStyle: currentNote.isEmpty 
-                  ? FontStyle.italic 
-                  : null,
+                color: currentNote.isEmpty
+                    ? context.colors.onSurfaceVariant
+                    : context.colors.onSurface,
+                fontStyle: currentNote.isEmpty ? FontStyle.italic : null,
                 fontSize: 16, // 폰트 크기 증가
               ),
             ),
@@ -501,8 +524,60 @@ class MeetingDetailWidgets {
     );
   }
 
+  /// 토론 조 구성원 섹션
+  static Widget _buildGroupMembersSection(
+    BuildContext context,
+    List<GroupMember> groupMembers,
+  ) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '토론 조 구성원',
+          style: context.textStyles.labelLarge?.copyWith(
+            color: context.colors.onSurfaceVariant,
+            fontWeight: FontWeight.w500,
+            fontSize: 16,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8.0, // Chip 간 가로 간격
+          runSpacing: 6.0, // Chip 간 세로 간격
+          children: groupMembers
+              .map((member) => _buildMemberChip(context, member))
+              .toList(),
+        ),
+      ],
+    );
+  }
+
+  /// 개별 조 구성원 Chip
+  static Widget _buildMemberChip(BuildContext context, GroupMember member) {
+    return Chip(
+      label: Text(
+        member.memberName,
+        style: context.textStyles.labelMedium?.copyWith(
+          fontSize: 14,
+          fontWeight: FontWeight.w500,
+          color: context.colors.primary, // 텍스트 색상을 직접 지정
+        ),
+      ),
+      backgroundColor: context.colors.primary.withOpacity(0.1),
+      side: BorderSide(
+        color: context.colors.primary.withOpacity(0.3),
+        width: 1,
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+    );
+  }
+
   /// 출석 상태 색상 가져오기
-  static Color _getAttendanceStatusColor(BuildContext context, String colorName) {
+  static Color _getAttendanceStatusColor(
+    BuildContext context,
+    String colorName,
+  ) {
     switch (colorName) {
       case 'green':
         return Colors.green;

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -45,10 +45,6 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
 
   /// 초기 데이터 로드
   Future<void> initializeMemberList() async {
-    if (AppConfig.debugMode) {
-      print('🚀 [MemberLogicMixin] 모임원 목록 초기화 시작');
-    }
-
     // 🎯 MemberService는 Singleton이므로 이미 초기화됨
 
     // 🎯 사용자 권한에 따른 필터 표시 가능 여부 설정
@@ -64,11 +60,6 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
   Future<void> _updateDeletedFilterPermission() async {
     final userRole = await _getUserRole();
     _canShowDeletedFilterSync = MemberService.canUseDeletedFilter(userRole);
-    
-    if (AppConfig.debugMode) {
-      print('🔍 [MemberLogicMixin] 사용자 권한: $userRole');
-      print('🔍 [MemberLogicMixin] 비활성 계정 필터 사용 가능: $_canShowDeletedFilterSync');
-    }
   }
 
   /// 🎯 초기 필터 설정 (비관리자급은 활성 계정만)
@@ -79,14 +70,6 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
     if (!isAdminLevel) {
       // 비관리자급은 초기 필터에 활성 계정만 조회로 설정
       _currentFilter = _currentFilter.copyWith(isDeleted: false);
-      
-      if (AppConfig.debugMode) {
-        print('🎨 [MemberLogicMixin] 초기 필터 설정: 비관리자급($userRole) - 활성 계정만 조회');
-      }
-    } else {
-      if (AppConfig.debugMode) {
-        print('🎨 [MemberLogicMixin] 초기 필터 설정: 관리자급($userRole) - 모든 계정 조회 가능');
-      }
     }
   }
 

--- a/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/member/mixins/member_logic_mixin.dart
@@ -49,8 +49,7 @@ mixin MemberLogicMixin<T extends StatefulWidget> on State<T> {
       print('🚀 [MemberLogicMixin] 모임원 목록 초기화 시작');
     }
 
-    // 🎯 MemberService 초기화
-    _memberService.initialize();
+    // 🎯 MemberService는 Singleton이므로 이미 초기화됨
 
     // 🎯 사용자 권한에 따른 필터 표시 가능 여부 설정
     await _updateDeletedFilterPermission();

--- a/geulnamu_frontend/lib/screens/profile/mixins/profile_admin_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/profile/mixins/profile_admin_logic_mixin.dart
@@ -67,8 +67,7 @@ mixin ProfileAdminLogicMixin<T extends StatefulWidget> on State<T> {
     super.initState();
     _nameController = TextEditingController(); // 🎯 Controller 초기화
     
-    // 🎯 MemberService 초기화
-    _memberService.initialize();
+    // 🎯 MemberService는 Singleton이므로 이미 초기화됨
     
     // 🛡️ 관리자 모드 권한 검증
     if (isAdminMode) {

--- a/geulnamu_frontend/lib/services/attendance/attendance_service.dart
+++ b/geulnamu_frontend/lib/services/attendance/attendance_service.dart
@@ -19,10 +19,6 @@ class AttendanceService {
     _dio = ApiUtils.createDioWithTimeout(
       baseUrl: AppConfig.apiBaseUrl,
     );
-    
-    if (AppConfig.debugMode) {
-      print('✅ [AttendanceService] 캐시 무효화 인터셉터와 함께 초기화 완료');
-    }
   }
 
   late final Dio _dio;

--- a/geulnamu_frontend/lib/services/attendance/attendance_service.dart
+++ b/geulnamu_frontend/lib/services/attendance/attendance_service.dart
@@ -14,16 +14,18 @@ import '../../models/attendance/request/attendance_note_request.dart';
 class AttendanceService {
   static final AttendanceService _instance = AttendanceService._internal();
   factory AttendanceService() => _instance;
-  AttendanceService._internal();
-
-  final Dio _dio = Dio();
-
-  /// 서비스 초기화
-  void initialize() {
-    _dio.options.baseUrl = AppConfig.apiBaseUrl;
-    _dio.options.connectTimeout = const Duration(seconds: 5);
-    _dio.options.receiveTimeout = const Duration(seconds: 3);
+  AttendanceService._internal() {
+    // 🔧 생성자에서 즉시 Dio 초기화
+    _dio = ApiUtils.createDioWithTimeout(
+      baseUrl: AppConfig.apiBaseUrl,
+    );
+    
+    if (AppConfig.debugMode) {
+      print('✅ [AttendanceService] 캐시 무효화 인터셉터와 함께 초기화 완료');
+    }
   }
+
+  late final Dio _dio;
 
   /// 모임 출석 체크인
   /// 

--- a/geulnamu_frontend/lib/services/attendance/attendance_service.dart
+++ b/geulnamu_frontend/lib/services/attendance/attendance_service.dart
@@ -1,0 +1,260 @@
+import 'package:dio/dio.dart';
+import '../../core/config/app_config.dart';
+import '../../core/utils/api_utils.dart';
+import '../../models/attendance/request/attendance_note_request.dart';
+
+/// 출석 관리 서비스 (Singleton)
+/// 
+/// 제공 기능:
+/// - 모임 출석 체크인
+/// - 본인 출석 정보 조회
+/// - 모임별 출석 현황 조회
+/// - 비고 작성
+/// - 토론 참석 의사 변경
+class AttendanceService {
+  static final AttendanceService _instance = AttendanceService._internal();
+  factory AttendanceService() => _instance;
+  AttendanceService._internal();
+
+  final Dio _dio = Dio();
+
+  /// 서비스 초기화
+  void initialize() {
+    _dio.options.baseUrl = AppConfig.apiBaseUrl;
+    _dio.options.connectTimeout = const Duration(seconds: 5);
+    _dio.options.receiveTimeout = const Duration(seconds: 3);
+  }
+
+  /// 모임 출석 체크인
+  /// 
+  /// API: POST /attendances/check-in?meetingId={meetingId}
+  /// 권한: MEMBER 이상
+  Future<int> checkIn({
+    required int meetingId,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [출석 체크인] API 요청 시작...');
+        print('🔗 [출석 체크인] 요청 URL: ${_dio.options.baseUrl}/attendances/check-in?meetingId=$meetingId');
+      }
+
+      final response = await _dio.post(
+        '/attendances/check-in',
+        queryParameters: {'meetingId': meetingId},
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '출석 체크인',
+        );
+
+        final attendanceId = processedResponse['data'] as int;
+        
+        if (AppConfig.debugMode) {
+          print('✅ [출석 체크인] 성공 - 출석 ID: $attendanceId');
+        }
+
+        return attendanceId;
+      } else {
+        throw Exception('[출석 체크인] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [출석 체크인] 오류 발생: $e');
+      }
+      
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '출석 체크인');
+      }
+      rethrow;
+    }
+  }
+
+  /// 비고 작성
+  /// 
+  /// API: PATCH /attendances/{attendanceId}/note
+  /// 권한: MEMBER 이상 (본인 출석만 수정 가능)
+  Future<void> writeNote({
+    required int attendanceId,
+    required String note,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [비고 작성] API 요청 시작...');
+        print('🔗 [비고 작성] 요청 URL: ${_dio.options.baseUrl}/attendances/$attendanceId/note');
+        print('📝 [비고 작성] 비고 내용: $note');
+      }
+
+      final request = AttendanceNoteRequest(note: note);
+
+      final response = await _dio.patch(
+        '/attendances/$attendanceId/note',
+        data: request.toJson(),
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '비고 작성',
+          expectData: false, // Void 응답이므로 data 없음
+        );
+        
+        if (AppConfig.debugMode) {
+          print('✅ [비고 작성] 성공');
+        }
+      } else {
+        throw Exception('[비고 작성] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [비고 작성] 오류 발생: $e');
+      }
+      
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '비고 작성');
+      }
+      rethrow;
+    }
+  }
+
+  /// 독서만 할래요 (토론 불참)
+  /// 
+  /// API: PATCH /attendances/{attendanceId}/just-read
+  /// 권한: MEMBER 이상
+  Future<void> setJustRead({
+    required int attendanceId,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [독서만 할래요] API 요청 시작...');
+      }
+
+      final response = await _dio.patch(
+        '/attendances/$attendanceId/just-read',
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        ApiUtils.processBackendResponse(
+          response,
+          '독서만 할래요',
+          expectData: false,
+        );
+        
+        if (AppConfig.debugMode) {
+          print('✅ [독서만 할래요] 성공');
+        }
+      } else {
+        throw Exception('[독서만 할래요] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [독서만 할래요] 오류 발생: $e');
+      }
+      
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '독서만 할래요');
+      }
+      rethrow;
+    }
+  }
+
+  /// 토론할래요 (토론 참석)
+  /// 
+  /// API: PATCH /attendances/{attendanceId}/want-discussion
+  /// 권한: MEMBER 이상
+  Future<void> setWantDiscussion({
+    required int attendanceId,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [토론할래요] API 요청 시작...');
+      }
+
+      final response = await _dio.patch(
+        '/attendances/$attendanceId/want-discussion',
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        ApiUtils.processBackendResponse(
+          response,
+          '토론할래요',
+          expectData: false,
+        );
+        
+        if (AppConfig.debugMode) {
+          print('✅ [토론할래요] 성공');
+        }
+      } else {
+        throw Exception('[토론할래요] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [토론할래요] 오류 발생: $e');
+      }
+      
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '토론할래요');
+      }
+      rethrow;
+    }
+  }
+
+  /// 본인 출석 정보 조회
+  /// 
+  /// API: GET /attendances/my-info?meetingId={meetingId}
+  /// 권한: MEMBER 이상
+  /// 
+  /// 향후 구현 예정 (현재는 모임 상세에서 함께 조회됨)
+  /*
+  Future<AttendanceInfo> getMyAttendanceInfo({
+    required int meetingId,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 필요시 구현
+  }
+  */
+
+  /// 모임별 출석 현황 조회
+  /// 
+  /// API: GET /attendances/list?meetingId={meetingId}
+  /// 권한: MEMBER 이상
+  /// 
+  /// 향후 구현 예정 (출석 현황 페이지에서 사용)
+  /*
+  Future<MeetingAttendanceDetails> getMeetingAttendanceStatus({
+    required int meetingId,
+    required String accessToken,
+  }) async {
+    // TODO: 향후 구현
+  }
+  */
+}

--- a/geulnamu_frontend/lib/services/home/home_route_service.dart
+++ b/geulnamu_frontend/lib/services/home/home_route_service.dart
@@ -24,7 +24,6 @@ class HomeRouteService {
     if (route != null && route is PageRoute) {
       try {
         routeObserver.subscribe(routeAware, route as PageRoute<dynamic>);
-        debugPrint('✅ [HomeRouteService] RouteObserver 등록 성공');
       } catch (e) {
         debugPrint('⚠️ [HomeRouteService] RouteObserver 등록 실패: $e');
       }
@@ -34,29 +33,28 @@ class HomeRouteService {
   void unregisterRouteObserver(RouteAware routeAware) {
     try {
       routeObserver.unsubscribe(routeAware);
-      debugPrint('✅ [HomeRouteService] RouteObserver 구독 해제 완료');
     } catch (e) {
       debugPrint('⚠️ [HomeRouteService] RouteObserver 구독 해제 실패: $e');
     }
   }
 
-  // 🎯 RouteAware 이벤트 처리 메서드들
+  // 🎯 RouteAware 이벤트 처리 메서드들 (로그 없이 기능만 유지)
 
   void onPush() {
-    debugPrint('🏠 [HomeRouteService] 화면 진입 (didPush)');
+    // 로그 제거: 기능만 유지
   }
 
   void onPushNext() {
-    debugPrint('🚪 [HomeRouteService] 다른 화면으로 이동 (didPushNext)');
+    // 로그 제거: 기능만 유지
   }
 
   void onPopNext(BuildContext context) {
-    debugPrint('🔄 [HomeRouteService] 다른 화면에서 돌아옴 감지 (didPopNext)');
+    // 로그 제거: 기능만 유지
     // 🎯 제거: 캐시 체크 로직 - ProfileStatusService에서 자동 처리
   }
 
   void onPop() {
-    debugPrint('🚪 [HomeRouteService] 화면 종료 (didPop)');
+    // 로그 제거: 기능만 유지
     // 🎯 제거: 캐시 초기화 로직 - ProfileStatusService에서 자동 처리
   }
 }

--- a/geulnamu_frontend/lib/services/meeting/meeting_service.dart
+++ b/geulnamu_frontend/lib/services/meeting/meeting_service.dart
@@ -15,16 +15,18 @@ import '../../models/meeting/meeting_detail_model.dart';
 class MeetingService {
   static final MeetingService _instance = MeetingService._internal();
   factory MeetingService() => _instance;
-  MeetingService._internal();
-
-  final Dio _dio = Dio();
-
-  /// 서비스 초기화
-  void initialize() {
-    _dio.options.baseUrl = AppConfig.apiBaseUrl;
-    _dio.options.connectTimeout = const Duration(seconds: 5);
-    _dio.options.receiveTimeout = const Duration(seconds: 3);
+  MeetingService._internal() {
+    // 🔧 생성자에서 즉시 Dio 초기화
+    _dio = ApiUtils.createDioWithTimeout(
+      baseUrl: AppConfig.apiBaseUrl,
+    );
+    
+    if (AppConfig.debugMode) {
+      print('✅ [MeetingService] 캐시 무효화 인터셉터와 함께 초기화 완료');
+    }
   }
+
+  late final Dio _dio;
 
   /// 모임 생성
   /// 
@@ -93,14 +95,25 @@ class MeetingService {
       if (AppConfig.debugMode) {
         print('🚀 [모임 목록 조회] API 요청 시작...');
       }
+      
+      // 🔥 강제 캐시 버스트 추가
+      final timestamp = DateTime.now().millisecondsSinceEpoch;
+      final queryParams = filter.toQueryParameters(isStaffMode: isStaffMode);
+      queryParams['_cache_bust'] = timestamp.toString();
+      queryParams['_t'] = timestamp.toString();
 
       final response = await _dio.get(
         '/meetings/list',
-        queryParameters: filter.toQueryParameters(isStaffMode: isStaffMode), // 🆕 isStaffMode 전달
+        queryParameters: queryParams,
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
             'Content-Type': 'application/json',
+            // 🔥 강력한 캐시 무효화 헤더
+            'Cache-Control': 'no-cache, no-store, must-revalidate, max-age=0',
+            'Pragma': 'no-cache',
+            'Expires': '0',
+            'If-Modified-Since': 'Mon, 26 Jul 1997 05:00:00 GMT',
           },
         ),
       );

--- a/geulnamu_frontend/lib/services/meeting/meeting_service.dart
+++ b/geulnamu_frontend/lib/services/meeting/meeting_service.dart
@@ -139,11 +139,6 @@ class MeetingService {
     required String accessToken,
   }) async {
     try {
-      if (AppConfig.debugMode) {
-        print('🚀 [모임 상세 조회] API 요청 시작...');
-        print('🔗 [모임 상세 조회] 요청 URL: ${_dio.options.baseUrl}/meetings/$meetingId');
-      }
-
       final response = await _dio.get(
         '/meetings/$meetingId',
         options: Options(
@@ -162,19 +157,11 @@ class MeetingService {
 
         final meetingDetail = MeetingDetailInfo.fromJson(processedResponse['data']);
         
-        if (AppConfig.debugMode) {
-          print('✅ [모임 상세 조회] 성공 - 모임: ${meetingDetail.meetingName}');
-        }
-
         return meetingDetail;
       } else {
         throw Exception('[모임 상세 조회] HTTP 오류: ${response.statusCode}');
       }
     } catch (e) {
-      if (AppConfig.debugMode) {
-        print('❌ [모임 상세 조회] 오류 발생: $e');
-      }
-      
       if (e is DioException) {
         throw ApiUtils.processDioException(e, '모임 상세 조회');
       }

--- a/geulnamu_frontend/lib/services/meeting/meeting_service.dart
+++ b/geulnamu_frontend/lib/services/meeting/meeting_service.dart
@@ -4,6 +4,7 @@ import '../../core/utils/api_utils.dart';
 import '../../models/meeting/meeting_model.dart';
 import '../../models/meeting/meeting_filter_model.dart';
 import '../../models/meeting/request/meeting_create_request.dart';
+import '../../models/meeting/meeting_detail_model.dart';
 
 /// 모임 관리 서비스 (Singleton)
 /// 
@@ -127,6 +128,58 @@ class MeetingService {
       
       if (e is DioException) {
         throw ApiUtils.processDioException(e, '모임 목록 조회');
+      }
+      rethrow;
+    }
+  }
+
+  /// 모임 상세 조회
+  /// 
+  /// API: GET /meetings/{meetingId}
+  /// 권한: MEMBER 이상
+  Future<MeetingDetailInfo> getMeetingDetail({
+    required int meetingId,
+    required String accessToken,
+  }) async {
+    try {
+      if (AppConfig.debugMode) {
+        print('🚀 [모임 상세 조회] API 요청 시작...');
+        print('🔗 [모임 상세 조회] 요청 URL: ${_dio.options.baseUrl}/meetings/$meetingId');
+      }
+
+      final response = await _dio.get(
+        '/meetings/$meetingId',
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $accessToken',
+            'Content-Type': 'application/json',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final processedResponse = ApiUtils.processBackendResponse(
+          response,
+          '모임 상세 조회',
+        );
+
+        final meetingDetail = MeetingDetailInfo.fromJson(processedResponse['data']);
+        
+        if (AppConfig.debugMode) {
+          print('✅ [모임 상세 조회] 성공 - 모임: ${meetingDetail.meetingName}');
+        }
+
+        return meetingDetail;
+      } else {
+        throw Exception('[모임 상세 조회] HTTP 오류: ${response.statusCode}');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [모임 상세 조회] 오류 발생: $e');
+      }
+      
+      if (e is DioException) {
+        throw ApiUtils.processDioException(e, '모임 상세 조회');
       }
       rethrow;
     }

--- a/geulnamu_frontend/lib/services/meeting/meeting_service.dart
+++ b/geulnamu_frontend/lib/services/meeting/meeting_service.dart
@@ -20,10 +20,6 @@ class MeetingService {
     _dio = ApiUtils.createDioWithTimeout(
       baseUrl: AppConfig.apiBaseUrl,
     );
-    
-    if (AppConfig.debugMode) {
-      print('✅ [MeetingService] 캐시 무효화 인터셉터와 함께 초기화 완료');
-    }
   }
 
   late final Dio _dio;
@@ -92,10 +88,6 @@ class MeetingService {
     bool isStaffMode = false, // 🆕 운영진용 모드 여부
   }) async {
     try {
-      if (AppConfig.debugMode) {
-        print('🚀 [모임 목록 조회] API 요청 시작...');
-      }
-      
       // 🔥 강제 캐시 버스트 추가
       final timestamp = DateTime.now().millisecondsSinceEpoch;
       final queryParams = filter.toQueryParameters(isStaffMode: isStaffMode);
@@ -126,19 +118,11 @@ class MeetingService {
 
         final meetingListResponse = MeetingListResponse.fromJson(processedResponse['data']);
         
-        if (AppConfig.debugMode) {
-          print('✅ [모임 목록 조회] 성공 - 총 ${meetingListResponse.meetingList.length}개 모임 로드');
-        }
-
         return meetingListResponse;
       } else {
         throw Exception('[모임 목록 조회] HTTP 오류: ${response.statusCode}');
       }
     } catch (e) {
-      if (AppConfig.debugMode) {
-        print('❌ [모임 목록 조회] 오류 발생: $e');
-      }
-      
       if (e is DioException) {
         throw ApiUtils.processDioException(e, '모임 목록 조회');
       }

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -15,21 +15,18 @@ import '../../models/member/member_list_model.dart';
 class MemberService {
   static final MemberService _instance = MemberService._internal();
   factory MemberService() => _instance;
-  MemberService._internal();
-
-  final Dio _dio = Dio(); // late 제거하고 즉시 초기화
-
-  /// 서비스 초기화
-  void initialize() {
-    // 기본 설정 적용
-    _dio.options.baseUrl = AppConfig.apiBaseUrl;
-    _dio.options.connectTimeout = const Duration(seconds: 5);
-    _dio.options.receiveTimeout = const Duration(seconds: 3);
+  MemberService._internal() {
+    // 🔧 생성자에서 즉시 Dio 초기화
+    _dio = ApiUtils.createDioWithTimeout(
+      baseUrl: AppConfig.apiBaseUrl,
+    );
     
     if (AppConfig.debugMode) {
-      print('🔧 [MemberService] 서비스 초기화 완료');
+      print('✅ [MemberService] 캐시 무효화 인터셉터와 함께 초기화 완료');
     }
   }
+
+  late final Dio _dio;
 
   /// 🎯 개별 모임원 상세 조회 (관리자용)
   /// 

--- a/geulnamu_frontend/lib/services/member/member_service.dart
+++ b/geulnamu_frontend/lib/services/member/member_service.dart
@@ -20,10 +20,6 @@ class MemberService {
     _dio = ApiUtils.createDioWithTimeout(
       baseUrl: AppConfig.apiBaseUrl,
     );
-    
-    if (AppConfig.debugMode) {
-      print('✅ [MemberService] 캐시 무효화 인터셉터와 함께 초기화 완료');
-    }
   }
 
   late final Dio _dio;

--- a/geulnamu_frontend/lib/services/profile/profile_service.dart
+++ b/geulnamu_frontend/lib/services/profile/profile_service.dart
@@ -18,10 +18,6 @@ class ProfileService {
     _dio = ApiUtils.createDioWithTimeout(
       baseUrl: AppConfig.apiBaseUrl,
     );
-    
-    if (AppConfig.debugMode) {
-      print('✅ [ProfileService] 캐시 무효화 인터셉터와 함께 초기화 완료');
-    }
   }
 
   late final Dio _dio;

--- a/geulnamu_frontend/lib/services/profile/profile_service.dart
+++ b/geulnamu_frontend/lib/services/profile/profile_service.dart
@@ -13,54 +13,38 @@ class ProfileService {
   // 🎯 Singleton 패턴
   static final ProfileService _instance = ProfileService._internal();
   factory ProfileService() => _instance;
-  ProfileService._internal();
-
-  final Dio _dio = Dio();
-  
-  /// 🚫 캐시 방지 전용 Dio 인스턴스 생성
-  Dio _createNoCacheDio() {
-    final dio = Dio();
+  ProfileService._internal() {
+    // 🔧 생성자에서 즉시 Dio 초기화
+    _dio = ApiUtils.createDioWithTimeout(
+      baseUrl: AppConfig.apiBaseUrl,
+    );
     
-    // 🚫 기본 옵션에서 캐시 비활성화
-    dio.options.headers.addAll({
-      'Cache-Control': 'no-cache, no-store, must-revalidate',
-      'Pragma': 'no-cache',
-      'Expires': '0',
-    });
-    
-    return dio;
+    if (AppConfig.debugMode) {
+      print('✅ [ProfileService] 캐시 무효화 인터셉터와 함께 초기화 완료');
+    }
   }
 
-  /// 본인 프로필 정보 조회 (캐시 방지 강화 버전)
+  late final Dio _dio;
+
+  /// 본인 프로필 정보 조회
   /// 
   /// API: GET /members/me/profile
   /// 권한: MEMBER 이상
-  /// 🚫 강력한 캐시 방지 적용
+  /// 🆕 글로벌 캐시 무효화 인터셉터 적용
   Future<ProfileModel> getMyProfile(String accessToken) async {
     try {
       if (AppConfig.debugMode) {
         print('🚀 [ProfileService] 본인 프로필 조회 시작...');
       }
 
-      // 🚫 캐시 방지 전용 Dio 인스턴스 사용
-      final noCacheDio = _createNoCacheDio();
-      
-      final response = await noCacheDio.get(
-        AppConfig.getApiEndpoint('members/me/profile'),
+      final response = await _dio.get(
+        '/members/me/profile',
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
             'Content-Type': 'application/json',
-            // 🚫 강력한 캐시 방지 헤더 추가
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            'Pragma': 'no-cache',
-            'Expires': '0',
-            // 🔄 매번 다른 요청으로 인식하도록 타임스탬프 추가
-            'X-Request-Time': DateTime.now().millisecondsSinceEpoch.toString(),
           },
         ),
-        // 🚫 쿼리 파라미터로도 캐싱 방지
-        queryParameters: {'_t': DateTime.now().millisecondsSinceEpoch},
       );
 
       if (response.statusCode == 200) {
@@ -75,7 +59,7 @@ class ProfileService {
           final profile = ProfileModel.fromJson(profileData);
           
           if (AppConfig.debugMode) {
-            print('✅ [ProfileService] 프로필 조회 성공: ${profile.displayName}');  // null 안전 getter 사용
+            print('✅ [ProfileService] 프로필 조회 성공: ${profile.displayName}');
           }
           
           return profile;
@@ -110,7 +94,7 @@ class ProfileService {
       }
 
       final response = await _dio.patch(
-        AppConfig.getApiEndpoint('members/me/profile'),
+        '/members/me/profile',
         data: updatedProfile.toUpdateJson(),
         options: Options(
           headers: {
@@ -158,25 +142,14 @@ class ProfileService {
         print('🚀 [ProfileService] 모임원 정보 조회 시작... (ID: $memberId)');
       }
 
-      // 🚫 캐시 방지 전용 Dio 인스턴스 사용
-      final noCacheDio = _createNoCacheDio();
-      
-      final response = await noCacheDio.get(
-        AppConfig.getApiEndpoint('members/$memberId'),
+      final response = await _dio.get(
+        '/members/$memberId',
         options: Options(
           headers: {
             'Authorization': 'Bearer $accessToken',
             'Content-Type': 'application/json',
-            // 🚫 강력한 캐시 방지 헤더 추가
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            'Pragma': 'no-cache',
-            'Expires': '0',
-            // 🔄 매번 다른 요청으로 인식하도록 타임스탬프 추가
-            'X-Request-Time': DateTime.now().millisecondsSinceEpoch.toString(),
           },
         ),
-        // 🚫 쿼리 파라미터로도 캐싱 방지
-        queryParameters: {'_t': DateTime.now().millisecondsSinceEpoch},
       );
 
       if (response.statusCode == 200) {


### PR DESCRIPTION
# 변경 내역
## (프론트 엔드) 페이지 구현
### 모임 상세 페이지
- 모임 상세 페이지 구현 및 백엔드 API 연동
  - 하위 기능으로 '비고 작성' 기능 연동
  - 하위 기능으로 '독서만 할래요' 기능 연동
  - 하위 기능으로 '토론할래요' 기능 연동
## 백엔드 API
### API 수정
- 모임 상세 조회 API 에서 본인 토론조 구성원 정보 같이 가져오도록 로직 수정
- 관련 내용 테스트 코드 및 API 문서 반영
