### PR TITLE
[Feat/BE] 캐싱 기능 추가 (with. Redis)

### DIFF
--- a/geulnamu_backend/build.gradle
+++ b/geulnamu_backend/build.gradle
@@ -72,6 +72,10 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 	// Firebase Admin SDK
 	implementation ('com.google.firebase:firebase-admin:9.2.0') {
 		exclude group: 'commons-logging', module: 'commons-logging'

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/AttendanceInfoResponse.java
@@ -20,15 +20,15 @@ public class AttendanceInfoResponse {
     private MeetingType meetingType;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime meetingDateTime;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime lateThresholdTime;
     private String meetingName;
     private String meetingPlace;
     private String description;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime attendTime;
     private String note;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime discussionTime;
     private DiscussionGroup discussionGroup;
     private List<AttendanceIdAndNameResponse> groupMemberList;

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/attendance/dto/response/MeetingAttendanceSummaryResponse.java
@@ -11,7 +11,7 @@ import java.time.LocalDateTime;
 public class MeetingAttendanceSummaryResponse {
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime meetingDate;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime lateThresholdTime;
     private Long totalAttendCount;
     private Long attendCount;

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingDetailResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingDetailResponse.java
@@ -6,11 +6,13 @@ import com.geulnamu.domain.attendance.DiscussionGroup;
 import com.geulnamu.domain.meeting.MeetingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor  // Redis 역직렬화용 기본 생성자
 @AllArgsConstructor
 public class MeetingDetailResponse {
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingInfoResponse.java
@@ -4,10 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.geulnamu.domain.meeting.MeetingType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@NoArgsConstructor  // Redis 역직렬화용 기본 생성자
 @AllArgsConstructor
 public class MeetingInfoResponse {
 
@@ -20,7 +22,7 @@ public class MeetingInfoResponse {
     private LocalDateTime meetingDateTime;
     private String meetingPlace;
     private String attendanceStatus;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd HH:mm")
     private LocalDateTime discussionTime;
     private Boolean isPrivate;
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingListResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/meeting/dto/response/MeetingListResponse.java
@@ -3,10 +3,12 @@ package com.geulnamu.controller.meeting.dto.response;
 import com.geulnamu.infrastructure.response.paging.PagingResponse;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor  // Redis 역직렬화용 기본 생성자
 @AllArgsConstructor
 public class MeetingListResponse {
     private PagingResponse pagingResponse;

--- a/geulnamu_backend/src/main/java/com/geulnamu/controller/shared/dto/response/AttendanceIdAndNameResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/controller/shared/dto/response/AttendanceIdAndNameResponse.java
@@ -2,8 +2,10 @@ package com.geulnamu.controller.shared.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor  // Redis 역직렬화용 기본 생성자
 @AllArgsConstructor
 public class AttendanceIdAndNameResponse {
     private Long attendanceId;

--- a/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/config/redis/CacheConfig.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/config/redis/CacheConfig.java
@@ -1,0 +1,61 @@
+package com.geulnamu.infrastructure.config.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+//@Configuration
+//@EnableCaching
+public class CacheConfig {
+
+    /**
+     * Redis 기반 CacheManager 설정
+     */
+    @Bean
+    @Profile("prod")  // prod 환경에서만 활성화
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        // ObjectMapper 설정
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+
+        // 다형성 타입 검증 (보안)
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
+            .builder()
+            .allowIfBaseType(Object.class)
+            .build();
+        objectMapper.activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL);
+
+        // Redis 캐시 기본 설정
+        RedisCacheConfiguration cacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofMinutes(5)) // 기본 TTL 5분
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new StringRedisSerializer()
+                )
+            )
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(
+                    new GenericJackson2JsonRedisSerializer(objectMapper)
+                )
+            )
+            .disableCachingNullValues(); // null 값 캐싱 안 함
+
+        return RedisCacheManager.builder(connectionFactory)
+            .cacheDefaults(cacheConfig)
+            .build();
+    }
+}

--- a/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/response/paging/PagingResponse.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/infrastructure/response/paging/PagingResponse.java
@@ -3,10 +3,12 @@ package com.geulnamu.infrastructure.response.paging;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 @Builder
 @Getter
+@NoArgsConstructor  // Redis 역직렬화용 기본 생성자
 @AllArgsConstructor
 public class PagingResponse {
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -17,6 +17,7 @@ import com.geulnamu.repository.meeting.MeetingQueryRepository;
 import com.geulnamu.repository.meeting.MeetingCommandRepository;
 import com.geulnamu.repository.member.MemberQueryRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,6 +50,19 @@ public class MeetingService {
         return meetingQueryRepository.findStaffList();
     }
 
+    @Cacheable(
+        value = "meeting:list",
+        key = "(#request.meetingType ?: 'ALL') + ':' + " +
+            "(#request.isTodayMeeting ?: 'ALL') + ':' + " +
+            "(#request.attendanceStatus ?: 'ALL') + ':' + " +
+            "(#request.isPrivate ?: 'ALL') + ':' + " +
+            "(#request.sortBy ?: 'id') + ':' + " +
+            "(#request.isAsc ?: 'true') + ':' + " +
+            "'page=' + #request.page + ':' + " +
+            "'size=' + #request.size + ':' + " +
+            "'member=' + #myMemberId",
+        unless = "#result == null || #result.meetingList.isEmpty()"
+    )
     @Transactional(readOnly = true)
     public MeetingListResponse getMeetingList(Long myMemberId, MeetingListRequest request) {
         Page<MeetingInfoResponse> meetingDslList = meetingQueryRepository.findMeetingsWithPaging(request, myMemberId);
@@ -58,13 +72,12 @@ public class MeetingService {
         return new MeetingListResponse(pagingResponse, meetingList);
     }
 
-    @Transactional(readOnly = true)
-    public MeetingDetailResponse getMeeting_original(Long meetingId, Long memberId) {
-        Meeting meeting = findMeetingOrThrow(meetingId);
-        return meetingQueryRepository.findMeeting(meeting.getId(), memberId);
-    }
-
     // TODO: 추후 쿼리 하나로 다 뽑아내도록 개선할 것!
+    @Cacheable(
+        value = "meeting:detail",
+        key = "#meetingId + ':' + #memberId",
+        unless = "#result == null"
+    )
     @Transactional(readOnly = true)
     public MeetingDetailResponse getMeeting(Long meetingId, Long memberId) {
         Meeting meeting = findMeetingOrThrow(meetingId);

--- a/geulnamu_backend/src/main/resources/application-local.yml
+++ b/geulnamu_backend/src/main/resources/application-local.yml
@@ -1,4 +1,10 @@
 spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
+  cache:
+    type: none
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}

--- a/geulnamu_backend/src/main/resources/application-prod.yml
+++ b/geulnamu_backend/src/main/resources/application-prod.yml
@@ -1,4 +1,20 @@
 spring:
+#  cache:
+#    type: redis
+#    redis:
+#      time-to-live: 300000 # 5분 (밀리초)
+#      cache-null-values: false # null 값 캐싱 안 함
+#  data:
+#    redis:
+#      host: localhost
+#      port: 6379
+#      timeout: 3000ms
+#      lettuce:
+#        pool:
+#          max-active: 10  # 최대 커넥션 수
+#          max-idle: 10    # 최대 idle 커넥션
+#          min-idle: 2     # 최소 idle 커넥션
+#          max-wait: -1ms  # 커넥션 대기 시간 (-1은 무제한)
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME}
@@ -16,6 +32,7 @@ spring:
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: validate
+
 server:
   forward-headers-strategy: framework
   compression:
@@ -31,11 +48,14 @@ server:
       charset: UTF-8
       enabled: true
       force: true
+
 logging:
   level:
     root: WARN
     com.geulnamu: INFO
     org.hibernate.SQL: WARN
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
+    org.springframework.cache: DEBUG
+    org.springframework.data.redis: DEBUG
 debug:
   mode: false

--- a/geulnamu_backend/src/main/resources/static/docs/attendance-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/attendance-api-guide.html
@@ -740,13 +740,13 @@ Content-Type: application/json;charset=UTF-8
     "meetingId" : 1,
     "meetingType" : "REGULAR",
     "meetingDateTime" : "2126.06.14 10:30",
-    "lateThresholdTime" : "10:45",
+    "lateThresholdTime" : "2126.06.14 10:45",
     "meetingName" : "1000회 정기모임",
     "meetingPlace" : "합정 저스티나",
     "description" : "조심히 오세요~",
-    "attendTime" : "10:00",
+    "attendTime" : "2126.06.14 10:00",
     "note" : "1등으로 왔지롱~",
-    "discussionTime" : "12:00",
+    "discussionTime" : "2126.06.14 12:00",
     "discussionGroup" : "A",
     "groupMemberList" : [ {
       "attendanceId" : 1,
@@ -995,7 +995,7 @@ Content-Type: application/json;charset=UTF-8
   "data" : {
     "meetingAttendanceSummaryResponse" : {
       "meetingDate" : "2025.05.31 10:30",
-      "lateThresholdTime" : "10:45",
+      "lateThresholdTime" : "2025.05.31 10:45",
       "totalAttendCount" : 3,
       "attendCount" : 2,
       "lateAttendCount" : 1,

--- a/geulnamu_backend/src/main/resources/static/docs/fcm-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/fcm-api-guide.html
@@ -731,8 +731,8 @@ Content-Type: application/json;charset=UTF-8
   "data" : {
     "successCount" : 2,
     "failureCount" : 0,
-    "allFailed" : false,
-    "allSuccess" : true
+    "allSuccess" : true,
+    "allFailed" : false
   }
 }</code></pre>
 </div>
@@ -814,7 +814,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-12-23 18:56:17 +0900
+Last updated 2025-12-24 14:44:36 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu_backend/src/main/resources/static/docs/health-check-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/health-check-api-guide.html
@@ -552,7 +552,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-12-23 15:58:26 +0900
+Last updated 2025-12-24 14:44:36 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu_backend/src/main/resources/static/docs/index.html
+++ b/geulnamu_backend/src/main/resources/static/docs/index.html
@@ -996,7 +996,7 @@ User-Agent: GeulnamuApp/1.0</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-12-24 02:40:32 +0900
+Last updated 2025-12-24 14:44:36 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/login-api-guide.html
@@ -535,7 +535,7 @@ Host: docs.api.com
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Sun, 21 Jun 2026 18:10:30 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code; Path=/; Max-Age=15552000; Expires=Mon, 22 Jun 2026 14:52:09 GMT; Secure; HttpOnly
 
 {
   "code" : 200,
@@ -700,7 +700,7 @@ Content-Type: application/x-www-form-urlencoded</code></pre>
 <div class="content">
 <pre class="highlightjs highlight"><code class="language-http hljs" data-lang="http">HTTP/2.0 200 OK
 Content-Type: application/json;charset=UTF-8
-Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Sun, 21 Jun 2026 18:10:30 GMT; Secure; HttpOnly
+Set-Cookie: refreshToken=random_refreshToken_code_2; Path=/; Max-Age=15552000; Expires=Mon, 22 Jun 2026 14:52:09 GMT; Secure; HttpOnly
 
 {
   "code" : 200,

--- a/geulnamu_backend/src/main/resources/static/docs/meeting-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/meeting-api-guide.html
@@ -956,7 +956,7 @@ Content-Type: application/json;charset=UTF-8
       "meetingDateTime" : "2025.05.31 10:30",
       "meetingPlace" : "합정 빌리프커피로스터리스",
       "attendanceStatus" : "~~",
-      "discussionTime" : "12:00",
+      "discussionTime" : "2025.05.31 12:00",
       "isPrivate" : false
     }, {
       "meetingId" : 2,
@@ -967,7 +967,7 @@ Content-Type: application/json;charset=UTF-8
       "meetingDateTime" : "2025.06.03 18:30",
       "meetingPlace" : "합정 저스티나",
       "attendanceStatus" : "~~",
-      "discussionTime" : "12:31",
+      "discussionTime" : "2025.05.01 12:31",
       "isPrivate" : true
     } ]
   }

--- a/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
+++ b/geulnamu_backend/src/main/resources/static/docs/member-api-guide.html
@@ -2258,7 +2258,7 @@ Content-Type: application/json;charset=UTF-8
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2025-12-23 17:16:26 +0900
+Last updated 2025-12-24 14:44:36 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
+++ b/geulnamu_frontend/lib/models/attendance/attendance_status_model.dart
@@ -73,18 +73,31 @@ class AttendanceSummary {
     }
   }
 
-  /// HH:mm 형식의 시간을 meetingDate와 결합하여 DateTime으로 변환 (null 안전)
+  /// HH:mm 또는 yyyy.MM.dd HH:mm 형식의 시간을 DateTime으로 변환 (null 안전)
   static DateTime _parseTimeAsDateTime(String? timeStr, String? dateStr) {
     if (timeStr == null || dateStr == null) {
       return DateTime.now(); // null인 경우 현재 시간 반환
     }
     
     try {
-      // dateStr: "yyyy.MM.dd HH:mm" -> yyyy-MM-dd 추출
-      final datePart = dateStr.split(' ')[0].replaceAll('.', '-');
-      // timeStr: "HH:mm"
-      final fullDateTimeStr = '${datePart}T$timeStr:00';
-      return DateTime.parse(fullDateTimeStr);
+      // 🆕 백엔드 새 날짜 형식: "yyyy.MM.dd HH:mm" 처리
+      if (timeStr.contains('.') && timeStr.contains(' ')) {
+        // "yyyy.MM.dd HH:mm" -> "yyyy-MM-ddTHH:mm:00"
+        final formatted = timeStr.replaceAll('.', '-').replaceAll(' ', 'T') + ':00';
+        return DateTime.parse(formatted);
+      }
+      
+      // 🔧 시간만 오는 경우 ("HH:mm") - 하위 호환성 유지
+      if (timeStr.contains(':') && !timeStr.contains(' ')) {
+        // dateStr: "yyyy.MM.dd HH:mm" -> yyyy-MM-dd 추출
+        final datePart = dateStr.split(' ')[0].replaceAll('.', '-');
+        // timeStr: "HH:mm"
+        final fullDateTimeStr = '${datePart}T$timeStr:00';
+        return DateTime.parse(fullDateTimeStr);
+      }
+      
+      // 표준 ISO 형식인 경우
+      return DateTime.parse(timeStr);
     } catch (e) {
       return DateTime.now(); // 파싱 실패 시 현재 시간 반환
     }

--- a/geulnamu_frontend/lib/models/meeting/meeting_model.dart
+++ b/geulnamu_frontend/lib/models/meeting/meeting_model.dart
@@ -242,17 +242,22 @@ class MeetingInfo {
 
     try {
       if (timeValue is String) {
-        // 시간만 오는 경우 ("11:13", "12:34")
+        // 🆕 백엔드 새 날짜 형식: "2025.06.26 11:12" 처리
+        if (timeValue.contains('.') && timeValue.contains(' ')) {
+          // "2025.06.26 11:12" -> "2025-06-26 11:12:00"
+          final formatted = '${timeValue.replaceAll('.', '-').trim()}:00';
+          return DateTime.parse(formatted);
+        }
+
+        // 🔧 시간만 오는 경우 ("11:13", "12:34") - 하위 호환성 유지
         if (timeValue.contains(':') && !timeValue.contains(' ')) {
-          // 모임일시에서 날짜 부분 추출
           final meetingDateTime = _parseDateTimeSafely(dateValue, '모임일시');
           final dateStr = DateFormat('yyyy-MM-dd').format(meetingDateTime);
-          final fullTimeStr = '$dateStr $timeValue:00'; // 초 추가
-
+          final fullTimeStr = '$dateStr $timeValue:00';
           return DateTime.parse(fullTimeStr);
         }
 
-        // 전체 날짜 시간 문자열인 경우
+        // 표준 ISO 형식인 경우
         return DateTime.parse(timeValue);
       }
 


### PR DESCRIPTION
# 변경 내역
## 백엔드
### 캐싱 기능 추가
- 사용이 많이 되는 API 캐싱 어노테이션(`cacheable`)적용
- `CacheConfig`클래스 파일 생성 (`prod` profile 전용)
- API 응답값 json 시간 포맷 변경 (redis 저장값 역직렬화를 위한 셋팅): `HH:mm` -> `yyyy.MM.dd HH:mm`
  - `AttendanceInfoResponse`: `lateThresholdTime`, `attendTime`, `discussionTime`
  - `MeetingAttendanceSummaryResponse` - `lateThresholdTime`
  - `MeetingInfoResponse` - `discussionTime`
-  (클라우드 서버 Redis 구축 완료)
## 프론트엔드
- 변경된 json 시간 포맷 대응 로직 설정