### PR TITLE
[Feat/BE] 캐싱 전략 수정 - 데이터 수정이 있을 경우, 캐싱 데이터 삭제 기능 추가

### DIFF
--- a/geulnamu_backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/attendance/AttendanceService.java
@@ -19,6 +19,7 @@ import com.geulnamu.repository.attendance.AttendanceQueryRepository;
 import com.geulnamu.repository.meeting.MeetingQueryRepository;
 import com.geulnamu.repository.member.MemberQueryRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,10 @@ public class AttendanceService {
 
 
     // TODO: 추후 lock을 걸지 고민해 볼 것
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public Long createAttendanceByQR(Long memberId, Long meetingId, String fcmToken) {
         Member member =  memberQueryRepository.findById(memberId)
@@ -90,12 +95,20 @@ public class AttendanceService {
         return convertToDiscussionGroupResponse(memberAttendanceInfoWithGroupList);
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void writeNote(Long attendanceId, Long memberId, String note) {
         Attendance attendance = getValidateAttendance(attendanceId, memberId);
         attendance.updateNote(note);
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void notWantDiscussion(Long attendanceId, Long memberId) {
         Attendance attendance = getValidateAttendance(attendanceId, memberId);
@@ -107,6 +120,10 @@ public class AttendanceService {
         attendance.updateNotWantDiscussion();
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void wantDiscussion(Long attendanceId, Long memberId) {
         Attendance attendance = getValidateAttendance(attendanceId, memberId);
@@ -118,6 +135,10 @@ public class AttendanceService {
         attendance.updateWantDiscussion();
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void manuallyAssignDiscussionGroups(Long meetingId, AssignDiscussionGroupsRequest request) {
         meetingQueryRepository.findById(meetingId).orElseThrow(() -> new NotFoundDataException(DomainType.MEETING.getDescription()));
@@ -128,6 +149,10 @@ public class AttendanceService {
         assignGroupsToMembers(request, meetingId); // 토론 그룹 할당
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void assignMemberToDiscussionGroup(Long meetingId, Long attendanceId, Integer optimizedGroupNumber) {
         meetingQueryRepository.findById(meetingId).orElseThrow(() -> new NotFoundDataException(DomainType.MEETING.getDescription()));
@@ -137,6 +162,10 @@ public class AttendanceService {
         attendance.updateDiscussionGroup(DiscussionGroup.values()[optimizedGroupNumber]);
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void deleteAttendance(Long attendanceId) {
         Attendance attendance = attendanceQueryRepository.findById(attendanceId)

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/login/LoginFacade.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/login/LoginFacade.java
@@ -17,6 +17,7 @@ import com.geulnamu.repository.member.MemberQueryRepository;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -88,6 +89,10 @@ public class LoginFacade {
     /**
      * 로그아웃 플로우
      */
+    @CacheEvict(
+        value = "member:infoRegisterStatus",
+        key = "#memberId"
+    )
     @Transactional(rollbackFor = Exception.class)
     public void logout(Long memberId, HttpServletResponse response) {
         // 1. 멤버 조회

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -17,6 +17,7 @@ import com.geulnamu.repository.meeting.MeetingQueryRepository;
 import com.geulnamu.repository.meeting.MeetingCommandRepository;
 import com.geulnamu.repository.member.MemberQueryRepository;
 import lombok.AllArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
@@ -96,6 +97,10 @@ public class MeetingService {
         return MeetingDetailResponseForStaff.of(meeting);
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void updateMeeting(Long meetingId, Long memberId, Role role, MeetingUpdateRequest request){
         // 모임 정보 수정 가능 권한 검사
@@ -120,6 +125,10 @@ public class MeetingService {
         if(request.getDescription() != null) meeting.updateMeetingDescription(request.getDescription());
     }
 
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void updateMeetingForDiscussion(Long meetingId, Long memberId, Role role, MeetingGroupUpdateRequest request) {
         // 모임 정보 수정 가능 권한 검사
@@ -155,6 +164,10 @@ public class MeetingService {
     }
 
     // 모임 시작 6시간 전까지만 삭제 가능
+    @CacheEvict(
+        value = {"meeting:detail", "meeting:list"},
+        allEntries = true
+    )
     @Transactional(rollbackFor = Exception.class)
     public void removeMeeting(Long meetingId, Long memberId, Role role) {
         // 모임 삭제 가능 여부 검사

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/member/MemberService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/member/MemberService.java
@@ -13,6 +13,8 @@ import com.geulnamu.infrastructure.exception.NotFoundDataException;
 import com.geulnamu.repository.member.MemberQueryRepository;
 import com.geulnamu.repository.member.MemberCommandRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,6 +35,11 @@ public class MemberService {
         memberCommandRepository.save(member);
     }
 
+    @Cacheable(
+        value = "member:infoRegisterStatus",
+        key = "#memberId",
+        unless = "#result == false"
+    )
     @Transactional(readOnly = true)
     public Boolean isMemberInfoRegistered(Long memberId) {
         Member member = findMemberOrThrow(memberId);
@@ -76,6 +83,10 @@ public class MemberService {
         member.updatePushSetting(pushEnabled);
     }
 
+    @CacheEvict(
+        value = "member:infoRegisterStatus",
+        key = "#memberId"
+    )
     @Transactional(rollbackFor = Exception.class)
     public void updateMemberRole(Long memberId, Role targetRole) {
         Member member = findMemberOrThrow(memberId);
@@ -95,6 +106,10 @@ public class MemberService {
         member.activate();
     }
 
+    @CacheEvict(
+        value = "member:infoRegisterStatus",
+        key = "#memberId"
+    )
     @Transactional(rollbackFor = Exception.class)
     public void deactivateMember(Long memberId) {
         Member member = findMemberOrThrow(memberId);


### PR DESCRIPTION
# 변경 내역
## 캐싱 대상 API 추가
- 개인정보 등록 여부 확인 API
## 캐싱 전략 수정
- 캐싱하는 데이터에 대해서 수정이 있는 메서드가 진행될 경우, 기존 저장했던 캐싱 데이터 삭제 기능 추가
  - CacheEvict 어노테이션 사용 (단점, 변경이 있는 데이터 뿐 아니라, 변경 없는 캐싱 데이터도 같이 삭제됨)