### PR TITLE
[Feat/FE] 모바일 환경 대응 UI 수정

### DIFF
--- a/geulnamu_frontend/lib/core/constants/permission_constants.dart
+++ b/geulnamu_frontend/lib/core/constants/permission_constants.dart
@@ -43,13 +43,13 @@ class PermissionConstants {
     '출석 체크': PermissionLevel.MEMBER,
     '발제 작성': PermissionLevel.MEMBER,
     '발제문 목록': PermissionLevel.MEMBER, // 🆕 발제문 목록
-    '모임 만들기': PermissionLevel.MEMBER,
     '모임 참여': PermissionLevel.MEMBER,
     '개인 대시보드': PermissionLevel.MEMBER,
 
     // STAFF: 운영진 이상 (모임 관리 관련)
     '모임원 목록': PermissionLevel.STAFF, // 🆕 모임원 목록
     '모임 목록 (운영진용)': PermissionLevel.STAFF, // 🆕 운영진용 모임 목록
+    '모임 만들기': PermissionLevel.STAFF, // 🔥 STAFF로 변경
     '모임 관리': PermissionLevel.STAFF,
     '모임 수정': PermissionLevel.STAFF,
     '모임 삭제': PermissionLevel.STAFF,

--- a/geulnamu_frontend/lib/core/constants/permission_constants.dart
+++ b/geulnamu_frontend/lib/core/constants/permission_constants.dart
@@ -38,18 +38,18 @@ class PermissionConstants {
     '프로필': PermissionLevel.MEMBER,
     '설정': PermissionLevel.MEMBER,
     '로그아웃': PermissionLevel.MEMBER,
-    '모임 목록': PermissionLevel.MEMBER,  // 🆕 일반 모임 목록
+    '모임 목록': PermissionLevel.MEMBER, // 🆕 일반 모임 목록
     '오늘의 모임': PermissionLevel.MEMBER,
     '출석 체크': PermissionLevel.MEMBER,
     '발제 작성': PermissionLevel.MEMBER,
-    '발제문 목록': PermissionLevel.MEMBER,  // 🆕 발제문 목록
+    '발제문 목록': PermissionLevel.MEMBER, // 🆕 발제문 목록
     '모임 만들기': PermissionLevel.MEMBER,
     '모임 참여': PermissionLevel.MEMBER,
     '개인 대시보드': PermissionLevel.MEMBER,
 
     // STAFF: 운영진 이상 (모임 관리 관련)
-    '모임원 목록': PermissionLevel.STAFF,  // 🆕 모임원 목록
-    '모임 목록 (운영진용)': PermissionLevel.STAFF,  // 🆕 운영진용 모임 목록
+    '모임원 목록': PermissionLevel.STAFF, // 🆕 모임원 목록
+    '모임 목록 (운영진용)': PermissionLevel.STAFF, // 🆕 운영진용 모임 목록
     '모임 관리': PermissionLevel.STAFF,
     '모임 수정': PermissionLevel.STAFF,
     '모임 삭제': PermissionLevel.STAFF,
@@ -69,13 +69,13 @@ class PermissionConstants {
   ///
   /// 백엔드에서 받은 role 문자열을 PermissionLevel로 변환
   static const Map<String, PermissionLevel> roleToPermissionLevel = {
-    'GUEST': PermissionLevel.PUBLIC,    // 비회원
-    'MEMBER': PermissionLevel.MEMBER,   // 일반 회원
+    'GUEST': PermissionLevel.PUBLIC, // 비회원
+    'MEMBER': PermissionLevel.MEMBER, // 모임원
     'VICE_STAFF': PermissionLevel.STAFF, // 준운영진 → STAFF
-    'STAFF': PermissionLevel.STAFF,     // 운영진 → STAFF
+    'STAFF': PermissionLevel.STAFF, // 운영진 → STAFF
     'VICE_LEADER': PermissionLevel.ADMIN, // 부모임장 → ADMIN ✅
-    'LEADER': PermissionLevel.ADMIN,    // 모임장 → ADMIN ✅
-    'ADMIN': PermissionLevel.ADMIN,     // 관리자 → ADMIN ✅
+    'LEADER': PermissionLevel.ADMIN, // 모임장 → ADMIN ✅
+    'ADMIN': PermissionLevel.ADMIN, // 관리자 → ADMIN ✅
   };
 
   // 🎯 편의 메서드들

--- a/geulnamu_frontend/lib/core/enums/permission_level.dart
+++ b/geulnamu_frontend/lib/core/enums/permission_level.dart
@@ -1,23 +1,23 @@
 /// 글나무 앱의 권한 레벨 정의
-/// 
+///
 /// 사용처:
 /// - HomeService: 메뉴 접근 제어
 /// - AuthService: 사용자 권한 확인
 /// - 기타 권한이 필요한 모든 서비스
-/// 
+///
 /// 확장 방법:
 /// - 새로운 권한 레벨 추가 시 이 enum에 추가
 /// - index 순서에 따라 권한 레벨이 결정됨 (낮은 index = 낮은 권한)
 enum PermissionLevel {
   /// 비로그인 사용자 - 공개된 기능만 접근 가능
   PUBLIC,
-  
-  /// 일반 회원 - 로그인 필요, 기본적인 회원 기능 사용 가능
+
+  /// (일반) 모임원 - 로그인 필요, 기본적인 회원 기능 사용 가능
   MEMBER,
-  
+
   /// 운영진/준운영진 - 모임 관리 등 운영 기능 사용 가능
   STAFF,
-  
+
   /// 관리자 - 회원 관리 등 최고 권한 기능 사용 가능
   ADMIN,
 }
@@ -30,14 +30,14 @@ extension PermissionLevelExtension on PermissionLevel {
       case PermissionLevel.PUBLIC:
         return '비회원';
       case PermissionLevel.MEMBER:
-        return '일반 회원';
+        return '모임원';
       case PermissionLevel.STAFF:
         return '운영진';
       case PermissionLevel.ADMIN:
         return '관리자';
     }
   }
-  
+
   /// 권한 레벨 설명
   String get description {
     switch (this) {
@@ -51,7 +51,7 @@ extension PermissionLevelExtension on PermissionLevel {
         return '회원 관리 등 관리자 전용 기능';
     }
   }
-  
+
   /// 특정 권한 레벨 이상인지 확인
   bool hasPermission(PermissionLevel requiredLevel) {
     return index >= requiredLevel.index;

--- a/geulnamu_frontend/lib/core/responsive.dart
+++ b/geulnamu_frontend/lib/core/responsive.dart
@@ -73,4 +73,10 @@ class ResponsiveHelper {
   static double getPWAIconSize(BuildContext context) {
     return getScreenWidth(context) >= Breakpoints.tablet ? 36.0 : 32.0;
   }
+
+  // 🆕 모임 목록 페이지 크기 (반응형)
+  static int getDefaultPageSize(BuildContext context) {
+    // 모바일: 5개, PC: 10개
+    return isMobile(context) ? 5 : 10;
+  }
 }

--- a/geulnamu_frontend/lib/models/meeting/meeting_filter_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_filter_model.dart
@@ -183,3 +183,22 @@ enum PrivacyStatusOption {
     );
   }
 }
+
+/// 🆕 페이지당 항목 수 옵션
+enum PageSizeOption {
+  small(5, '5개'),
+  medium(10, '10개');
+
+  const PageSizeOption(this.value, this.displayName);
+
+  final int value;
+  final String displayName;
+
+  static PageSizeOption fromValue(int? value) {
+    if (value == null) return PageSizeOption.medium;
+    return PageSizeOption.values.firstWhere(
+      (option) => option.value == value,
+      orElse: () => PageSizeOption.medium,
+    );
+  }
+}

--- a/geulnamu_frontend/lib/models/meeting/meeting_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_model.dart
@@ -81,6 +81,32 @@ class MeetingInfo {
     return DateFormat('yyyy.MM.dd HH:mm').format(meetingDateTime);
   }
 
+  /// 📱 반응형 모임 개최일자 표시 (화면 크기에 따라 다른 포맷)
+  /// 
+  /// - 매우 작은 화면 (~360px): "08.09 01:00"
+  /// - 작은 화면 (360~600px): "08.09 01:00 (금)"
+  /// - 큰 화면 (600px+): "2025.08.09 01:00 (금)"
+  String getResponsiveMeetingDateTime(double screenWidth) {
+    final weekday = _getWeekdayKorean(meetingDateTime.weekday);
+    
+    if (screenWidth < 360) {
+      // 매우 작은 화면: 년도, 요일 제거
+      return DateFormat('MM.dd HH:mm').format(meetingDateTime);
+    } else if (screenWidth < 600) {
+      // 작은~중간 화면: 년도 제거, 요일 포함
+      return '${DateFormat('MM.dd HH:mm').format(meetingDateTime)} ($weekday)';
+    } else {
+      // 큰 화면: 전체 표시
+      return '${DateFormat('yyyy.MM.dd HH:mm').format(meetingDateTime)} ($weekday)';
+    }
+  }
+
+  /// 요일을 한글로 변환
+  String _getWeekdayKorean(int weekday) {
+    const weekdays = ['월', '화', '수', '목', '금', '토', '일'];
+    return weekdays[weekday - 1];
+  }
+
   /// 모임 개최 날짜만 (yyyy.MM.dd)
   String get displayMeetingDate {
     return DateFormat('yyyy.MM.dd').format(meetingDateTime);
@@ -96,6 +122,29 @@ class MeetingInfo {
     if (discussionTime == null) return '-';
     // 원본 데이터가 시간만 이라면 그대로 사용
     return DateFormat('HH:mm').format(discussionTime!);
+  }
+
+  /// 📱 반응형 토론 시간 표시 (화면 크기에 따라 다른 포맷)
+  /// 
+  /// 개최일시와 동일한 포맷으로 통일
+  /// - 매우 작은 화면 (~360px): "08.09 12:00"
+  /// - 작은 화면 (360~600px): "08.09 12:00 (금)"
+  /// - 큰 화면 (600px+): "2025.08.09 12:00 (금)"
+  String getResponsiveDiscussionTime(double screenWidth) {
+    if (discussionTime == null) return '-';
+    
+    final weekday = _getWeekdayKorean(discussionTime!.weekday);
+    
+    if (screenWidth < 360) {
+      // 매우 작은 화면: 년도, 요일 제거
+      return DateFormat('MM.dd HH:mm').format(discussionTime!);
+    } else if (screenWidth < 600) {
+      // 작은~중간 화면: 년도 제거, 요일 포함
+      return '${DateFormat('MM.dd HH:mm').format(discussionTime!)} ($weekday)';
+    } else {
+      // 큰 화면: 전체 표시
+      return '${DateFormat('yyyy.MM.dd HH:mm').format(discussionTime!)} ($weekday)';
+    }
   }
 
   /// 출석 상태 표시명

--- a/geulnamu_frontend/lib/models/member/member_list_model.dart
+++ b/geulnamu_frontend/lib/models/member/member_list_model.dart
@@ -111,7 +111,7 @@ class MemberListItem {
       case 'VICE_STAFF':
         return '준운영진';
       case 'MEMBER':
-        return '일반 회원';
+        return '모임원';
       default:
         return '알 수 없음';
     }
@@ -130,7 +130,7 @@ class MemberListItem {
     if (birthDate == null) {
       return '생년월일 미입력';
     }
-    
+
     // 2022-01-01 형식을 22.01.01 형식으로 변경
     try {
       final parts = birthDate!.split('-');
@@ -296,7 +296,7 @@ enum RoleOption {
   admin('ADMIN', '관리자'),
   staff('STAFF', '운영진'),
   viceStaff('VICE_STAFF', '준운영진'),
-  member('MEMBER', '일반 회원');
+  member('MEMBER', '모임원');
 
   const RoleOption(this.value, this.displayName);
 

--- a/geulnamu_frontend/lib/models/profile/profile_model.dart
+++ b/geulnamu_frontend/lib/models/profile/profile_model.dart
@@ -98,7 +98,7 @@ class ProfileModel {
       case 'VICE_STAFF':
         return '준운영진';
       case 'MEMBER':
-        return '일반 회원';
+        return '모임원';
       default:
         return '알 수 없음';
     }

--- a/geulnamu_frontend/lib/providers/auth_provider.dart
+++ b/geulnamu_frontend/lib/providers/auth_provider.dart
@@ -263,7 +263,7 @@ class AuthProvider with ChangeNotifier {
       case 'VICE_STAFF':
         return '준운영진';
       case 'MEMBER':
-        return '일반 회원';
+        return '모임원';
       default:
         return '알 수 없음';
     }

--- a/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
+++ b/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
@@ -328,10 +328,12 @@ class AttendanceStatusWidgets {
               ),
               const SizedBox(width: 16),
 
-              // 이름
+              // 🎯 이름 부분 (개선 - 남은 공간 모두 사용)
               Expanded(
                 child: Text(
                   attendance.name,
+                  maxLines: 2,  // 최대 2줄까지 표시
+                  // 🎯 overflow 제거 - 자연스럽게 줄바꿈
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                     fontWeight: FontWeight.w600,
                     color: context.colors.onSurface,
@@ -339,20 +341,38 @@ class AttendanceStatusWidgets {
                 ),
               ),
 
-              // 출석 시간 (기본 색상)
-              Text(
-                _formatDateTime(attendance.attendanceTime),
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  color: context.colors.onSurface,
-                  fontWeight: FontWeight.w500,
+              const SizedBox(width: 8),  // 🎯 12 → 8로 줄임
+
+              // 🎯 출석 시간 부분 (고정 너비 - 필요한 만큼만 차지)
+              SizedBox(
+                width: 80,  // 🎯 고정 너비 ("2025.08.07" + "00:37" 표시 가능)
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _formatDate(attendance.attendanceTime),  // 날짜
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: context.colors.onSurface.withValues(alpha: 0.7),
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                    Text(
+                      _formatTime(attendance.attendanceTime),  // 시간
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: context.colors.onSurface,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
                 ),
               ),
 
-              const SizedBox(width: 12),
+              const SizedBox(width: 8),  // 🎯 12 → 8로 줄임
 
               // 출석/지각 상태 표시
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 3),  // 🎯 padding 축소
                 decoration: BoxDecoration(
                   color: (attendance.isLate ? Colors.orange : Colors.green)
                       .withValues(alpha: 0.1),
@@ -363,54 +383,57 @@ class AttendanceStatusWidgets {
                   style: Theme.of(context).textTheme.bodySmall?.copyWith(
                     color: attendance.isLate ? Colors.orange : Colors.green,
                     fontWeight: FontWeight.w600,
+                    fontSize: 11,  // 🎯 폰트 크기 약간 축소
                   ),
                 ),
               ),
 
-              const SizedBox(width: 8),
+              const SizedBox(width: 4),  // 🎯 8 → 4로 줄임
 
               // 더보기 메뉴 버튼 (관리자급에게만 표시)
-              if (showAdminActions) ...[
-                PopupMenuButton<String>(
-                  icon: Icon(
-                    Icons.more_vert,
-                    color: context.colors.onSurface.withValues(alpha: 0.6),
-                    size: 20,
-                  ),
-                  onSelected: (value) {
-                    _handleAttendanceMenuAction(
-                      context,
-                      attendance,
-                      value,
-                      onDeleteAttendance,
-                    );
-                  },
-                  itemBuilder: (context) => [
-                    PopupMenuItem<String>(
-                      value: 'delete',
-                      child: Row(
-                        children: [
-                          Icon(
-                            Icons.delete_outline,
-                            color: Colors.red,
-                            size: 18,
-                          ),
-                          const SizedBox(width: 8),
-                          Text(
-                            '출석 삭제',
-                            style: Theme.of(
-                              context,
-                            ).textTheme.bodyMedium?.copyWith(color: Colors.red),
-                          ),
-                        ],
-                      ),
+              if (showAdminActions)
+                SizedBox(
+                  width: 28,  // 🎯 버튼 영역 크기 제한
+                  height: 28,
+                  child: PopupMenuButton<String>(
+                    padding: EdgeInsets.zero,  // 🎯 내부 패딩 제거
+                    iconSize: 18,  // 🎯 아이콘 크기 축소
+                    icon: Icon(
+                      Icons.more_vert,
+                      color: context.colors.onSurface.withValues(alpha: 0.6),
+                      size: 18,  // 🎯 20 → 18로 축소
                     ),
-                  ],
+                    onSelected: (value) {
+                      _handleAttendanceMenuAction(
+                        context,
+                        attendance,
+                        value,
+                        onDeleteAttendance,
+                      );
+                    },
+                    itemBuilder: (context) => [
+                      PopupMenuItem<String>(
+                        value: 'delete',
+                        child: Row(
+                          children: [
+                            Icon(
+                              Icons.delete_outline,
+                              color: Colors.red,
+                              size: 18,
+                            ),
+                            const SizedBox(width: 8),
+                            Text(
+                              '출석 삭제',
+                              style: Theme.of(
+                                context,
+                              ).textTheme.bodyMedium?.copyWith(color: Colors.red),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ] else ...[
-                // 관리자가 아니면 빈 공간으로 레이아웃 유지
-                const SizedBox(width: 28),
-              ],
             ],
           ),
         ),
@@ -647,5 +670,15 @@ class AttendanceStatusWidgets {
   /// DateTime을 "yyyy.MM.dd HH:mm" 형식으로 포맷
   static String _formatDateTime(DateTime dateTime) {
     return '${dateTime.year}.${dateTime.month.toString().padLeft(2, '0')}.${dateTime.day.toString().padLeft(2, '0')} ${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
+  }
+
+  /// 날짜만 포맷 (yyyy.MM.dd)
+  static String _formatDate(DateTime dateTime) {
+    return '${dateTime.year}.${dateTime.month.toString().padLeft(2, '0')}.${dateTime.day.toString().padLeft(2, '0')}';
+  }
+
+  /// 시간만 포맷 (HH:mm)
+  static String _formatTime(DateTime dateTime) {
+    return '${dateTime.hour.toString().padLeft(2, '0')}:${dateTime.minute.toString().padLeft(2, '0')}';
   }
 }

--- a/geulnamu_frontend/lib/screens/book_question/widgets/book_question_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/book_question/widgets/book_question_detail_widgets.dart
@@ -4,14 +4,13 @@ import '../../../models/book_question/book_question_model.dart';
 import 'post_it_widgets.dart';
 
 /// 발제문 상세 페이지 관련 위젯들
-/// 
+///
 /// 기능:
 /// - 탭바 및 탭뷰 구성
 /// - 로딩/에러 상태 처리
 /// - 그룹별 발제문 표시
 /// - 헤더 정보 표시
 class BookQuestionDetailWidgets {
-
   /// 📊 헤더 정보 카드 (모임 정보 + 전체 통계)
   static Widget buildHeaderInfo(
     BuildContext context, {
@@ -54,9 +53,9 @@ class BookQuestionDetailWidgets {
               ),
             ],
           ),
-          
+
           const SizedBox(height: 12),
-          
+
           // 통계 정보
           Row(
             children: [
@@ -65,23 +64,23 @@ class BookQuestionDetailWidgets {
                 context,
                 icon: Icons.groups,
                 label: '전체 그룹',
-                value: '${totalGroups}개',
+                value: '$totalGroups개',
               ),
-              
+
               const SizedBox(width: 24),
-              
+
               // 전체 발제문 수
               _buildStatItem(
                 context,
                 icon: Icons.sticky_note_2,
                 label: '전체 발제문',
-                value: '${totalQuestions}개',
+                value: '$totalQuestions개',
               ),
             ],
           ),
-          
+
           const SizedBox(height: 8),
-          
+
           // 현재 선택된 그룹 정보
           Container(
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
@@ -101,7 +100,7 @@ class BookQuestionDetailWidgets {
       ),
     );
   }
-  
+
   /// 📈 통계 아이템 (아이콘 + 라벨 + 값)
   static Widget _buildStatItem(
     BuildContext context, {
@@ -112,11 +111,7 @@ class BookQuestionDetailWidgets {
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Icon(
-          icon,
-          size: 16,
-          color: context.colors.onSurface.withOpacity(0.7),
-        ),
+        Icon(icon, size: 16, color: context.colors.onSurface.withOpacity(0.7)),
         const SizedBox(width: 4),
         Text(
           label,
@@ -146,7 +141,7 @@ class BookQuestionDetailWidgets {
     if (groupCount == 0) {
       return const SizedBox.shrink();
     }
-    
+
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 16),
       decoration: BoxDecoration(
@@ -199,7 +194,7 @@ class BookQuestionDetailWidgets {
     if (bookQuestionResponse.groups.isEmpty) {
       return buildEmptyAllGroups(context);
     }
-    
+
     return TabBarView(
       controller: tabController,
       children: bookQuestionResponse.groups.map((group) {
@@ -245,11 +240,7 @@ class BookQuestionDetailWidgets {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(
-              Icons.error_outline,
-              size: 64,
-              color: context.colors.error,
-            ),
+            Icon(Icons.error_outline, size: 64, color: context.colors.error),
             const SizedBox(height: 16),
             Text(
               message,
@@ -299,7 +290,7 @@ class BookQuestionDetailWidgets {
             ),
             const SizedBox(height: 8),
             Text(
-              '토론 참여자들이 발제문을 작성하면\\n여기에 그룹별로 표시됩니다',
+              '토론 참여자들이 발제문을 작성하면\n여기에 그룹별로 표시됩니다',
               textAlign: TextAlign.center,
               style: context.textStyles.bodyMedium?.copyWith(
                 color: context.colors.onSurfaceVariant.withOpacity(0.7),
@@ -319,11 +310,7 @@ class BookQuestionDetailWidgets {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(
-              Icons.lock_outline,
-              size: 64,
-              color: context.colors.outline,
-            ),
+            Icon(Icons.lock_outline, size: 64, color: context.colors.outline),
             const SizedBox(height: 16),
             Text(
               '접근 권한이 없습니다',
@@ -366,15 +353,9 @@ class BookQuestionDetailWidgets {
       SnackBar(
         content: Row(
           children: [
-            Icon(
-              Icons.info_outline,
-              color: context.colors.onPrimary,
-              size: 20,
-            ),
+            Icon(Icons.info_outline, color: context.colors.onPrimary, size: 20),
             const SizedBox(width: 8),
-            const Expanded(
-              child: Text('관리자급만 발제문을 수정/삭제할 수 있습니다.'),
-            ),
+            const Expanded(child: Text('관리자급만 발제문을 수정/삭제할 수 있습니다.')),
           ],
         ),
         backgroundColor: context.colors.primary,

--- a/geulnamu_frontend/lib/screens/home/widgets/home_widgets.dart
+++ b/geulnamu_frontend/lib/screens/home/widgets/home_widgets.dart
@@ -113,57 +113,66 @@ class HomeWidgets {
           ),
         ),
         const SizedBox(height: 16),
-        GridView.builder(
-          shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-            crossAxisCount: 2,
-            crossAxisSpacing: 12,
-            mainAxisSpacing: 12,
-            childAspectRatio: 1.3,
-          ),
-          itemCount: menuItems.length,
-          itemBuilder: (context, index) {
-            final item = menuItems[index];
-            return Card(
-              child: InkWell(
-                onTap: () => onMenuTap(item['title'] as String),
-                borderRadius: BorderRadius.circular(12),
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Container(
-                        padding: const EdgeInsets.all(8),
-                        decoration: BoxDecoration(
-                          color: context.colors.primary.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: Icon(
-                          item['icon'] as IconData,
-                          size: 24,
-                          color: context.colors.primary,
-                        ),
-                      ),
-                      const Spacer(),
-                      Text(
-                        item['title'] as String,
-                        style: context.textStyles.bodyLarge?.copyWith(
-                          fontWeight: FontWeight.w600,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        item['subtitle'] as String,
-                        style: context.textStyles.bodySmall?.copyWith(
-                          color: context.colors.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            // 🎯 반응형 그리드: 화면 크기에 따라 열 개수 및 비율 조정
+            final isSmallScreen = constraints.maxWidth < 600;
+            final crossAxisCount = isSmallScreen ? 1 : 2;
+            final childAspectRatio = isSmallScreen ? 2.5 : 1.1;
+            
+            return GridView.builder(
+              shrinkWrap: true,
+              physics: const NeverScrollableScrollPhysics(),
+              gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: crossAxisCount,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
+                childAspectRatio: childAspectRatio,
               ),
+              itemCount: menuItems.length,
+              itemBuilder: (context, index) {
+                final item = menuItems[index];
+                return Card(
+                  child: InkWell(
+                    onTap: () => onMenuTap(item['title'] as String),
+                    borderRadius: BorderRadius.circular(12),
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              color: context.colors.primary.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(8),
+                            ),
+                            child: Icon(
+                              item['icon'] as IconData,
+                              size: 24,
+                              color: context.colors.primary,
+                            ),
+                          ),
+                          const Spacer(),
+                          Text(
+                            item['title'] as String,
+                            style: context.textStyles.bodyLarge?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            item['subtitle'] as String,
+                            style: context.textStyles.bodySmall?.copyWith(
+                              color: context.colors.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                );
+              },
             );
           },
         ),

--- a/geulnamu_frontend/lib/screens/introduction/introduction_screen.dart
+++ b/geulnamu_frontend/lib/screens/introduction/introduction_screen.dart
@@ -318,7 +318,7 @@ class IntroductionScreen extends StatelessWidget {
                       const SizedBox(width: 8),
                       Expanded(
                         child: Text(
-                          '당일 취소 자제 부탁드리고 노쇼 2번은 강퇴입니다\n본위기를 흐리거나 다른 목적으로 가입하신 분들, 운영진 회의 하에 강퇴입니다 (무통보 강제퇴장)',
+                          '당일 취소 자제 부탁드리고 노쇼 2번은 강퇴입니다\n분위기를 흐리거나 다른 목적으로 가입하신 분들, 운영진 회의 하에 강퇴입니다 (무통보 강제퇴장)',
                           style: context.textStyles.bodySmall?.copyWith(
                             color: context.warningColor,
                             height: 1.4,

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
@@ -10,7 +10,10 @@ import '../../services/home/home_route_service.dart'; // RouteObserver
 import 'mixins/meeting_logic_mixin.dart';
 import 'widgets/meeting_widgets.dart';
 import 'widgets/meeting_list_widgets.dart';
+import 'widgets/meeting_speed_dial.dart'; // 🆕 SpeedDial 위젯
 import 'meeting_qr_scanner_screen.dart'; // 🆕 QR 스캔 화면
+import '../../core/enums/permission_level.dart';
+import '../../core/constants/permission_constants.dart';
 
 /// 모임 목록 화면
 ///
@@ -119,13 +122,21 @@ class _MeetingListScreenState extends State<MeetingListScreen>
                 // 메인 콘텐츠
                 _buildMainContent(),
 
-                // 플로팅 필터 버튼
+                // 플로팅 필터 버튼 (좌측 하단)
                 Positioned(
                   bottom: 16,
                   left: 16,
                   child: MeetingListWidgets.buildFilterFab(
                     context,
                     _showFilterBottomSheet,
+                  ),
+                ),
+
+                // SpeedDial (우측 하단 - 전체 화면 오버레이 가능)
+                Positioned.fill(
+                  child: MeetingSpeedDial(
+                    canCreateMeeting: _canCreateMeeting(),
+                    onCreateMeeting: _handleCreateMeeting,
                   ),
                 ),
               ],
@@ -248,5 +259,26 @@ class _MeetingListScreenState extends State<MeetingListScreen>
   /// 출석현황 확인 버튼 처리 (MeetingLogicMixin에서 처리)
   void _handleAttendanceCheck(int meetingId) {
     handleAttendanceCheck(meetingId);
+  }
+
+  /// 🆕 모임 만들기 권한 체크
+  bool _canCreateMeeting() {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    final userRole = authProvider.userRole;
+
+    // 권한 확인
+    final permissionLevel = PermissionConstants.convertRoleToPermissionLevel(
+      userRole,
+    );
+    final requiredLevel = PermissionConstants.getRequiredPermissionLevel(
+      '모임 만들기',
+    );
+
+    return permissionLevel.hasPermission(requiredLevel);
+  }
+
+  /// 🆕 모임 만들기 버튼 처리
+  void _handleCreateMeeting() {
+    Navigator.pushNamed(context, '/meeting-create'); // 정확한 라우트로 수정
   }
 }

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
@@ -7,9 +7,12 @@ import '../../core/theme.dart';
 import '../../models/meeting/meeting_model.dart';
 import '../../services/home/home_service.dart';
 import '../../services/home/home_route_service.dart'; // RouteObserver 추가
+import '../../core/enums/permission_level.dart'; // 🆕 권한 시스템 import
+import '../../core/constants/permission_constants.dart'; // 🆕 권한 상수 import
 import 'mixins/meeting_logic_mixin.dart';
 import 'widgets/meeting_widgets.dart';
 import 'widgets/meeting_list_widgets.dart';
+import 'widgets/meeting_speed_dial.dart'; // 🆕 SpeedDial 위젯 import
 
 /// 🆕 모임 목록 조회 (운영진용) 화면
 ///
@@ -124,26 +127,29 @@ class _MeetingListStaffScreenState extends State<MeetingListStaffScreen>
               ),
             ],
             body: Stack(
-            children: [
-            // 메인 콘텐츠
-            _buildMainContent(),
+              children: [
+                // 메인 콘텐츠
+                _buildMainContent(),
 
-            // 플로팅 버튼들 (맨 아래)
-            Positioned(
-            bottom: 16,
-            left: 16,
-                child: MeetingListWidgets.buildFilterFab(
+                // 플로팅 필터 버튼 (좌측 하단)
+                Positioned(
+                  bottom: 16,
+                  left: 16,
+                  child: MeetingListWidgets.buildFilterFab(
                     context,
-                      _showStaffFilterBottomSheet,
-                    ),
+                    _showStaffFilterBottomSheet,
                   ),
-            Positioned(
-            bottom: 16,
-              right: 16,
-            child: _buildCreateMeetingFab(), // 모임 만들기 FAB
+                ),
+
+                // 🆕 SpeedDial (우측 하단 - 전체 화면 오버레이 가능)
+                Positioned.fill(
+                  child: MeetingSpeedDial(
+                    canCreateMeeting: _canCreateMeeting(),
+                    onCreateMeeting: _handleCreateMeeting,
+                  ),
+                ),
+              ],
             ),
-                ],
-              ),
           ),
         );
       },
@@ -238,44 +244,6 @@ class _MeetingListStaffScreenState extends State<MeetingListStaffScreen>
     );
   }
 
-  /// 모임 만들기 플로팅 버튼 빌드
-  Widget _buildCreateMeetingFab() {
-    return Consumer<AuthProvider>(
-      builder: (context, authProvider, child) {
-        // 운영진 권한 체크
-        if (!authProvider.isStaffLevel) {
-          return const SizedBox.shrink();
-        }
-
-        return FloatingActionButton.extended(
-          onPressed: () {
-            // 모임 만들기 페이지로 이동
-            Navigator.pushNamed(
-              context,
-              '/meeting-create',  // 라우트 이름 수정
-            ).then((result) {
-              // 모임 생성 후 목록 새로고침
-              if (result == true && mounted) {
-                refreshMeetingList();
-              }
-            });
-          },
-          label: const Text('모임 만들기'),
-          icon: const Icon(Icons.add),
-          backgroundColor: context.colors.primary,
-          foregroundColor: context.colors.onPrimary,
-          elevation: 4,
-        );
-      },
-    );
-  }
-
-  /// 로그아웃 처리 (HomeService 활용)
-  Future<void> _handleLogout() async {
-    final authProvider = Provider.of<AuthProvider>(context, listen: false);
-    await _homeService.handleLogout(context, authProvider);
-  }
-
   /// 모임 카드 탭 처리 (운영진용 상세보기 기능)
   void _handleMeetingTap(MeetingInfo meeting) {
     Navigator.pushNamed(context, '/meeting/${meeting.meetingId}/staff').then((result) {
@@ -284,5 +252,38 @@ class _MeetingListStaffScreenState extends State<MeetingListStaffScreen>
         refreshMeetingList();
       }
     });
+  }
+
+  /// 🆕 모임 만들기 권한 체크
+  bool _canCreateMeeting() {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    final userRole = authProvider.userRole;
+
+    // 권한 확인
+    final permissionLevel =
+        PermissionConstants.convertRoleToPermissionLevel(userRole);
+    final requiredLevel =
+        PermissionConstants.getRequiredPermissionLevel('모임 만들기');
+
+    return permissionLevel.hasPermission(requiredLevel);
+  }
+
+  /// 🆕 모임 만들기 버튼 처리
+  void _handleCreateMeeting() {
+    Navigator.pushNamed(
+      context,
+      '/meeting-create',
+    ).then((result) {
+      // 모임 생성 후 목록 새로고침
+      if (result == true && mounted) {
+        refreshMeetingList();
+      }
+    });
+  }
+
+  /// 로그아웃 처리 (HomeService 활용)
+  Future<void> _handleLogout() async {
+    final authProvider = Provider.of<AuthProvider>(context, listen: false);
+    await _homeService.handleLogout(context, authProvider);
   }
 }

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_logic_mixin.dart
@@ -5,6 +5,7 @@ import '../../../services/meeting/meeting_service.dart';
 import '../../../models/meeting/meeting_model.dart';
 import '../../../models/meeting/meeting_filter_model.dart';
 import '../../../core/config/app_config.dart'; // AppConfig import 추가
+import '../../../core/responsive.dart'; // 🆕 반응형 헬퍼 import
 
 /// 모임 목록 화면 로직 Mixin
 ///
@@ -51,9 +52,16 @@ mixin MeetingLogicMixin<T extends StatefulWidget> on State<T> {
   Future<void> initializeMeetingList({MeetingListFilter? initialFilter}) async {
     // 🎯 MeetingService는 Singleton이므로 이미 초기화됨
 
+    // 🆕 반응형 기본 페이지 크기 설정
+    final defaultPageSize = ResponsiveHelper.getDefaultPageSize(context);
+
     // 🎯 초기 필터 설정 (제공된 경우)
     if (initialFilter != null) {
-      _currentFilter = initialFilter;
+      // 🆕 페이지 크기를 반영형 기본값으로 설정
+      _currentFilter = initialFilter.copyWith(size: defaultPageSize);
+    } else {
+      // 🆕 기본 필터에 반응형 크기 적용
+      _currentFilter = MeetingListFilter(size: defaultPageSize);
     }
 
     await loadMeetingList(isInitial: true);

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_filter_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_filter_widgets.dart
@@ -79,6 +79,7 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
   late PrivacyStatusOption selectedPrivacyStatus; // 운영진용
   late SortByOption selectedSort;
   late bool isAscending;
+  late PageSizeOption selectedPageSize; // 🆕 페이지당 항목 수
 
   @override
   void initState() {
@@ -89,6 +90,7 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
     selectedPrivacyStatus = widget.currentFilter.privacyStatus;
     selectedSort = widget.currentFilter.sortBy;
     isAscending = widget.currentFilter.isAsc;
+    selectedPageSize = PageSizeOption.fromValue(widget.currentFilter.size); // 🆕 초기화
   }
 
   @override
@@ -118,6 +120,7 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
                     selectedPrivacyStatus = PrivacyStatusOption.all;
                     selectedSort = SortByOption.meetingDate;
                     isAscending = false;
+                    selectedPageSize = PageSizeOption.medium; // 🆕 초기화
                   });
                 },
                 child: Text(
@@ -324,6 +327,33 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
             ),
           ),
 
+          const SizedBox(height: 16),
+
+          // 🆕 페이지당 항목 수 (모든 모드에서 공통)
+          MeetingFilterWidgets.buildFilterSection(
+            context,
+            title: '한 페이지에 보이는 모임 개수',
+            child: Wrap(
+              spacing: 8,
+              children: PageSizeOption.values.map((option) {
+                final isSelected = selectedPageSize == option;
+                return ChoiceChip(
+                  label: Text(option.displayName),
+                  selected: isSelected,
+                  onSelected: (selected) {
+                    if (selected) {
+                      setState(() {
+                        selectedPageSize = option;
+                      });
+                    }
+                  },
+                  selectedColor: context.colors.primary.withOpacity(0.2),
+                  backgroundColor: context.colors.surfaceContainerHighest,
+                );
+              }).toList(),
+            ),
+          ),
+
           const SizedBox(height: 24),
 
           // 적용 버튼
@@ -338,6 +368,7 @@ class _FilterBottomSheetContentState extends State<_FilterBottomSheetContent> {
                   privacyStatus: selectedPrivacyStatus,
                   sortBy: selectedSort,
                   isAsc: isAscending,
+                  size: selectedPageSize.value, // 🆕 페이지 크기 적용
                 );
 
                 Navigator.pop(context);

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_speed_dial.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_speed_dial.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'dart:math' as math;
+import '../../../core/theme.dart';
+
+/// 모임 목록 SpeedDial 위젯
+///
+/// 모바일 환경에서 FAB 충돌 문제 해결을 위한 SpeedDial 구현
+/// - 기본 상태: '...' 버튼만 표시
+/// - 탭 시: '모임 만들기' 등 액션 버튼 펼침
+class MeetingSpeedDial extends StatefulWidget {
+  /// 모임 만들기 콜백
+  final VoidCallback? onCreateMeeting;
+
+  /// 권한 체크 (모임 만들기 버튼 표시 여부)
+  final bool canCreateMeeting;
+
+  const MeetingSpeedDial({
+    super.key,
+    this.onCreateMeeting,
+    this.canCreateMeeting = false,
+  });
+
+  @override
+  State<MeetingSpeedDial> createState() => _MeetingSpeedDialState();
+}
+
+class _MeetingSpeedDialState extends State<MeetingSpeedDial>
+    with SingleTickerProviderStateMixin {
+  /// 애니메이션 컨트롤러
+  late AnimationController _animationController;
+
+  /// 회전 애니메이션
+  late Animation<double> _rotationAnimation;
+
+  /// 확장/축소 애니메이션
+  late Animation<double> _scaleAnimation;
+
+  /// SpeedDial 열림/닫힘 상태
+  bool _isOpen = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    // 애니메이션 컨트롤러 초기화
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 250),
+      vsync: this,
+    );
+
+    // 회전 애니메이션 (0 -> 45도)
+    _rotationAnimation = Tween<double>(
+      begin: 0.0,
+      end: math.pi / 4, // 45도
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+
+    // 스케일 애니메이션 (0 -> 1)
+    _scaleAnimation = CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    );
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  /// SpeedDial 토글
+  void _toggleSpeedDial() {
+    setState(() {
+      _isOpen = !_isOpen;
+      if (_isOpen) {
+        _animationController.forward();
+      } else {
+        _animationController.reverse();
+      }
+    });
+  }
+
+  /// SpeedDial 닫기
+  void _closeSpeedDial() {
+    if (_isOpen) {
+      setState(() {
+        _isOpen = false;
+        _animationController.reverse();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // 권한이 없으면 비어있는 컸테이너 반환
+    if (!widget.canCreateMeeting) {
+      return const SizedBox.shrink();
+    }
+
+    return Stack(
+      children: [
+        // 백그라운드 오버레이 (SpeedDial 열렸을 때)
+        if (_isOpen)
+          Positioned.fill(
+            child: GestureDetector(
+              onTap: _closeSpeedDial,
+              child: Container(
+                color: Colors.black.withValues(alpha: 0.3),
+              ),
+            ),
+          ),
+
+        // SpeedDial 버튼들
+        Positioned(
+          bottom: 0,
+          right: 0,
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                // 모임 만들기 버튼
+                _buildSpeedDialAction(
+                  icon: Icons.add,
+                  label: '모임 만들기',
+                  onTap: () {
+                    _closeSpeedDial();
+                    widget.onCreateMeeting?.call();
+                  },
+                ),
+                const SizedBox(height: 16),
+
+                // 메인 FAB (... 버튼)
+                _buildMainFab(),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  /// SpeedDial 액션 버튼
+  Widget _buildSpeedDialAction({
+    required IconData icon,
+    required String label,
+    required VoidCallback onTap,
+  }) {
+    return ScaleTransition(
+      scale: _scaleAnimation,
+      child: Material(
+        color: context.colors.primary,
+        elevation: 6,
+        borderRadius: BorderRadius.circular(16),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(16),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  icon,
+                  color: context.colors.onPrimary,
+                  size: 20,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  label,
+                  style: context.textStyles.labelLarge?.copyWith(
+                    color: context.colors.onPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// 메인 FAB (... 버튼)
+  Widget _buildMainFab() {
+    return FloatingActionButton(
+      onPressed: _toggleSpeedDial,
+      backgroundColor: context.colors.primary,
+      foregroundColor: context.colors.onPrimary,
+      elevation: _isOpen ? 8 : 6,
+      heroTag: 'meeting_speed_dial', // Hero 태그 충돌 방지
+      child: AnimatedBuilder(
+        animation: _rotationAnimation,
+        builder: (context, child) {
+          return Transform.rotate(
+            angle: _rotationAnimation.value,
+            child: Icon(
+              _isOpen ? Icons.close : Icons.more_horiz,
+              size: 28,
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
@@ -99,7 +99,7 @@ class MeetingStaffWidgets {
                     ),
                     secondIcon: Icons.tag,
                     secondLabel: '모임번호',
-                    secondValue: '#${meeting.meetingId}',
+                    secondValue: '${meeting.meetingId}', // # 기호 제거
                   ),
                 ],
               ),

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
@@ -66,7 +66,9 @@ class MeetingStaffWidgets {
                     context,
                     icon: Icons.schedule,
                     label: '개최일시',
-                    value: meeting.displayMeetingDateTime,
+                    value: meeting.getResponsiveMeetingDateTime(
+                      MediaQuery.of(context).size.width,
+                    ),
                     secondIcon: Icons.location_on_outlined,
                     secondLabel: '장소',
                     secondValue: meeting.meetingPlace,
@@ -79,7 +81,9 @@ class MeetingStaffWidgets {
                     context,
                     icon: Icons.chat_bubble_outline,
                     label: '토론시간',
-                    value: meeting.displayDiscussionTime,
+                    value: meeting.getResponsiveDiscussionTime(
+                      MediaQuery.of(context).size.width,
+                    ),
                     secondIcon: Icons.person_outline,
                     secondLabel: '개설자',
                     secondValue: meeting.meetingCreatorName,
@@ -228,6 +232,8 @@ class MeetingStaffWidgets {
   }
 
   /// 정보 행 위젯 (2개 정보를 한 행에 표시)
+  /// 
+  /// 반응형: 모바일(~600px)에서는 레이블 숨김, 아이콘+데이터만 표시
   static Widget _buildInfoRow(
     BuildContext context, {
     required IconData icon,
@@ -239,6 +245,10 @@ class MeetingStaffWidgets {
     String? secondValue,
     Color? secondValueColor,
   }) {
+    // 📱 반응형: 화면 크기 감지
+    final screenWidth = MediaQuery.of(context).size.width;
+    final isMobile = screenWidth < 600; // 모바일 기준: 600px 미만
+
     return Row(
       children: [
         // 첫 번째 정보
@@ -251,16 +261,18 @@ class MeetingStaffWidgets {
                 color: context.colors.onSurface.withOpacity(0.65),
               ),
               const SizedBox(width: 6),
-              Text(
-                '$label: ',
-                style: context.textStyles.bodySmall?.copyWith(
-                  color: context.colors.onSurface.withOpacity(0.55),
-                  fontSize: 14,
-                  fontWeight: Theme.of(context).brightness == Brightness.light
-                      ? FontWeight.w600
-                      : FontWeight.w500,
+              // 📱 모바일에서는 레이블 숨김
+              if (!isMobile)
+                Text(
+                  '$label: ',
+                  style: context.textStyles.bodySmall?.copyWith(
+                    color: context.colors.onSurface.withOpacity(0.55),
+                    fontSize: 14,
+                    fontWeight: Theme.of(context).brightness == Brightness.light
+                        ? FontWeight.w600
+                        : FontWeight.w500,
+                  ),
                 ),
-              ),
               Expanded(
                 child: Text(
                   value,
@@ -292,16 +304,18 @@ class MeetingStaffWidgets {
                   color: context.colors.onSurface.withOpacity(0.65),
                 ),
                 const SizedBox(width: 6),
-                Text(
-                  '$secondLabel: ',
-                  style: context.textStyles.bodySmall?.copyWith(
-                    color: context.colors.onSurface.withOpacity(0.55),
-                    fontSize: 14,
-                    fontWeight: Theme.of(context).brightness == Brightness.light
-                        ? FontWeight.w600
-                        : FontWeight.w500,
+                // 📱 모바일에서는 레이블 숨김
+                if (!isMobile)
+                  Text(
+                    '$secondLabel: ',
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withOpacity(0.55),
+                      fontSize: 14,
+                      fontWeight: Theme.of(context).brightness == Brightness.light
+                          ? FontWeight.w600
+                          : FontWeight.w500,
+                    ),
                   ),
-                ),
                 Expanded(
                   child: Text(
                     secondValue,

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
@@ -107,7 +107,7 @@ class MeetingWidgets {
                     ),
                     secondIcon: Icons.tag,
                     secondLabel: '모임번호',
-                    secondValue: '#${meeting.meetingId}',
+                    secondValue: '${meeting.meetingId}', // # 기호 제거
                   ),
                 ],
               ),

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
@@ -74,7 +74,9 @@ class MeetingWidgets {
                     context,
                     icon: Icons.schedule,
                     label: '개최일시',
-                    value: meeting.displayMeetingDateTime,
+                    value: meeting.getResponsiveMeetingDateTime(
+                      MediaQuery.of(context).size.width,
+                    ),
                     secondIcon: Icons.location_on_outlined,
                     secondLabel: '장소',
                     secondValue: meeting.meetingPlace,
@@ -87,7 +89,9 @@ class MeetingWidgets {
                     context,
                     icon: Icons.chat_bubble_outline,
                     label: '토론시간',
-                    value: meeting.displayDiscussionTime,
+                    value: meeting.getResponsiveDiscussionTime(
+                      MediaQuery.of(context).size.width,
+                    ),
                     secondIcon: Icons.person_outline,
                     secondLabel: '개설자',
                     secondValue: meeting.meetingCreatorName,
@@ -283,6 +287,8 @@ class MeetingWidgets {
   }
 
   /// 정보 행 위젯 (2개 정보를 한 행에 표시)
+  /// 
+  /// 반응형: 모바일(~600px)에서는 레이블 숨김, 아이콘+데이터만 표시
   static Widget _buildInfoRow(
     BuildContext context, {
     required IconData icon,
@@ -294,6 +300,10 @@ class MeetingWidgets {
     String? secondValue,
     Color? secondValueColor,
   }) {
+    // 📱 반응형: 화면 크기 감지
+    final screenWidth = MediaQuery.of(context).size.width;
+    final isMobile = screenWidth < 600; // 모바일 기준: 600px 미만
+
     return Row(
       children: [
         // 첫 번째 정보
@@ -306,16 +316,18 @@ class MeetingWidgets {
                 color: context.colors.onSurface.withOpacity(0.65),
               ),
               const SizedBox(width: 6),
-              Text(
-                '$label: ',
-                style: context.textStyles.bodySmall?.copyWith(
-                  color: context.colors.onSurface.withOpacity(0.55),
-                  fontSize: 14,
-                  fontWeight: Theme.of(context).brightness == Brightness.light
-                      ? FontWeight.w600
-                      : FontWeight.w500,
+              // 📱 모바일에서는 레이블 숨김
+              if (!isMobile)
+                Text(
+                  '$label: ',
+                  style: context.textStyles.bodySmall?.copyWith(
+                    color: context.colors.onSurface.withOpacity(0.55),
+                    fontSize: 14,
+                    fontWeight: Theme.of(context).brightness == Brightness.light
+                        ? FontWeight.w600
+                        : FontWeight.w500,
+                  ),
                 ),
-              ),
               Expanded(
                 child: Text(
                   value,
@@ -347,16 +359,18 @@ class MeetingWidgets {
                   color: context.colors.onSurface.withOpacity(0.65),
                 ),
                 const SizedBox(width: 6),
-                Text(
-                  '$secondLabel: ',
-                  style: context.textStyles.bodySmall?.copyWith(
-                    color: context.colors.onSurface.withOpacity(0.55),
-                    fontSize: 14,
-                    fontWeight: Theme.of(context).brightness == Brightness.light
-                        ? FontWeight.w600
-                        : FontWeight.w500,
+                // 📱 모바일에서는 레이블 숨김
+                if (!isMobile)
+                  Text(
+                    '$secondLabel: ',
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withOpacity(0.55),
+                      fontSize: 14,
+                      fontWeight: Theme.of(context).brightness == Brightness.light
+                          ? FontWeight.w600
+                          : FontWeight.w500,
+                    ),
                   ),
-                ),
                 Expanded(
                   child: Text(
                     secondValue,

--- a/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
+++ b/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
@@ -59,12 +59,15 @@ class MemberWidgets {
                           ),
                         ),
                         const SizedBox(width: 6),
-                        Text(
-                          '(${member.nickname})',
-                          style: context.textStyles.bodySmall?.copyWith(
-                            color: isActive
-                                ? context.colors.onSurfaceVariant
-                                : context.colors.onSurfaceVariant.withOpacity(0.5),
+                        Flexible(  // 🎯 추가: 닉네임을 Flexible로 감싸기
+                          child: Text(
+                            '(${member.nickname})',
+                            overflow: TextOverflow.ellipsis,  // 🎯 추가: 넘치면 ...
+                            style: context.textStyles.bodySmall?.copyWith(
+                              color: isActive
+                                  ? context.colors.onSurfaceVariant
+                                  : context.colors.onSurfaceVariant.withOpacity(0.5),
+                            ),
                           ),
                         ),
                       ],

--- a/geulnamu_frontend/lib/screens/profile/widgets/profile_widgets.dart
+++ b/geulnamu_frontend/lib/screens/profile/widgets/profile_widgets.dart
@@ -4,7 +4,7 @@ import '../../../core/utils/date_utils.dart' as app_date_utils;
 import '../../../widgets/common/loading_widgets.dart';
 
 /// 프로필 화면 UI 위젯들 (Static Methods)
-/// 
+///
 /// 제공 위젯:
 /// - 프로필 이미지
 /// - 기본 정보 섹션 (이름, 성별, 생년월일)
@@ -14,7 +14,7 @@ class ProfileWidgets {
   ProfileWidgets._(); // private constructor - static class
 
   /// 프로필 이미지 위젯
-  /// 
+  ///
   /// 기본 아이콘 사용, 추후 이미지 업로드 기능 확장 가능
   static Widget buildProfileImage(
     BuildContext context, {
@@ -54,7 +54,7 @@ class ProfileWidgets {
   }
 
   /// 기본 정보 섹션 (조회 모드)
-  /// 
+  ///
   /// 이름, 성별, 생년월일 표시 (수정 가능한 필드들)
   static Widget buildBasicInfoSection(
     BuildContext context,
@@ -80,7 +80,9 @@ class ProfileWidgets {
                   '기본 정보',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onSurface, // 🎯 다크모드 대비 개선
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface, // 🎯 다크모드 대비 개선
                   ),
                 ),
               ],
@@ -91,7 +93,7 @@ class ProfileWidgets {
             _buildInfoRow(
               context,
               label: '이름',
-              value: profile.displayName,  // null 안전 getter 사용
+              value: profile.displayName, // null 안전 getter 사용
               icon: Icons.badge,
             ),
 
@@ -111,13 +113,15 @@ class ProfileWidgets {
             _buildInfoRow(
               context,
               label: '생년월일',
-              value: profile.hasBirthDate 
-                ? app_date_utils.DateUtils.formatDisplayDate(profile.birthDate!)
-                : '생년월일 미입력',
+              value: profile.hasBirthDate
+                  ? app_date_utils.DateUtils.formatDisplayDate(
+                      profile.birthDate!,
+                    )
+                  : '생년월일 미입력',
               icon: Icons.cake,
-              subtitle: profile.hasBirthDate 
-                ? '(만 ${app_date_utils.DateUtils.calculateAge(profile.birthDate!)}세)'
-                : null,
+              subtitle: profile.hasBirthDate
+                  ? '(만 ${app_date_utils.DateUtils.calculateAge(profile.birthDate!)}세)'
+                  : null,
             ),
           ],
         ),
@@ -161,7 +165,9 @@ class ProfileWidgets {
                       errorText = '이름을 입력해주세요.';
                     } else if (value.length < 2) {
                       errorText = '이름은 2자 이상이어야 합니다.';
-                    } else if (RegExp(r'[!@#$%^&*(),.?":{}|<>]').hasMatch(value)) {
+                    } else if (RegExp(
+                      r'[!@#$%^&*(),.?":{}|<>]',
+                    ).hasMatch(value)) {
                       errorText = '특수문자를 사용할 수 없습니다.';
                     } else {
                       errorText = null;
@@ -194,9 +200,9 @@ class ProfileWidgets {
     String currentRole,
   ) async {
     String selectedRole = currentRole;
-    
+
     final roleOptions = [
-      {'value': 'MEMBER', 'label': '일반 회원'},
+      {'value': 'MEMBER', 'label': '모임원'},
       {'value': 'VICE_STAFF', 'label': '준운영진'},
       {'value': 'STAFF', 'label': '운영진'},
       {'value': 'ADMIN', 'label': '관리자'},
@@ -214,21 +220,25 @@ class ProfileWidgets {
             children: [
               const Text('새로운 권한을 선택해주세요.'),
               const SizedBox(height: 16),
-              ...roleOptions.map((role) => RadioListTile<String>(
-                title: Text(role['label']!),
-                value: role['value']!,
-                groupValue: selectedRole,
-                onChanged: (value) {
-                  setState(() {
-                    selectedRole = value!;
-                  });
-                },
-              )),
+              ...roleOptions.map(
+                (role) => RadioListTile<String>(
+                  title: Text(role['label']!),
+                  value: role['value']!,
+                  groupValue: selectedRole,
+                  onChanged: (value) {
+                    setState(() {
+                      selectedRole = value!;
+                    });
+                  },
+                ),
+              ),
               const SizedBox(height: 8),
               Container(
                 padding: const EdgeInsets.all(12),
                 decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.primaryContainer.withOpacity(0.3),
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Row(
@@ -296,8 +306,12 @@ class ProfileWidgets {
               padding: const EdgeInsets.all(12),
               decoration: BoxDecoration(
                 color: newStatus
-                    ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
-                    : Theme.of(context).colorScheme.errorContainer.withOpacity(0.3),
+                    ? Theme.of(
+                        context,
+                      ).colorScheme.primaryContainer.withOpacity(0.3)
+                    : Theme.of(
+                        context,
+                      ).colorScheme.errorContainer.withOpacity(0.3),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(
@@ -348,7 +362,7 @@ class ProfileWidgets {
   }
 
   /// 계정 정보 섹션 (읽기 전용)
-  /// 
+  ///
   /// 닉네임, 권한 표시 (수정 불가능한 필드들)
   static Widget buildAccountInfoSection(
     BuildContext context,
@@ -374,7 +388,9 @@ class ProfileWidgets {
                   '계정 정보',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onSurface, // 🎯 다크모드 대비 개선
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface, // 🎯 다크모드 대비 개선
                   ),
                 ),
               ],
@@ -422,9 +438,9 @@ class ProfileWidgets {
         Icon(
           icon,
           size: 18,
-          color: isReadOnly 
-            ? Theme.of(context).colorScheme.outline
-            : Theme.of(context).colorScheme.primary,
+          color: isReadOnly
+              ? Theme.of(context).colorScheme.outline
+              : Theme.of(context).colorScheme.primary,
         ),
         const SizedBox(width: 12),
 
@@ -450,9 +466,9 @@ class ProfileWidgets {
               Text(
                 value,
                 style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                  color: isReadOnly 
-                    ? Theme.of(context).colorScheme.onSurfaceVariant
-                    : Theme.of(context).colorScheme.onSurface,
+                  color: isReadOnly
+                      ? Theme.of(context).colorScheme.onSurfaceVariant
+                      : Theme.of(context).colorScheme.onSurface,
                 ),
               ),
               if (subtitle != null) ...[
@@ -480,7 +496,7 @@ class ProfileWidgets {
   }
 
   /// 기본 정보 수정 폼
-  /// 
+  ///
   /// 이름, 성별, 생년월일 입력 위젯들
   static Widget buildEditForm(
     BuildContext context, {
@@ -513,7 +529,9 @@ class ProfileWidgets {
                   '정보 수정',
                   style: Theme.of(context).textTheme.titleMedium?.copyWith(
                     fontWeight: FontWeight.bold,
-                    color: Theme.of(context).colorScheme.onSurface, // 🎯 다크모드 대비 개선
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface, // 🎯 다크모드 대비 개선
                   ),
                 ),
               ],
@@ -529,7 +547,9 @@ class ProfileWidgets {
                 helperText: '2-10자, 특수문자 제외',
                 border: const OutlineInputBorder(),
               ),
-              controller: nameController ?? TextEditingController(text: name), // 🎯 Controller 사용
+              controller:
+                  nameController ??
+                  TextEditingController(text: name), // 🎯 Controller 사용
               onChanged: onNameChanged,
               maxLength: 10,
             ),
@@ -587,7 +607,8 @@ class ProfileWidgets {
 
             // 생년월일 선택
             InkWell(
-              onTap: () => _showDatePicker(context, birthDate, onBirthDateChanged),
+              onTap: () =>
+                  _showDatePicker(context, birthDate, onBirthDateChanged),
               child: InputDecorator(
                 decoration: InputDecoration(
                   labelText: '생년월일',
@@ -598,7 +619,8 @@ class ProfileWidgets {
                 child: Text(
                   birthDate != null
                       ? app_date_utils.DateUtils.formatDisplayDate(
-                          birthDate.toIso8601String().split('T')[0])
+                          birthDate.toIso8601String().split('T')[0],
+                        )
                       : '날짜를 선택해주세요',
                   style: birthDate != null
                       ? Theme.of(context).textTheme.bodyLarge
@@ -732,7 +754,7 @@ class ProfileWidgets {
   // 🎯 관리자 모드 전용 위젯들
 
   /// 관리자용 계정 정보 섹션
-  /// 
+  ///
   /// 비활성화 계정 표시 및 인라인 수정 버튼 포함
   static Widget buildAdminAccountInfoSection(
     BuildContext context,
@@ -866,9 +888,9 @@ class ProfileWidgets {
             _buildAdminInfoRow(
               context,
               label: '생년월일',
-              value: profile.hasBirthDate 
-                ? '${profile.displayBirthDate} (만 ${DateTime.now().year - int.parse(profile.birthDate!.substring(0, 4))}세)'
-                : '생년월일 미입력',
+              value: profile.hasBirthDate
+                  ? '${profile.displayBirthDate} (만 ${DateTime.now().year - int.parse(profile.birthDate!.substring(0, 4))}세)'
+                  : '생년월일 미입력',
               icon: Icons.cake,
               isReadOnly: true,
             ),
@@ -895,9 +917,9 @@ class ProfileWidgets {
         Icon(
           icon,
           size: 18,
-          color: isReadOnly 
-            ? Theme.of(context).colorScheme.outline
-            : Theme.of(context).colorScheme.primary,
+          color: isReadOnly
+              ? Theme.of(context).colorScheme.outline
+              : Theme.of(context).colorScheme.primary,
         ),
         const SizedBox(width: 12),
 
@@ -920,9 +942,9 @@ class ProfileWidgets {
           child: Text(
             value,
             style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-              color: isReadOnly 
-                ? Theme.of(context).colorScheme.onSurfaceVariant
-                : Theme.of(context).colorScheme.onSurface,
+              color: isReadOnly
+                  ? Theme.of(context).colorScheme.onSurfaceVariant
+                  : Theme.of(context).colorScheme.onSurface,
             ),
           ),
         ),
@@ -957,19 +979,19 @@ class ProfileWidgets {
     bool isProcessing = false,
   }) {
     final isActive = profile.isActive;
-    
+
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: isActive 
-          ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
-          : Theme.of(context).colorScheme.errorContainer.withOpacity(0.3),
+        color: isActive
+            ? Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3)
+            : Theme.of(context).colorScheme.errorContainer.withOpacity(0.3),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isActive 
-            ? Theme.of(context).colorScheme.primary.withOpacity(0.3)
-            : Theme.of(context).colorScheme.error.withOpacity(0.3),
+          color: isActive
+              ? Theme.of(context).colorScheme.primary.withOpacity(0.3)
+              : Theme.of(context).colorScheme.error.withOpacity(0.3),
         ),
       ),
       child: Column(
@@ -980,9 +1002,9 @@ class ProfileWidgets {
             children: [
               Icon(
                 isActive ? Icons.check_circle : Icons.warning,
-                color: isActive 
-                  ? Theme.of(context).colorScheme.primary
-                  : Theme.of(context).colorScheme.error,
+                color: isActive
+                    ? Theme.of(context).colorScheme.primary
+                    : Theme.of(context).colorScheme.error,
                 size: 20,
               ),
               const SizedBox(width: 8),
@@ -990,14 +1012,14 @@ class ProfileWidgets {
                 isActive ? '활성 계정' : '비활성 계정',
                 style: Theme.of(context).textTheme.titleSmall?.copyWith(
                   fontWeight: FontWeight.bold,
-                  color: isActive 
-                    ? Theme.of(context).colorScheme.primary
-                    : Theme.of(context).colorScheme.error,
+                  color: isActive
+                      ? Theme.of(context).colorScheme.primary
+                      : Theme.of(context).colorScheme.error,
                 ),
               ),
             ],
           ),
-          
+
           if (!isActive) ...[
             const SizedBox(height: 8),
             Text(
@@ -1007,9 +1029,9 @@ class ProfileWidgets {
               ),
             ),
           ],
-          
+
           const SizedBox(height: 12),
-          
+
           // 토글 버튼
           SizedBox(
             width: double.infinity,
@@ -1024,12 +1046,12 @@ class ProfileWidgets {
                   : Icon(isActive ? Icons.block : Icons.check_circle),
               label: Text(isActive ? '비활성화' : '활성화'),
               style: ElevatedButton.styleFrom(
-                backgroundColor: isActive 
-                  ? Theme.of(context).colorScheme.error
-                  : Theme.of(context).colorScheme.primary,
-                foregroundColor: isActive 
-                  ? Theme.of(context).colorScheme.onError
-                  : Theme.of(context).colorScheme.onPrimary,
+                backgroundColor: isActive
+                    ? Theme.of(context).colorScheme.error
+                    : Theme.of(context).colorScheme.primary,
+                foregroundColor: isActive
+                    ? Theme.of(context).colorScheme.onError
+                    : Theme.of(context).colorScheme.onPrimary,
               ),
             ),
           ),
@@ -1101,9 +1123,9 @@ class ProfileWidgets {
                 ),
               ),
             ),
-            
+
             const SizedBox(width: 16),
-            
+
             // 저장 버튼
             Expanded(
               flex: 2,

--- a/geulnamu_frontend/lib/screens/settings_screen.dart
+++ b/geulnamu_frontend/lib/screens/settings_screen.dart
@@ -146,7 +146,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
     return SingleChildScrollView(
       physics: const AlwaysScrollableScrollPhysics(),
       child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.stretch,  // 🎯 start → stretch로 변경 (가로 전체 사용)
         children: [
           // 🎨 외관 설정 섹션
           SettingsWidgets.buildSectionHeader(

--- a/geulnamu_frontend/lib/widgets/common/settings_widgets.dart
+++ b/geulnamu_frontend/lib/widgets/common/settings_widgets.dart
@@ -247,7 +247,7 @@ class SettingsWidgets {
   /// 설정 완료 메시지 카드
   static Widget buildCompletionCard(BuildContext context) {
     return Card(
-      margin: const EdgeInsets.all(16),
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),  // 🎯 다른 카드들과 동일한 마진 적용
       child: Padding(
         padding: const EdgeInsets.all(24),
         child: Column(


### PR DESCRIPTION
# 변경 내역
## 모바일 환경 대응 UI 수정
### 메인 페이지 수정
- 텍스트 오버플로우 문제 수정
### 설정 페이지 수정
- '설정 완료' 위젯 위치 다른 위젯들과 동일하도록 수정
### 출석 현황 페이지 수정
- 인원별 출석 상태 위젯 공간 차지 비율 수정
### 모임원 목록 페이지 수정
- 닉네임 텍스트 오버플로우 문제 수정
### 모임 목록 페이지 수정
- 모임별 항목 데이터 디스플레이별 출력 텍스트 포맷 분리
- '모임 만들기' 버튼 스피드 다이얼 하위로 이동
### 기타 텍스트 오타 문제 수정
- 모임 소개 및 발제문 설명 오타 수정
- 일반 회원 등급 명칭 수정