### PR TITLE
[Feat/common] fix minor issue

### DIFF
--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceStatusResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceStatusResponse.java
@@ -10,8 +10,10 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class MeetingAttendanceStatusResponse {
     private Long attendanceId;
+    private Long memberId;
     private String name;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime attendanceTime;
     private Boolean isLate;
+    private Boolean wantDiscussion;
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
@@ -16,4 +16,5 @@ public class MeetingAttendanceSummaryResponse {
     private Long totalAttendCount;
     private Long attendCount;
     private Long lateAttendCount;
+    private Long wantDiscussionCount;
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -35,7 +35,9 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
             .select(Projections.constructor(MeetingAttendanceSummaryResponse.class,
                 meeting.meetingDate, meeting.lateThresholdTime, attendance.member.count(),
                     normalAttendanceCount(),
-                    attendance.member.count().subtract(normalAttendanceCount()))
+                    attendance.member.count().subtract(normalAttendanceCount()),
+                    attendance.wantDiscussion.count()
+                )
             )
             .from(meeting)
             .leftJoin(attendance).on(meeting.id.eq(attendance.meeting.id))

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/attendance/AttendanceQueryRepositoryImpl.java
@@ -87,7 +87,9 @@ public class AttendanceQueryRepositoryImpl implements AttendanceQueryRepositoryC
     public List<MeetingAttendanceStatusResponse> findMeetingAttendanceStatus(Long meetingId) {
         return queryFactory
             .select(Projections.constructor(MeetingAttendanceStatusResponse.class,
-                attendance.id, attendance.member.name, attendance.createdAt, attendance.createdAt.after(meeting.lateThresholdTime))
+                attendance.id, attendance.member.id, attendance.member.name,
+                attendance.createdAt, attendance.createdAt.after(meeting.lateThresholdTime),
+                attendance.wantDiscussion)
             )
             .from(meeting)
             .join(attendance).on(meeting.id.eq(attendance.meeting.id))

--- a/geulnamu_backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -998,23 +998,30 @@ Content-Type: application/json;charset=UTF-8
       "lateThresholdTime" : "10:45",
       "totalAttendCount" : 3,
       "attendCount" : 2,
-      "lateAttendCount" : 1
+      "lateAttendCount" : 1,
+      "wantDiscussionCount" : 2
     },
     "meetingAttendanceStatusResponseList" : [ {
       "attendanceId" : 1,
+      "memberId" : 1,
       "name" : "나뭉일",
       "attendanceTime" : "2025.05.31 10:20",
-      "isLate" : false
+      "isLate" : false,
+      "wantDiscussion" : true
     }, {
       "attendanceId" : 2,
+      "memberId" : 2,
       "name" : "나뭉이",
       "attendanceTime" : "2025.05.31 10:44",
-      "isLate" : false
+      "isLate" : false,
+      "wantDiscussion" : true
     }, {
       "attendanceId" : 3,
+      "memberId" : 3,
       "name" : "나뭉삼",
       "attendanceTime" : "2025.05.31 10:50",
-      "isLate" : true
+      "isLate" : true,
+      "wantDiscussion" : false
     } ]
   }
 }</code></pre>
@@ -1098,6 +1105,13 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">지각 참석자 수</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceSummaryResponse.wantDiscussionCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 참석 희망자 수</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[]</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
@@ -1110,6 +1124,13 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">출석 고유번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].memberId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">모임원 고유번호</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].name</code></p></td>
@@ -1131,6 +1152,13 @@ Content-Type: application/json;charset=UTF-8
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">지각 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.meetingAttendanceStatusResponseList[].wantDiscussion</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">토론 참여 여부</p></td>
 </tr>
 </tbody>
 </table>

--- a/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
@@ -535,7 +535,7 @@ Host: docs.api.com
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Mon, 01 Jun 2026 16:01:46 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Tue, 02 Jun 2026 06:57:19 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -700,7 +700,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Mon, 01 Jun 2026 16:01:46 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Tue, 02 Jun 2026 06:57:20 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -164,11 +164,11 @@ public class AttendanceControllerTest extends ControllerTest {
                 ),
                 Arrays.asList(
                     new MeetingAttendanceStatusResponse(
-                        1L, "나뭉일", LocalDateTime.of(2025, 5, 31, 10, 20), false),
+                        1L, 1L, "나뭉일", LocalDateTime.of(2025, 5, 31, 10, 20), false, true),
                     new MeetingAttendanceStatusResponse(
-                        2L, "나뭉이", LocalDateTime.of(2025, 5, 31, 10, 44), false),
+                        2L, 2L, "나뭉이", LocalDateTime.of(2025, 5, 31, 10, 44), false, true),
                     new MeetingAttendanceStatusResponse(
-                        3L, "나뭉삼", LocalDateTime.of(2025, 5, 31, 10, 50), true)
+                        3L, 3L, "나뭉삼", LocalDateTime.of(2025, 5, 31, 10, 50), true, false)
                 )
             );
 
@@ -209,9 +209,11 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingAttendanceSummaryResponse.lateAttendCount").type(JsonFieldType.NUMBER).description("지각 참석자 수"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[]").type(JsonFieldType.ARRAY).description("모임원별 출석 정보"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].attendanceId").type(JsonFieldType.NUMBER).description("출석 고유번호"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].name").type(JsonFieldType.STRING).description("모임원 이름"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].attendanceTime").type(JsonFieldType.STRING).description("출석 시간"),
-                    fieldWithPath("data.meetingAttendanceStatusResponseList[].isLate").type(JsonFieldType.BOOLEAN).description("지각 여부")
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].isLate").type(JsonFieldType.BOOLEAN).description("지각 여부"),
+                    fieldWithPath("data.meetingAttendanceStatusResponseList[].wantDiscussion").type(JsonFieldType.BOOLEAN).description("토론 참여 여부")
                 )
             ));
     }

--- a/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
+++ b/geulnamu_backend/src/test/java/com/geulnamu/controller/attendance/AttendanceControllerTest.java
@@ -160,7 +160,7 @@ public class AttendanceControllerTest extends ControllerTest {
                 new MeetingAttendanceSummaryResponse(
                     LocalDateTime.of(2025, 5, 31, 10, 30),
                     LocalDateTime.of(2025, 5, 31, 10, 45),
-                    3L, 2L, 1L
+                    3L, 2L, 1L, 2L
                 ),
                 Arrays.asList(
                     new MeetingAttendanceStatusResponse(
@@ -207,6 +207,7 @@ public class AttendanceControllerTest extends ControllerTest {
                     fieldWithPath("data.meetingAttendanceSummaryResponse.totalAttendCount").type(JsonFieldType.NUMBER).description("전체 참석 인원수"),
                     fieldWithPath("data.meetingAttendanceSummaryResponse.attendCount").type(JsonFieldType.NUMBER).description("정상 참석자 수"),
                     fieldWithPath("data.meetingAttendanceSummaryResponse.lateAttendCount").type(JsonFieldType.NUMBER).description("지각 참석자 수"),
+                    fieldWithPath("data.meetingAttendanceSummaryResponse.wantDiscussionCount").type(JsonFieldType.NUMBER).description("토론 참석 희망자 수"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[]").type(JsonFieldType.ARRAY).description("모임원별 출석 정보"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].attendanceId").type(JsonFieldType.NUMBER).description("출석 고유번호"),
                     fieldWithPath("data.meetingAttendanceStatusResponseList[].memberId").type(JsonFieldType.NUMBER).description("모임원 고유번호"),

--- a/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
+++ b/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
@@ -36,6 +36,7 @@ class AttendanceSummary {
   final int totalAttendCount;
   final int attendCount;
   final int lateAttendCount;
+  final int wantDiscussionCount;  // 🆕 토론 참여 희망자 수
 
   const AttendanceSummary({
     required this.meetingDate,
@@ -43,6 +44,7 @@ class AttendanceSummary {
     required this.totalAttendCount,
     required this.attendCount,
     required this.lateAttendCount,
+    required this.wantDiscussionCount,
   });
 
   factory AttendanceSummary.fromJson(Map<String, dynamic> json) {
@@ -55,6 +57,7 @@ class AttendanceSummary {
       totalAttendCount: (json['totalAttendCount'] as num?)?.toInt() ?? 0,
       attendCount: (json['attendCount'] as num?)?.toInt() ?? 0,
       lateAttendCount: (json['lateAttendCount'] as num?)?.toInt() ?? 0,
+      wantDiscussionCount: (json['wantDiscussionCount'] as num?)?.toInt() ?? 0,  // 🆕 파싱
     );
   }
 
@@ -94,6 +97,7 @@ class AttendanceSummary {
       'totalAttendCount': totalAttendCount,
       'attendCount': attendCount,
       'lateAttendCount': lateAttendCount,
+      'wantDiscussionCount': wantDiscussionCount,
     };
   }
 

--- a/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
+++ b/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
@@ -103,24 +103,30 @@ class AttendanceSummary {
 
 /// 개별 출석 상태 정보
 class AttendanceStatus {
-  final int attendanceId;  // memberId → attendanceId로 변경
+  final int attendanceId;
+  final int memberId;  // 🆕 회원 ID 추가 (푸시 알림 수신자용)
   final String name;
   final DateTime attendanceTime;
   final bool isLate;
+  final bool? wantDiscussion;  // 🆕 토론 참여 희망 여부 추가
 
   const AttendanceStatus({
-    required this.attendanceId,  // memberId → attendanceId로 변경
+    required this.attendanceId,
+    required this.memberId,
     required this.name,
     required this.attendanceTime,
     required this.isLate,
+    this.wantDiscussion,
   });
 
   factory AttendanceStatus.fromJson(Map<String, dynamic> json) {
     return AttendanceStatus(
-      attendanceId: (json['attendanceId'] as num?)?.toInt() ?? 0,  // memberId → attendanceId로 변경
+      attendanceId: (json['attendanceId'] as num?)?.toInt() ?? 0,
+      memberId: (json['memberId'] as num?)?.toInt() ?? 0,  // 🆕 memberId 파싱
       name: json['name']?.toString() ?? '알 수 없음',
       attendanceTime: _parseDateTime(json['attendanceTime']),
       isLate: json['isLate'] as bool? ?? false,
+      wantDiscussion: json['wantDiscussion'] as bool?,  // 🆕 wantDiscussion 파싱
     );
   }
 
@@ -138,10 +144,12 @@ class AttendanceStatus {
 
   Map<String, dynamic> toJson() {
     return {
-      'attendanceId': attendanceId,  // memberId → attendanceId로 변경
+      'attendanceId': attendanceId,
+      'memberId': memberId,
       'name': name,
       'attendanceTime': attendanceTime.toIso8601String(),
       'isLate': isLate,
+      'wantDiscussion': wantDiscussion,
     };
   }
 }

--- a/geulnamu_frontend/lib/screens/attendance/attendance_status_screen.dart
+++ b/geulnamu_frontend/lib/screens/attendance/attendance_status_screen.dart
@@ -110,8 +110,12 @@ class _AttendanceStatusScreenState extends State<AttendanceStatusScreen>
         // 구분선
         Divider(height: 1, color: context.colors.outline.withOpacity(0.2)),
 
-        // 출석자 목록 헤더
-        AttendanceStatusWidgets.buildAttendanceListHeader(context),
+        // 출석자 목록 헤더 (🆕 관리자용 복사 버튼 포함)
+        AttendanceStatusWidgets.buildAttendanceListHeader(
+          context,
+          attendanceList: attendanceList,
+          showAdminActions: _isAdminLevel(),
+        ),
 
         // 출석자 목록
         Expanded(

--- a/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
+++ b/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
@@ -147,6 +147,20 @@ class AttendanceStatusWidgets {
             Colors.orange,
           ),
         ),
+        // 🆕 토론희망 항목 추가
+        Container(
+          width: 1,
+          height: 40,
+          color: context.colors.outline.withValues(alpha: 0.3),
+        ),
+        Expanded(
+          child: _buildStatItem(
+            context,
+            '토론희망',
+            '${summary.wantDiscussionCount}명',
+            context.colors.primary,
+          ),
+        ),
       ],
     );
   }

--- a/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
+++ b/geulnamu_frontend/lib/screens/attendance/widgets/attendance_status_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';  // 🆕 클립보드 복사용
 import '../../../core/theme.dart';
 import '../../../models/attendance/attendance_status_model.dart';
 
@@ -237,30 +238,174 @@ class AttendanceStatusWidgets {
   // ==================== 출석자 목록 ====================
 
   /// 출석자 목록 헤더
-  static Widget buildAttendanceListHeader(BuildContext context) {
+  static Widget buildAttendanceListHeader(
+    BuildContext context, {
+    List<AttendanceStatus>? attendanceList,  // 🆕 복사 기능을 위해 추가
+    bool showAdminActions = false,  // 🆕 관리자 액션 표시 여부
+  }) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: Row(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Icon(Icons.people_outline, color: context.colors.primary, size: 24),
-          const SizedBox(width: 8),
-          Text(
-            '출석자 목록',
-            style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: context.colors.onSurface,
-            ),
+          // 헤더 행
+          Row(
+            children: [
+              Icon(Icons.people_outline, color: context.colors.primary, size: 24),
+              const SizedBox(width: 8),
+              Text(
+                '출석자 목록',
+                style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: context.colors.onSurface,
+                ),
+              ),
+              const Spacer(),
+              Text(
+                '(늦게 온 순)',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: context.colors.onSurface.withValues(alpha: 0.5),
+                ),
+              ),
+            ],
           ),
-          const Spacer(),
-          Text(
-            '(늦게 온 순)',
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: context.colors.onSurface.withValues(alpha: 0.5),
-            ),
-          ),
+          
+          // 🆕 관리자용 복사 버튼들
+          if (showAdminActions && attendanceList != null && attendanceList.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            _buildCopyButtonsRow(context, attendanceList),
+          ],
         ],
       ),
     );
+  }
+
+  /// 🆕 관리자용 복사 버튼 행
+  static Widget _buildCopyButtonsRow(
+    BuildContext context,
+    List<AttendanceStatus> attendanceList,
+  ) {
+    // 토론 참여 희망자 수 계산
+    final discussionWantCount = attendanceList
+        .where((a) => a.wantDiscussion == true)
+        .length;
+
+    return Wrap(
+      spacing: 8,
+      runSpacing: 8,
+      children: [
+        // 모임원 명단 복사 버튼
+        _buildCopyButton(
+          context,
+          icon: Icons.content_copy,
+          label: '모임원 명단 (${attendanceList.length}명)',
+          onPressed: () => _copyAttendeeIds(context, attendanceList),
+        ),
+        
+        // 토론 참여 모임원 명단 복사 버튼
+        _buildCopyButton(
+          context,
+          icon: Icons.forum_outlined,
+          label: '토론 참여 모임원 명단 ($discussionWantCount명)',
+          onPressed: discussionWantCount > 0
+              ? () => _copyDiscussionWantIds(context, attendanceList)
+              : null,  // 0명이면 비활성화
+        ),
+      ],
+    );
+  }
+
+  /// 🆕 복사 버튼 위젯
+  static Widget _buildCopyButton(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required VoidCallback? onPressed,
+  }) {
+    return OutlinedButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 16),
+      label: Text(label, style: const TextStyle(fontSize: 13)),
+      style: OutlinedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        side: BorderSide(
+          color: onPressed != null
+              ? context.colors.primary
+              : context.colors.outline.withValues(alpha: 0.3),
+        ),
+        foregroundColor: onPressed != null
+            ? context.colors.primary
+            : context.colors.onSurface.withValues(alpha: 0.4),
+      ),
+    );
+  }
+
+  /// 🆕 출석자 전체 memberId 복사
+  static Future<void> _copyAttendeeIds(
+    BuildContext context,
+    List<AttendanceStatus> attendanceList,
+  ) async {
+    final memberIds = attendanceList
+        .map((a) => a.memberId.toString())
+        .join(',');
+    
+    await Clipboard.setData(ClipboardData(text: memberIds));
+    
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '모임원 ${attendanceList.length}명의 ID가 복사되었습니다.',
+                ),
+              ),
+            ],
+          ),
+          backgroundColor: context.colors.primary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  /// 🆕 토론 참여 희망자 memberId 복사
+  static Future<void> _copyDiscussionWantIds(
+    BuildContext context,
+    List<AttendanceStatus> attendanceList,
+  ) async {
+    final discussionWantList = attendanceList
+        .where((a) => a.wantDiscussion == true)
+        .toList();
+    
+    final memberIds = discussionWantList
+        .map((a) => a.memberId.toString())
+        .join(',');
+    
+    await Clipboard.setData(ClipboardData(text: memberIds));
+    
+    if (context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Row(
+            children: [
+              const Icon(Icons.check_circle, color: Colors.white, size: 20),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  '토론 참여 희망자 ${discussionWantList.length}명의 ID가 복사되었습니다.',
+                ),
+              ),
+            ],
+          ),
+          backgroundColor: context.colors.primary,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
   }
 
   /// 출석자 목록 빌드

--- a/geulnamu_frontend/lib/screens/discussion/discussion_group_screen.dart
+++ b/geulnamu_frontend/lib/screens/discussion/discussion_group_screen.dart
@@ -198,6 +198,9 @@ class _DiscussionGroupScreenState extends State<DiscussionGroupScreen> {
 
   /// 에러 위젯
   Widget _buildError(String message) {
+    // 로그인 관련 에러인지 확인
+    final isAuthError = _isAuthenticationError(message);
+
     return Center(
       child: Padding(
         padding: const EdgeInsets.all(32),
@@ -214,15 +217,51 @@ class _DiscussionGroupScreenState extends State<DiscussionGroupScreen> {
               ),
             ),
             const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: _loadDiscussionGroups,
-              icon: const Icon(Icons.refresh),
-              label: const Text('다시 시도'),
+            // 버튼들 (Row로 배치)
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                // 다시 시도 버튼
+                ElevatedButton.icon(
+                  onPressed: _loadDiscussionGroups,
+                  icon: const Icon(Icons.refresh),
+                  label: const Text('다시 시도'),
+                ),
+                // 로그인 관련 에러일 때만 로그인 버튼 표시
+                if (isAuthError) ...[
+                  const SizedBox(width: 12),
+                  OutlinedButton.icon(
+                    onPressed: _navigateToLogin,
+                    icon: const Icon(Icons.login),
+                    label: const Text('로그인하기'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: context.colors.primary,
+                      side: BorderSide(color: context.colors.primary),
+                    ),
+                  ),
+                ],
+              ],
             ),
           ],
         ),
       ),
     );
+  }
+
+  /// 인증 관련 에러인지 확인
+  bool _isAuthenticationError(String message) {
+    final lowerMessage = message.toLowerCase();
+    return lowerMessage.contains('로그인') ||
+        lowerMessage.contains('인증') ||
+        lowerMessage.contains('토큰') ||
+        lowerMessage.contains('401') ||
+        lowerMessage.contains('unauthorized') ||
+        lowerMessage.contains('authentication');
+  }
+
+  /// 로그인 페이지로 이동
+  void _navigateToLogin() {
+    Navigator.of(context).pushNamedAndRemoveUntil('/login', (route) => false);
   }
 
   /// 빈 상태 위젯

--- a/geulnamu_frontend/lib/screens/home/mixins/route_aware_mixin.dart
+++ b/geulnamu_frontend/lib/screens/home/mixins/route_aware_mixin.dart
@@ -3,6 +3,8 @@ import 'package:provider/provider.dart';
 import '../../../core/config/app_config.dart';
 import '../../../services/home/home_route_service.dart';
 import '../../../providers/auth_provider.dart';
+import '../../../services/navigation/pending_navigation_service.dart';
+import '../../../main.dart' show navigatorKey;
 
 /// RouteAware 기능을 담당하는 mixin
 /// 
@@ -17,6 +19,10 @@ import '../../../providers/auth_provider.dart';
 /// 주의: RouteAware를 함께 with 해야 함
 mixin RouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
   final HomeRouteService _routeService = HomeRouteService();
+  final PendingNavigationService _pendingNavigationService = PendingNavigationService();
+  
+  // 🚨 Pending Navigation 처리 중복 방지 플래그
+  bool _isProcessingPendingNavigation = false;
 
   // 🎯 RouteObserver 등록/해제 메서드들
   
@@ -86,6 +92,9 @@ mixin RouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
         
         // 로그인 상태에서만 실행
         if (authProvider.isAuthenticated) {
+          // 🚀 Pending Navigation 처리 (로그인 완료 후)
+          await _processPendingNavigation();
+          
           try {
             await authProvider.checkProfileStatus();
           } catch (profileError) {
@@ -109,6 +118,66 @@ mixin RouteAwareMixin<T extends StatefulWidget> on State<T>, RouteAware {
         // UI에 영향주지 않음
       }
     });
+  }
+
+  /// 🚀 Pending Navigation 처리
+  /// 
+  /// 로그인 완료 후 저장된 목적지로 이동
+  Future<void> _processPendingNavigation() async {
+    // 중복 처리 방지
+    if (_isProcessingPendingNavigation) {
+      if (AppConfig.debugMode) {
+        print('⚠️ [RouteAwareMixin] Pending Navigation 이미 처리 중 - 건너뜀');
+      }
+      return;
+    }
+
+    try {
+      _isProcessingPendingNavigation = true;
+
+      final pending = await _pendingNavigationService.getPendingNavigation();
+      
+      if (pending == null) {
+        if (AppConfig.debugMode) {
+          print('📭 [RouteAwareMixin] Pending Navigation 없음');
+        }
+        return;
+      }
+
+      if (AppConfig.debugMode) {
+        print('🚀 [RouteAwareMixin] Pending Navigation 발견!');
+        print('🚀 route: ${pending.route}');
+        print('🚀 arguments: ${pending.arguments}');
+      }
+
+      // 목적지로 이동
+      if (navigatorKey.currentState != null) {
+        // 먼저 Pending Navigation 삭제 (중복 이동 방지)
+        await _pendingNavigationService.clearPendingNavigation();
+        
+        // 약간의 지연 후 이동 (화면 렌더링 완료 대기)
+        await Future.delayed(const Duration(milliseconds: 300));
+        
+        if (AppConfig.debugMode) {
+          print('🚀 [RouteAwareMixin] 목적지로 이동: ${pending.route}');
+        }
+        
+        navigatorKey.currentState?.pushNamed(
+          pending.route,
+          arguments: pending.arguments,
+        );
+      } else {
+        if (AppConfig.debugMode) {
+          print('⚠️ [RouteAwareMixin] Navigator가 아직 준비되지 않음');
+        }
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [RouteAwareMixin] Pending Navigation 처리 오류: $e');
+      }
+    } finally {
+      _isProcessingPendingNavigation = false;
+    }
   }
 
   /// 🔍 인증 에러 여부 정확히 감지

--- a/geulnamu_frontend/lib/screens/meeting/meeting_detail_staff_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_detail_staff_screen.dart
@@ -77,6 +77,8 @@ class _MeetingDetailStaffScreenState extends State<MeetingDetailStaffScreen>
         return MainLayout(
           title: currentTitle,
           isHomePage: false, // 서브 페이지이므로 뒤로가기 버튼 표시
+          // 🎯 PWA 키보드 처리를 직접 함 (viewInsets 사용)
+          resizeToAvoidBottomInset: false,
           // HomeService를 통한 메뉴 및 로그아웃 처리
           onMenuTap: (menu) => _homeService.handleMenuTap(context, menu),
           onLogoutTap: () => _handleLogout(),

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_screen.dart
@@ -178,6 +178,7 @@ class _MeetingListScreenState extends State<MeetingListScreen>
           context,
           totalElements: totalElements,
           currentFilter: currentFilter,
+          onFilterTap: _showFilterBottomSheet,
         ),
 
         // 구분선

--- a/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_list_staff_screen.dart
@@ -188,6 +188,7 @@ class _MeetingListStaffScreenState extends State<MeetingListStaffScreen>
             context,
             totalElements: totalElements,
             currentFilter: currentFilter,
+            onFilterTap: _showStaffFilterBottomSheet,
           ),
         ),
 

--- a/geulnamu_frontend/lib/screens/meeting/meeting_qr_display_screen.dart
+++ b/geulnamu_frontend/lib/screens/meeting/meeting_qr_display_screen.dart
@@ -1,4 +1,8 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 import '../../providers/auth_provider.dart';
 import '../../services/attendance/qr_service.dart';
@@ -6,6 +10,10 @@ import '../../services/home/home_service.dart';
 import '../../models/attendance/qr_data.dart';
 import '../../widgets/common/main_layout.dart';
 import '../../core/config/app_config.dart';
+import '../../core/theme.dart';
+
+// 웹 환경에서 다운로드를 위한 import
+import 'package:web/web.dart' as web;
 
 /// 운영진용 QR 코드 표시 화면
 ///
@@ -32,6 +40,10 @@ class _MeetingQrDisplayScreenState extends State<MeetingQrDisplayScreen> {
   final HomeService _homeService = HomeService();
   late QrData _currentQrData;
 
+  // 🆕 QR 코드 캔처를 위한 GlobalKey
+  final GlobalKey _qrKey = GlobalKey();
+  bool _isDownloading = false;
+
   @override
   void initState() {
     super.initState();
@@ -53,6 +65,111 @@ class _MeetingQrDisplayScreenState extends State<MeetingQrDisplayScreen> {
   Future<void> _handleLogout() async {
     final authProvider = Provider.of<AuthProvider>(context, listen: false);
     await _homeService.handleLogout(context, authProvider);
+  }
+
+  /// 🆕 QR 코드 이미지 다운로드
+  Future<void> _downloadQrImage() async {
+    if (_isDownloading) return;
+
+    setState(() {
+      _isDownloading = true;
+    });
+
+    try {
+      // RepaintBoundary로부터 이미지 캔처
+      final RenderRepaintBoundary? boundary =
+          _qrKey.currentContext?.findRenderObject() as RenderRepaintBoundary?;
+
+      if (boundary == null) {
+        throw Exception('QR 코드를 찾을 수 없습니다.');
+      }
+
+      // 이미지로 변환 (고해상도)
+      final ui.Image image = await boundary.toImage(pixelRatio: 3.0);
+      final ByteData? byteData = await image.toByteData(
+        format: ui.ImageByteFormat.png,
+      );
+
+      if (byteData == null) {
+        throw Exception('이미지 변환에 실패했습니다.');
+      }
+
+      final Uint8List pngBytes = byteData.buffer.asUint8List();
+
+      // 웹 환경에서 다운로드
+      await _downloadImageWeb(pngBytes);
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Row(
+              children: [
+                Icon(Icons.check_circle, color: Colors.white),
+                SizedBox(width: 8),
+                Text('QR 코드 이미지가 다운로드되었습니다.'),
+              ],
+            ),
+            backgroundColor: context.colors.primary,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+
+      if (AppConfig.debugMode) {
+        print('✅ [QR 다운로드] 성공');
+      }
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [QR 다운로드] 실패: $e');
+      }
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Row(
+              children: [
+                const Icon(Icons.error, color: Colors.white),
+                const SizedBox(width: 8),
+                Expanded(child: Text('QR 다운로드 실패: $e')),
+              ],
+            ),
+            backgroundColor: context.colors.error,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isDownloading = false;
+        });
+      }
+    }
+  }
+
+  /// 웹 환경에서 이미지 다운로드
+  Future<void> _downloadImageWeb(Uint8List imageBytes) async {
+    // Base64로 인코딩
+    final base64Image = base64Encode(imageBytes);
+    final dataUrl = 'data:image/png;base64,$base64Image';
+
+    // 파일명 생성 (모임명_QR_날짜)
+    final now = DateTime.now();
+    final dateStr =
+        '${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}';
+    final safeTitle = widget.meetingTitle
+        .replaceAll(RegExp(r'[^a-zA-Z0-9가-힣]'), '_');
+    final fileName = '${safeTitle}_QR_$dateStr.png';
+
+    // 다운로드 링크 생성 및 클릭
+    final anchor = web.HTMLAnchorElement()
+      ..href = dataUrl
+      ..download = fileName
+      ..style.display = 'none';
+
+    web.document.body?.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
   }
 
   @override
@@ -167,55 +284,74 @@ class _MeetingQrDisplayScreenState extends State<MeetingQrDisplayScreen> {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        // QR 코드
-                        Container(
-                          padding: const EdgeInsets.all(16),
-                          decoration: BoxDecoration(
-                            color: Colors.white,
-                            borderRadius: BorderRadius.circular(12),
-                            boxShadow: [
-                              BoxShadow(
-                                color: Colors.black.withValues(alpha: 0.1),
-                                blurRadius: 8,
-                                offset: const Offset(0, 2),
-                              ),
-                            ],
-                          ),
-                          child: FutureBuilder<Widget>(
-                            future: _qrService.createQrWidget(
-                              qrData: _currentQrData,
-                              size: 250,
-                              backgroundColor: Colors.white,
-                              foregroundColor: Colors.black,
+                        // QR 코드 (🆕 RepaintBoundary로 감싸서 캔처 가능하게)
+                        RepaintBoundary(
+                          key: _qrKey,
+                          child: Container(
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: Colors.white,
+                              borderRadius: BorderRadius.circular(12),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.black.withValues(alpha: 0.1),
+                                  blurRadius: 8,
+                                  offset: const Offset(0, 2),
+                                ),
+                              ],
                             ),
-                            builder: (context, snapshot) {
-                              if (snapshot.hasData) {
-                                return snapshot.data!;
-                              } else {
-                                return Container(
-                                  width: 250,
-                                  height: 250,
-                                  alignment: Alignment.center,
-                                  child: CircularProgressIndicator(
-                                    color: Theme.of(
-                                      context,
-                                    ).colorScheme.primary,
-                                  ),
-                                );
-                              }
-                            },
+                            child: FutureBuilder<Widget>(
+                              future: _qrService.createQrWidget(
+                                qrData: _currentQrData,
+                                size: 250,
+                                backgroundColor: Colors.white,
+                                foregroundColor: Colors.black,
+                              ),
+                              builder: (context, snapshot) {
+                                if (snapshot.hasData) {
+                                  return snapshot.data!;
+                                } else {
+                                  return Container(
+                                    width: 250,
+                                    height: 250,
+                                    alignment: Alignment.center,
+                                    child: CircularProgressIndicator(
+                                      color: Theme.of(
+                                        context,
+                                      ).colorScheme.primary,
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
                           ),
                         ),
 
                         const SizedBox(height: 20),
 
-                        // QR 정보 - 텍스트 제거
-                        // Text(
-                        //   '📚 고정 출석 QR 코드 (시간 제한 없음)',
-                        //   style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                        //     color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
-                        //   ),
-                        // ),
+                        // 🆕 다운로드 버튼
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton.icon(
+                            onPressed: _isDownloading ? null : _downloadQrImage,
+                            icon: _isDownloading
+                                ? const SizedBox(
+                                    width: 20,
+                                    height: 20,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      color: Colors.white,
+                                    ),
+                                  )
+                                : const Icon(Icons.download),
+                            label: Text(
+                              _isDownloading ? '다운로드 중...' : 'QR 이미지 다운로드',
+                            ),
+                            style: ElevatedButton.styleFrom(
+                              padding: const EdgeInsets.symmetric(vertical: 12),
+                            ),
+                          ),
+                        ),
                       ],
                     ),
                   ),

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_staff_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_staff_logic_mixin.dart
@@ -847,12 +847,29 @@ mixin MeetingDetailStaffLogicMixin<T extends StatefulWidget> on State<T> {
 
     // 🔥 토론 시간이 설정된 경우에만 유효성 검사
     if (_selectedDiscussionTime != null && _selectedMeetingDateTime != null) {
+      // 검증 1: 모임 당일 & 모임 시간 이후인지
       if (!_isValidDiscussionTime(_selectedDiscussionTime!, _selectedMeetingDateTime!)) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
               '⚠️ 토론 시간이 올바르지 않습니다.\n'
               '조건: ${_formatDate(_selectedMeetingDateTime!)} (모임 당일) ${_formatTime(_selectedMeetingDateTime!)} 이후로 설정해주세요.',
+            ),
+            backgroundColor: Colors.red,
+            duration: const Duration(seconds: 4),
+          ),
+        );
+        return false;
+      }
+      
+      // 검증 2: 현재 시간 이후인지
+      final now = DateTime.now();
+      if (_selectedDiscussionTime!.isBefore(now)) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              '⚠️ 토론 시간이 올바르지 않습니다.\n'
+              '현재 시간(${_formatTime(now)}) 이후로 설정해주세요.',
             ),
             backgroundColor: Colors.red,
             duration: const Duration(seconds: 4),
@@ -961,12 +978,27 @@ mixin MeetingDetailStaffLogicMixin<T extends StatefulWidget> on State<T> {
 
   void onDiscussionTimeChanged(DateTime? value) {
     if (value != null && _selectedMeetingDateTime != null) {
-      // 🔥 토론 시간 검증
+      // 🔥 토론 시간 검증 1: 모임 당일 & 모임 시간 이후인지
       if (!_isValidDiscussionTime(value, _selectedMeetingDateTime!)) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(
               content: Text('⚠️ 토론 시간은 모임 당일에 모임 시간 이후로 설정해야 합니다.'),
+              backgroundColor: Colors.orange,
+              duration: Duration(seconds: 3),
+            ),
+          );
+        }
+        return; // 변경 차단
+      }
+      
+      // 🔥 토론 시간 검증 2: 현재 시간 이후인지
+      final now = DateTime.now();
+      if (value.isBefore(now)) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('⚠️ 토론 시간은 현재 시간 이후로 설정해야 합니다.'),
               backgroundColor: Colors.orange,
               duration: Duration(seconds: 3),
             ),

--- a/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_staff_logic_mixin.dart
+++ b/geulnamu_frontend/lib/screens/meeting/mixins/meeting_detail_staff_logic_mixin.dart
@@ -656,8 +656,8 @@ mixin MeetingDetailStaffLogicMixin<T extends StatefulWidget> on State<T> {
           const SnackBar(content: Text('모임이 삭제되었습니다.')),
         );
 
-        // 목록 화면으로 돌아가기
-        Navigator.of(context).pop(true); // 삭제 성공 결과 반환
+        // 🆕 목록 화면으로 교체 이동 (브라우저 히스토리에서 삭제된 페이지 제거)
+        Navigator.of(context).pushReplacementNamed('/meeting-list-staff');
       }
     } catch (e) {
       if (mounted) {

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/basic_info_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/basic_info_widgets.dart
@@ -38,6 +38,8 @@ class BasicInfoWidgets {
               onSave: onSave,
             ),
 
+            const SizedBox(height: 16), // 헤더와 콘텐츠 사이 여백
+
             // 내용 (조회 모드 vs 편집 모드)
             if (isEditing)
               _buildBasicInfoEditForm(
@@ -83,23 +85,39 @@ class BasicInfoWidgets {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // 취소 버튼
+              // 취소 버튼 (크기 축소)
               TextButton(
                 onPressed: isSaving ? null : onToggleEdit,
-                child: const Text('취소'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: const Text('취소', style: TextStyle(fontSize: 13)),
               ),
-              const SizedBox(width: 8),
-              // 저장 버튼
-              ElevatedButton.icon(
-                onPressed: isSaving ? null : onSave,
-                icon: isSaving
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.save),
-                label: Text(isSaving ? '저장 중...' : '저장'),
+              const SizedBox(width: 4),
+              // 저장 버튼 (크기 축소)
+              SizedBox(
+                height: 32,
+                child: ElevatedButton.icon(
+                  onPressed: isSaving ? null : onSave,
+                  icon: isSaving
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save, size: 16),
+                  label: Text(
+                    isSaving ? '저장중' : '저장',
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
               ),
             ],
           )

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/discussion_group_edit_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/discussion_group_edit_widgets.dart
@@ -223,12 +223,14 @@ class DiscussionGroupEditWidgets {
               color: Theme.of(context).colorScheme.primary,
             ),
             const SizedBox(width: 8),
-            Text(
-              '토론 그룹 구성 현황 (드래그&드롭 편집)',
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: Theme.of(context).colorScheme.onSurface,
-                fontSize: 16,
+            Flexible(
+              child: Text(
+                '토론 그룹 구성 현황 (드래그&드롭 편집)',
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: Theme.of(context).colorScheme.onSurface,
+                  fontSize: 16,
+                ),
               ),
             ),
           ],
@@ -426,14 +428,16 @@ class DiscussionGroupEditWidgets {
                 color: Theme.of(context).colorScheme.primary,
               ),
               const SizedBox(width: 8),
-              Text(
-                isHighlighted
-                    ? '➕ 새 그룹을 만들고 여기에 추가하세요!'
-                    : '➕ 멤버를 여기로 드래그하면 새 그룹이 생성됩니다',
-                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: isHighlighted ? FontWeight.bold : FontWeight.w600,
-                  color: Theme.of(context).colorScheme.onSurface,
-                  fontSize: 16,
+              Flexible(
+                child: Text(
+                  isHighlighted
+                      ? '➕ 새 그룹을 만들고 여기에 추가하세요!'
+                      : '➕ 멤버를 여기로 드래그하면 새 그룹이 생성됩니다',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: isHighlighted ? FontWeight.bold : FontWeight.w600,
+                    color: Theme.of(context).colorScheme.onSurface,
+                    fontSize: 16,
+                  ),
                 ),
               ),
             ],

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/discussion_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff/discussion_widgets.dart
@@ -162,23 +162,39 @@ class DiscussionWidgets {
           Row(
             mainAxisSize: MainAxisSize.min,
             children: [
-              // 취소 버튼
+              // 취소 버튼 (크기 축소)
               TextButton(
                 onPressed: isSaving ? null : onToggleEdit,
-                child: const Text('취소'),
+                style: TextButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  minimumSize: Size.zero,
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: const Text('취소', style: TextStyle(fontSize: 13)),
               ),
-              const SizedBox(width: 8),
-              // 저장 버튼
-              ElevatedButton.icon(
-                onPressed: isSaving ? null : onSave,
-                icon: isSaving
-                    ? const SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.save),
-                label: Text(isSaving ? '저장 중...' : '저장'),
+              const SizedBox(width: 4),
+              // 저장 버튼 (크기 축소)
+              SizedBox(
+                height: 32,
+                child: ElevatedButton.icon(
+                  onPressed: isSaving ? null : onSave,
+                  icon: isSaving
+                      ? const SizedBox(
+                          width: 14,
+                          height: 14,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Icon(Icons.save, size: 16),
+                  label: Text(
+                    isSaving ? '저장중' : '저장',
+                    style: const TextStyle(fontSize: 13),
+                  ),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(horizontal: 10),
+                    minimumSize: Size.zero,
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  ),
+                ),
               ),
             ],
           )
@@ -356,8 +372,9 @@ class DiscussionWidgets {
   }) {
     return Row(
       children: [
+        // 🆕 편집 중에도 제목은 동일하게 표시 ('편집 중' 텍스트 제거)
         Text(
-          isEditingDiscussionGroups ? '👥 토론 조 정보 (편집 중)' : '👥 토론 조 정보',
+          '👥 토론 조 정보',
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
             fontWeight: FontWeight.bold,
             color: Theme.of(context).colorScheme.primary,
@@ -366,22 +383,39 @@ class DiscussionWidgets {
         const Spacer(),
 
         if (isEditingDiscussionGroups) ...[
-          // 편집 모드: 취소 + 저장 버튼
+          // 편집 모드: 취소 + 저장 버튼 (크기 축소)
           TextButton(
             onPressed: isSaving ? null : onToggleEdit,
-            child: const Text('취소'),
+            style: TextButton.styleFrom(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              minimumSize: Size.zero,
+              tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            ),
+            child: const Text('취소', style: TextStyle(fontSize: 13)),
           ),
-          const SizedBox(width: 8),
-          ElevatedButton.icon(
-            onPressed: isSaving ? null : onSave,
-            icon: isSaving
-                ? const SizedBox(
-                    width: 16,
-                    height: 16,
-                    child: CircularProgressIndicator(strokeWidth: 2),
-                  )
-                : const Icon(Icons.save),
-            label: Text(isSaving ? '저장 중...' : '저장'),
+          const SizedBox(width: 4),
+          // 🆕 저장 버튼 크기 축소
+          SizedBox(
+            height: 32,
+            child: ElevatedButton.icon(
+              onPressed: isSaving ? null : onSave,
+              icon: isSaving
+                  ? const SizedBox(
+                      width: 14,
+                      height: 14,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.save, size: 16),
+              label: Text(
+                isSaving ? '저장중' : '저장',
+                style: const TextStyle(fontSize: 13),
+              ),
+              style: ElevatedButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 10),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+            ),
           ),
         ] else ...[
           // 조회 모드: 새로고침 + 편집 버튼

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_staff_widgets.dart
@@ -101,8 +101,23 @@ class MeetingDetailStaffWidgets {
     required VoidCallback onRefreshBookQuestionData,
     Function(BookQuestionModel)? onBookQuestionTap,
   }) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16),
+    // 🎯 키보드 높이 가져오기 (viewInsets 직접 처리)
+    final bottomInset = MediaQuery.of(context).viewInsets.bottom;
+    
+    return GestureDetector(
+      // 🎯 빈 영역 탭 시 키보드 닫기
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: SingleChildScrollView(
+        // 🎯 키보드 드래그 시 닫기
+        keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
+        // 🎯 키보드 높이만큼 하단 패딩 추가
+        padding: EdgeInsets.only(
+          left: 16,
+          right: 16,
+          top: 16,
+          // 키보드 있을 때: 키보드 높이, 없을 때: 일반 여백
+          bottom: bottomInset > 0 ? bottomInset + 16 : 16,
+        ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -219,6 +234,7 @@ class MeetingDetailStaffWidgets {
           ),
         ],
       ),
-    );
+      ),  // SingleChildScrollView 닫힘
+    );  // GestureDetector 닫힘
   }
 }

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -99,6 +99,50 @@ class MeetingDetailWidgets {
            lowerMessage.contains('authentication');
   }
   
+  /// QR 출석 섹션 표시 여부 확인
+  /// - 운영진 이상: 항상 표시
+  /// - 일반 사용자: 미출석/불참 상태이고 모임 당일까지만 표시
+  static bool _canShowQrSection(MeetingDetailInfo meeting, bool isStaffOrAbove) {
+    // 운영진 이상은 항상 표시
+    if (isStaffOrAbove) return true;
+    
+    // 이미 출석/지각 상태면 표시 안 함
+    if (meeting.attendanceStatus == 'ATTENDED' || 
+        meeting.attendanceStatus == 'LATE') {
+      return false;
+    }
+    
+    // 모임 당일까지만 표시 (미출석/불참 상태)
+    return _isOnOrBeforeMeetingDay(meeting.meetingDateTime);
+  }
+  
+  /// QR 출석 버튼 표시 여부 확인 (일반 사용자용)
+  /// - 미출석/불참 상태이고 모임 당일까지만 표시
+  static bool _canShowQrScanButton(MeetingDetailInfo meeting) {
+    // 이미 출석/지각 상태면 표시 안 함
+    if (meeting.attendanceStatus == 'ATTENDED' || 
+        meeting.attendanceStatus == 'LATE') {
+      return false;
+    }
+    
+    // 모임 당일까지만 표시
+    return _isOnOrBeforeMeetingDay(meeting.meetingDateTime);
+  }
+  
+  /// 모임 당일 또는 이전인지 확인
+  static bool _isOnOrBeforeMeetingDay(DateTime meetingDateTime) {
+    final now = DateTime.now();
+    final meetingDate = DateTime(
+      meetingDateTime.year,
+      meetingDateTime.month,
+      meetingDateTime.day,
+    );
+    final today = DateTime(now.year, now.month, now.day);
+    
+    // 오늘이 모임 날짜와 같거나 이전이면 true
+    return !today.isAfter(meetingDate);
+  }
+  
   /// 에러 메시지 정리 (불필요한 접두사 제거)
   static String _cleanErrorMessage(String message) {
     return message
@@ -151,9 +195,10 @@ class MeetingDetailWidgets {
           ),
           const SizedBox(height: 16),
 
-          // QR 출석 기능 (조건부 표시 - '진행 전' 상태일 때만)
-          // 참석, 지각, 불참 상태에서는 QR 출석 섹션 숨김
-          if (meeting.attendanceStatus == 'NOT_STARTED') ...[
+          // QR 출석 기능 (조건부 표시)
+          // - 일반 사용자: 미출석/불참 상태이고 모임 당일까지만 표시
+          // - 운영진 이상: 항상 표시 (출석용 QR 표시 버튼 접근 위해)
+          if (_canShowQrSection(meeting, isStaffOrAbove)) ...[
             _buildQrAttendanceCard(
               context,
               meeting,
@@ -848,21 +893,41 @@ class MeetingDetailWidgets {
             ),
             const SizedBox(height: 16),
 
-            // 버튼들 - 🆕 모든 사용자가 출석 가능하도록 수정
-            // 운영진도 일반 모임 상세에서는 출석만 가능 (QR 관리는 운영진용 페이지에서)
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: onQrScanTap,
-                icon: const Icon(Icons.qr_code_scanner),
-                label: const Text('QR로 출석하기'),
-                style: ElevatedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 16),
-                  backgroundColor: context.colors.primary,
-                  foregroundColor: context.colors.onPrimary,
+            // 🆕 QR로 출석하기 버튼 - 미출석/불참 상태이고 모임 당일까지만 표시
+            if (_canShowQrScanButton(meeting)) ...[
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: onQrScanTap,
+                  icon: const Icon(Icons.qr_code_scanner),
+                  label: const Text('QR로 출석하기'),
+                  style: ElevatedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    backgroundColor: context.colors.primary,
+                    foregroundColor: context.colors.onPrimary,
+                  ),
                 ),
               ),
-            ),
+            ],
+            
+            // 🆕 운영진 이상일 때 QR 표시 버튼 (출석 여부와 무관하게 항상 표시)
+            if (isStaffOrAbove && onQrDisplayTap != null) ...[
+              // QR 출석 버튼이 있으면 간격 추가
+              if (_canShowQrScanButton(meeting))
+                const SizedBox(height: 12),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton.icon(
+                  onPressed: onQrDisplayTap,
+                  icon: const Icon(Icons.qr_code_2),
+                  label: const Text('출석용 QR 표시 (운영진용)'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    side: BorderSide(color: context.colors.primary),
+                  ),
+                ),
+              ),
+            ],
           ],
         ),
       ),

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_detail_widgets.dart
@@ -107,8 +107,8 @@ class MeetingDetailWidgets {
     if (isStaffOrAbove) return true;
     
     // 이미 출석/지각 상태면 표시 안 함
-    if (meeting.attendanceStatus == 'ATTENDED' || 
-        meeting.attendanceStatus == 'LATE') {
+    if (meeting.attendanceStatus == 'ATTEND' || 
+        meeting.attendanceStatus == 'ATTEND_LATE') {
       return false;
     }
     
@@ -120,8 +120,8 @@ class MeetingDetailWidgets {
   /// - 미출석/불참 상태이고 모임 당일까지만 표시
   static bool _canShowQrScanButton(MeetingDetailInfo meeting) {
     // 이미 출석/지각 상태면 표시 안 함
-    if (meeting.attendanceStatus == 'ATTENDED' || 
-        meeting.attendanceStatus == 'LATE') {
+    if (meeting.attendanceStatus == 'ATTEND' || 
+        meeting.attendanceStatus == 'ATTEND_LATE') {
       return false;
     }
     

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_list_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_list_widgets.dart
@@ -325,6 +325,7 @@ class MeetingListWidgets {
     BuildContext context, {
     required int totalElements,
     required MeetingListFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -338,10 +339,31 @@ class MeetingListWidgets {
               color: context.colors.onSurface,
             ),
           ),
-          Text(
-            _getFilterSummary(currentFilter),
-            style: context.textStyles.bodySmall?.copyWith(
-              color: context.colors.onSurface.withValues(alpha: 0.7),
+          // 🎯 필터 텍스트를 탭 가능하게 변경
+          InkWell(
+            onTap: onFilterTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _getFilterSummary(currentFilter),
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  if (onFilterTap != null) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.tune,
+                      size: 14,
+                      color: context.colors.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         ],

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_staff_widgets.dart
@@ -121,6 +121,7 @@ class MeetingStaffWidgets {
     BuildContext context, {
     required int totalElements,
     required MeetingListFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -144,10 +145,31 @@ class MeetingStaffWidgets {
               ),
             ],
           ),
-          Text(
-            _getStaffFilterSummary(currentFilter),
-            style: context.textStyles.bodySmall?.copyWith(
-              color: context.colors.onSurface.withOpacity(0.7),
+          // 🎯 필터 텍스트를 탭 가능하게 변경
+          InkWell(
+            onTap: onFilterTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _getStaffFilterSummary(currentFilter),
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withOpacity(0.7),
+                    ),
+                  ),
+                  if (onFilterTap != null) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.tune,
+                      size: 14,
+                      color: context.colors.onSurface.withOpacity(0.7),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         ],

--- a/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
+++ b/geulnamu_frontend/lib/screens/meeting/widgets/meeting_widgets.dart
@@ -509,10 +509,12 @@ class MeetingWidgets {
     BuildContext context, {
     required int totalElements,
     required MeetingListFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) => MeetingStaffWidgets.buildStaffListHeader(
     context,
     totalElements: totalElements,
     currentFilter: currentFilter,
+    onFilterTap: onFilterTap,
   );
 
   static Widget buildStaffFilterBottomSheet(

--- a/geulnamu_frontend/lib/screens/member/member_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/member/member_list_screen.dart
@@ -137,6 +137,7 @@ class _MemberListScreenState extends State<MemberListScreen>
           context,
           totalElements: totalElements,
           currentFilter: currentFilter,
+          onFilterTap: _showFilterBottomSheet,
         ),
         
         // 구분선

--- a/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
+++ b/geulnamu_frontend/lib/screens/member/widgets/member_widgets.dart
@@ -483,6 +483,7 @@ class MemberWidgets {
     BuildContext context, {
     required int totalElements,
     required MemberListFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -497,11 +498,32 @@ class MemberWidgets {
               color: context.colors.onBackground,
             ),
           ),
-          Text(
-            _getFilterSummary(currentFilter),
-            style: context.textStyles.bodySmall?.copyWith(
-              // 🎯 다크모드 대비 강화: onSurfaceVariant 대신 onBackground 사용
-              color: context.colors.onBackground.withOpacity(0.7),
+          // 🎯 필터 텍스트를 탭 가능하게 변경
+          InkWell(
+            onTap: onFilterTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _getFilterSummary(currentFilter),
+                    style: context.textStyles.bodySmall?.copyWith(
+                      // 🎯 다크모드 대비 강화: onSurfaceVariant 대신 onBackground 사용
+                      color: context.colors.onBackground.withOpacity(0.7),
+                    ),
+                  ),
+                  if (onFilterTap != null) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.tune,
+                      size: 14,
+                      color: context.colors.onBackground.withOpacity(0.7),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         ],

--- a/geulnamu_frontend/lib/screens/presentation/presentation_list_screen.dart
+++ b/geulnamu_frontend/lib/screens/presentation/presentation_list_screen.dart
@@ -197,6 +197,7 @@ class _PresentationListScreenState extends State<PresentationListScreen>
           context,
           totalElements: totalElements,
           currentFilter: currentFilter,
+          onFilterTap: _showFilterBottomSheet,
         ),
 
         // 구분선

--- a/geulnamu_frontend/lib/screens/presentation/widgets/presentation_list_widgets.dart
+++ b/geulnamu_frontend/lib/screens/presentation/widgets/presentation_list_widgets.dart
@@ -336,6 +336,7 @@ class PresentationListWidgets {
     BuildContext context, {
     required int totalElements,
     required PresentationListFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -359,10 +360,31 @@ class PresentationListWidgets {
               ),
             ],
           ),
-          Text(
-            _getFilterSummary(currentFilter),
-            style: context.textStyles.bodySmall?.copyWith(
-              color: context.colors.onSurface.withOpacity(0.7),
+          // 🎯 필터 텍스트를 탭 가능하게 변경
+          InkWell(
+            onTap: onFilterTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _getFilterSummary(currentFilter),
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withOpacity(0.7),
+                    ),
+                  ),
+                  if (onFilterTap != null) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.tune,
+                      size: 14,
+                      color: context.colors.onSurface.withOpacity(0.7),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         ],

--- a/geulnamu_frontend/lib/screens/voc_management/voc_management_screen.dart
+++ b/geulnamu_frontend/lib/screens/voc_management/voc_management_screen.dart
@@ -94,8 +94,8 @@ class _VoCManagementScreenState extends State<VoCManagementScreen>
         VoCManagementWidgets.buildListHeader(
           context,
           totalElements: currentResponse!.totalElements,
-          currentPage: currentResponse!.pageNumber,
-          totalPages: currentResponse!.totalPages,
+          currentFilter: currentFilter,
+          onFilterTap: _showFilterBottomSheet,
         ),
 
         // 이슈 목록

--- a/geulnamu_frontend/lib/screens/voc_management/widgets/voc_management_widgets.dart
+++ b/geulnamu_frontend/lib/screens/voc_management/widgets/voc_management_widgets.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../core/theme.dart';
 import '../../../core/responsive.dart';
 import '../../../models/voc/voc_model.dart';
+import '../../../models/voc/voc_filter_model.dart';
 
 /// 문의 목록 화면 UI 위젯들
 ///
@@ -101,8 +102,8 @@ class VoCManagementWidgets {
   static Widget buildListHeader(
     BuildContext context, {
     required int totalElements,
-    required int currentPage,
-    required int totalPages,
+    required VoCFilter currentFilter,
+    VoidCallback? onFilterTap,
   }) {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
@@ -116,15 +117,57 @@ class VoCManagementWidgets {
               color: context.colors.onSurface,
             ),
           ),
-          Text(
-            '$currentPage / $totalPages 페이지',
-            style: context.textStyles.bodySmall?.copyWith(
-              color: context.colors.onSurface.withValues(alpha: 0.7),
+          // 🎯 필터 텍스트를 탭 가능하게 변경
+          InkWell(
+            onTap: onFilterTap,
+            borderRadius: BorderRadius.circular(8),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    _getFilterSummary(currentFilter),
+                    style: context.textStyles.bodySmall?.copyWith(
+                      color: context.colors.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ),
+                  if (onFilterTap != null) ...[
+                    const SizedBox(width: 4),
+                    Icon(
+                      Icons.tune,
+                      size: 14,
+                      color: context.colors.onSurface.withValues(alpha: 0.7),
+                    ),
+                  ],
+                ],
+              ),
             ),
           ),
         ],
       ),
     );
+  }
+
+  /// 필터 요약 텍스트 생성
+  static String _getFilterSummary(VoCFilter filter) {
+    final List<String> filterParts = [];
+
+    // 이슈 유형 필터
+    if (filter.voCType != null) {
+      filterParts.add(filter.voCType!.displayName);
+    }
+
+    // 이슈 상태 필터
+    if (filter.issueStatus != null) {
+      filterParts.add(filter.issueStatus!.displayName);
+    }
+
+    // 정렬 정보
+    final order = filter.isAsc ? '↑' : '↓';
+    filterParts.add('${filter.sortBy.displayName}$order');
+
+    return filterParts.join(' · ');
   }
 
   // ==================== 이슈 목록 ====================

--- a/geulnamu_frontend/lib/services/navigation/pending_navigation_service.dart
+++ b/geulnamu_frontend/lib/services/navigation/pending_navigation_service.dart
@@ -1,0 +1,233 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../core/config/app_config.dart';
+
+/// Pending Navigation 데이터 모델
+class PendingNavigation {
+  final String route;
+  final Map<String, dynamic>? arguments;
+  final DateTime createdAt;
+
+  PendingNavigation({
+    required this.route,
+    this.arguments,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  /// JSON으로 변환
+  Map<String, dynamic> toJson() => {
+        'route': route,
+        'arguments': arguments,
+        'createdAt': createdAt.toIso8601String(),
+      };
+
+  /// JSON에서 생성
+  factory PendingNavigation.fromJson(Map<String, dynamic> json) {
+    return PendingNavigation(
+      route: json['route'] as String,
+      arguments: json['arguments'] as Map<String, dynamic>?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  /// 만료 여부 확인 (기본 5분)
+  bool isExpired({Duration expiration = const Duration(minutes: 5)}) {
+    return DateTime.now().difference(createdAt) > expiration;
+  }
+
+  @override
+  String toString() => 'PendingNavigation(route: $route, arguments: $arguments, createdAt: $createdAt)';
+}
+
+/// Pending Navigation 서비스
+///
+/// 알림 클릭 시 목적지를 저장하고, 로그인 완료 후 해당 페이지로 이동하는 기능을 제공합니다.
+///
+/// 주요 기능:
+/// - 알림 클릭 시 목적지 저장 (SharedPreferences)
+/// - 로그인 완료 후 목적지 조회 및 삭제
+/// - 만료된 pending navigation 자동 정리
+///
+/// 사용 예시:
+/// ```dart
+/// // 알림 클릭 시 저장
+/// await PendingNavigationService().savePendingNavigation(
+///   route: '/discussion-group',
+///   arguments: {'meetingId': 123},
+/// );
+///
+/// // 로그인 완료 후 조회 및 처리
+/// final pending = await PendingNavigationService().getPendingNavigation();
+/// if (pending != null) {
+///   navigatorKey.currentState?.pushNamed(pending.route, arguments: pending.arguments);
+///   await PendingNavigationService().clearPendingNavigation();
+/// }
+/// ```
+class PendingNavigationService {
+  static final PendingNavigationService _instance =
+      PendingNavigationService._internal();
+  factory PendingNavigationService() => _instance;
+  PendingNavigationService._internal();
+
+  static const String _storageKey = 'pending_navigation';
+
+  /// Pending Navigation 저장
+  ///
+  /// [route]: 이동할 라우트 경로 (예: '/discussion-group')
+  /// [arguments]: 라우트에 전달할 인자 (선택)
+  Future<bool> savePendingNavigation({
+    required String route,
+    Map<String, dynamic>? arguments,
+  }) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+
+      final pending = PendingNavigation(
+        route: route,
+        arguments: arguments,
+      );
+
+      final jsonString = jsonEncode(pending.toJson());
+      final result = await prefs.setString(_storageKey, jsonString);
+
+      if (AppConfig.debugMode) {
+        print('📌 [PendingNavigation] 저장 완료: $pending');
+      }
+
+      return result;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [PendingNavigation] 저장 실패: $e');
+      }
+      return false;
+    }
+  }
+
+  /// Pending Navigation 조회
+  ///
+  /// 만료된 경우 null 반환 및 자동 삭제
+  /// [clearExpired]: 만료된 항목 자동 삭제 여부 (기본 true)
+  Future<PendingNavigation?> getPendingNavigation({
+    bool clearExpired = true,
+  }) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = prefs.getString(_storageKey);
+
+      if (jsonString == null || jsonString.isEmpty) {
+        if (AppConfig.debugMode) {
+          print('📭 [PendingNavigation] 저장된 항목 없음');
+        }
+        return null;
+      }
+
+      final json = jsonDecode(jsonString) as Map<String, dynamic>;
+      final pending = PendingNavigation.fromJson(json);
+
+      // 만료 체크
+      if (pending.isExpired()) {
+        if (AppConfig.debugMode) {
+          print('⏰ [PendingNavigation] 만료됨 (생성 시간: ${pending.createdAt})');
+        }
+        if (clearExpired) {
+          await clearPendingNavigation();
+        }
+        return null;
+      }
+
+      if (AppConfig.debugMode) {
+        print('📬 [PendingNavigation] 조회 성공: $pending');
+      }
+
+      return pending;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [PendingNavigation] 조회 실패: $e');
+      }
+      // 파싱 오류 시 데이터 삭제
+      await clearPendingNavigation();
+      return null;
+    }
+  }
+
+  /// Pending Navigation 삭제
+  Future<bool> clearPendingNavigation() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final result = await prefs.remove(_storageKey);
+
+      if (AppConfig.debugMode) {
+        print('🗑️ [PendingNavigation] 삭제 완료');
+      }
+
+      return result;
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [PendingNavigation] 삭제 실패: $e');
+      }
+      return false;
+    }
+  }
+
+  /// Pending Navigation 존재 여부 확인 (만료 포함)
+  Future<bool> hasPendingNavigation() async {
+    final pending = await getPendingNavigation(clearExpired: true);
+    return pending != null;
+  }
+
+  /// URL 문자열로 Pending Navigation 저장 (FCM에서 사용)
+  ///
+  /// URL 형식: '/discussion-group?meetingId=123&meetingTitle=테스트'
+  Future<bool> savePendingNavigationFromUrl(String url) async {
+    try {
+      final uri = Uri.parse(url);
+      final route = uri.path;
+      
+      // 쿼리 파라미터를 arguments로 변환
+      Map<String, dynamic>? arguments;
+      if (uri.queryParameters.isNotEmpty) {
+        arguments = Map<String, dynamic>.from(uri.queryParameters);
+        
+        // meetingId는 int로 변환
+        if (arguments.containsKey('meetingId')) {
+          arguments['meetingId'] = int.tryParse(arguments['meetingId'] ?? '') ?? arguments['meetingId'];
+        }
+      }
+
+      return await savePendingNavigation(
+        route: route,
+        arguments: arguments,
+      );
+    } catch (e) {
+      if (AppConfig.debugMode) {
+        print('❌ [PendingNavigation] URL 파싱 실패: $e');
+      }
+      return false;
+    }
+  }
+
+  /// 디버그용: 현재 저장된 데이터 출력
+  Future<void> debugPrintStatus() async {
+    if (!AppConfig.debugMode) return;
+
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final jsonString = prefs.getString(_storageKey);
+
+      print('📊 [PendingNavigation] === 현재 상태 ===');
+      print('📊 저장된 데이터: $jsonString');
+
+      if (jsonString != null && jsonString.isNotEmpty) {
+        final json = jsonDecode(jsonString) as Map<String, dynamic>;
+        final pending = PendingNavigation.fromJson(json);
+        print('📊 route: ${pending.route}');
+        print('📊 arguments: ${pending.arguments}');
+        print('📊 createdAt: ${pending.createdAt}');
+        print('📊 만료 여부: ${pending.isExpired()}');
+      }
+      print('📊 ============================');
+    } catch (e) {
+      print('❌ [PendingNavigation] 상태 출력 실패: $e');
+    }
+  }
+}

--- a/geulnamu_frontend/lib/services/notification/fcm_service.dart
+++ b/geulnamu_frontend/lib/services/notification/fcm_service.dart
@@ -11,6 +11,7 @@ import '../../core/utils/api_utils.dart';
 import '../../core/services/auth_service.dart';
 import '../../models/fcm/fcm_send_result.dart';
 import '../../main.dart' show navigatorKey;
+import '../navigation/pending_navigation_service.dart';
 
 /// FCM 푸시 알림 서비스
 ///
@@ -28,6 +29,7 @@ class FcmService {
   final FirebaseMessaging _messaging = FirebaseMessaging.instance;
   final Dio _dio = Dio();
   final AuthService _authService = AuthService();
+  final PendingNavigationService _pendingNavigationService = PendingNavigationService();
 
   String? _currentToken;
   String? get currentToken => _currentToken;
@@ -214,7 +216,7 @@ class FcmService {
   }
 
   /// Service Worker 알림 클릭 처리
-  void _handleServiceWorkerNotificationClick(Map<String, dynamic> message) {
+  void _handleServiceWorkerNotificationClick(Map<String, dynamic> message) async {
     if (AppConfig.debugMode) {
       print('📩 [FCM] Service Worker 알림 클릭 수신!');
       print('📩 [FCM] 메시지 전체: $message');
@@ -228,24 +230,93 @@ class FcmService {
       print('📩 [FCM] data: $notificationData');
     }
 
+    // 🔐 로그인 상태 확인
+    final isLoggedIn = await _authService.isLoggedIn();
+    
+    if (AppConfig.debugMode) {
+      print('🔐 [FCM] 로그인 상태: ${isLoggedIn ? '로그인됨' : '비로그인'}');
+    }
+
     if (url != null && url.isNotEmpty) {
-      if (AppConfig.debugMode) {
-        print('🚀 [FCM] URL로 이동 시도: $url');
+      if (isLoggedIn) {
+        if (AppConfig.debugMode) {
+          print('🚀 [FCM] 로그인 상태 - URL로 바로 이동: $url');
+        }
+        _navigateToUrl(url);
+      } else {
+        if (AppConfig.debugMode) {
+          print('📌 [FCM] 비로그인 상태 - Pending Navigation 저장: $url');
+        }
+        await _pendingNavigationService.savePendingNavigationFromUrl(url);
+        // 홈화면으로 이동 (로그인 유도)
+        _navigateToUrl('/home');
       }
-      _navigateToUrl(url);
     } else if (notificationData != null) {
       final data = notificationData is Map 
           ? Map<String, dynamic>.from(notificationData)
           : <String, dynamic>{};
-      if (AppConfig.debugMode) {
-        print('🚀 [FCM] data로 이동 시도: $data');
+      
+      if (isLoggedIn) {
+        if (AppConfig.debugMode) {
+          print('🚀 [FCM] 로그인 상태 - data로 바로 이동: $data');
+        }
+        _navigateByNotificationData(data);
+      } else {
+        if (AppConfig.debugMode) {
+          print('📌 [FCM] 비로그인 상태 - Pending Navigation 저장 (data): $data');
+        }
+        await _savePendingNavigationFromData(data);
+        // 홈화면으로 이동 (로그인 유도)
+        _navigateToUrl('/home');
       }
-      _navigateByNotificationData(data);
     } else {
       if (AppConfig.debugMode) {
         print('⚠️ [FCM] 이동할 URL이나 data가 없음!');
       }
     }
+  }
+
+  /// 알림 data를 기반으로 Pending Navigation 저장
+  Future<void> _savePendingNavigationFromData(Map<String, dynamic> data) async {
+    final type = data['type'] as String?;
+    final meetingIdStr = data['meetingId'] as String?;
+    final meetingTitle = data['meetingTitle'] as String?;
+
+    String route;
+    Map<String, dynamic>? arguments;
+
+    switch (type) {
+      case typeDiscussionGroup:
+        route = '/discussion-group';
+        break;
+      case 'ATTENDANCE':
+        route = '/attendance/status';
+        break;
+      default:
+        // 기본값: 토론 조 화면
+        if (meetingIdStr != null && meetingIdStr.isNotEmpty) {
+          route = '/discussion-group';
+        } else if (data.containsKey('route')) {
+          route = data['route'] as String? ?? '/home';
+        } else {
+          route = '/home';
+        }
+    }
+
+    if (meetingIdStr != null && meetingIdStr.isNotEmpty) {
+      final meetingId = int.tryParse(meetingIdStr);
+      if (meetingId != null) {
+        arguments = {
+          'meetingId': meetingId,
+          if (meetingTitle != null) 'meetingTitle': meetingTitle,
+        };
+      }
+    }
+
+    await _pendingNavigationService.savePendingNavigation(
+      route: route,
+      arguments: arguments,
+    );
   }
 
   /// URL로 화면 이동

--- a/geulnamu_frontend/lib/widgets/dialogs/add_members_dialog.dart
+++ b/geulnamu_frontend/lib/widgets/dialogs/add_members_dialog.dart
@@ -67,9 +67,24 @@ class _AddMembersDialogState extends State<AddMembersDialog> {
 
   @override
   Widget build(BuildContext context) {
+    // 🎯 화면 크기 기반 동적 사이즈 계산
+    final screenHeight = MediaQuery.of(context).size.height;
+    final screenWidth = MediaQuery.of(context).size.width;
+
+    // 높이: 화면의 75%, 최소 350px, 최대 600px
+    final dialogHeight = (screenHeight * 0.75).clamp(350.0, 600.0);
+
+    // 너비: 모바일(600px 미만)에서는 화면의 90%, 그 외에는 400px 고정
+    final dialogWidth = screenWidth < 600 ? screenWidth * 0.9 : 400.0;
+
     return AlertDialog(
       backgroundColor: Theme.of(context).colorScheme.surface,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      // 🎯 다이얼로그 여백 조정 (모바일에서 더 넓게 표시)
+      insetPadding: EdgeInsets.symmetric(
+        horizontal: screenWidth < 600 ? 16 : 40,
+        vertical: 24,
+      ),
       title: Row(
         children: [
           Icon(
@@ -78,18 +93,20 @@ class _AddMembersDialogState extends State<AddMembersDialog> {
             size: 24,
           ),
           const SizedBox(width: 8),
-          Text(
-            '토론 인원 추가',
-            style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              fontWeight: FontWeight.bold,
-              color: Theme.of(context).colorScheme.onSurface,
+          Expanded(
+            child: Text(
+              '토론 인원 추가',
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
             ),
           ),
         ],
       ),
       content: SizedBox(
-        width: double.maxFinite,
-        height: 400, // 고정 높이
+        width: dialogWidth,
+        height: dialogHeight - 140, // title과 actions 영역 고려
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -148,10 +165,14 @@ class _AddMembersDialogState extends State<AddMembersDialog> {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(),
+          style: TextButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+          ),
           child: Text(
             '닫기',
             style: TextStyle(
               color: Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+              fontWeight: FontWeight.w600,
             ),
           ),
         ),

--- a/geulnamu_frontend/pubspec.lock
+++ b/geulnamu_frontend/pubspec.lock
@@ -875,7 +875,7 @@ packages:
     source: hosted
     version: "15.0.0"
   web:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"

--- a/geulnamu_frontend/pubspec.yaml
+++ b/geulnamu_frontend/pubspec.yaml
@@ -2,7 +2,7 @@ name: geulnamu_frontend
 description: "글나무 - 독서 토론 모임 관리 서비스. 모임 출석, 발제문 작성, 토론 참여를 간편하게 관리하는 앱입니다."
 publish_to: "none"
 
-version: 1.0.0+48
+version: 1.0.0+49
 
 environment:
   sdk: ^3.8.1

--- a/geulnamu_frontend/pubspec.yaml
+++ b/geulnamu_frontend/pubspec.yaml
@@ -52,6 +52,9 @@ dependencies:
   firebase_core: ^4.2.1
   firebase_messaging: ^16.0.4
 
+  # Web support
+  web: ^1.1.0 # 웹 환경에서 파일 다운로드 등에 사용
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
# 변경 내역
## 프론트엔드
### 앱 푸시 관련
- 앱 종료된 상태에서도 알림을 받은 경우, 터치 시 로그인 후 자동으로 기존 이동하려던 페이지로 이동
### 로그인 관련
- 로그인이 필요한 기능의 경우, 다시 시도 외에, 로그인하기 버튼 추가
### 모임 상세 페이지
- 모임 당일까지는 QR 출석 버튼 보이도록 수정
- 운영진의 경우, QR 표시 버튼 추가
### 운영진용 모임 상세 페이지
- 토론 관련 항목 UI, 모바일 환경에 맞게 최적화 (입력창 검정 패딩 문제도 삭제)
- 토론 시간 설정 시, 현재 시간은 설정하지 못하도록 제한
- 모임 삭제 시, 모임 목록 페이지로 이동하도록 수정
### 출석 현황 페이지
- 토론 희망자 인원 수 표시
- 참석자 및 토론 희망자 명단 복사 기능 추가 (관리자용 기능)
### 문의 목록 페이지
- 앱바 하단에서 페이지 정보 대신에 목록 필터링 정보가 보이도록 수정
### 목록 페이지 공통
- 목록 필터링 정보 클릭 시, FAB 필터창이 나오도록 수정
### QR 출석 관련
- QR 이미지로 다운 받을 수 있도록 기능 추가
### 기타
- 빌드 버전 업

## 백엔드
### 모임별 출석 현황 API 관련
- 응답값 추가: `wantDiscussionCount`, `memberId`, `wantDiscussion`