### PR TITLE
[Feat/BE] 성능 개선 - N+1 이슈 개선

### DIFF
--- a/geulnamu_backend/build.gradle
+++ b/geulnamu_backend/build.gradle
@@ -78,12 +78,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 
 	// Firebase Admin SDK
-	implementation ('com.google.firebase:firebase-admin:9.2.0') {
+	implementation ('com.google.firebase:firebase-admin:9.4.3') {
 		exclude group: 'commons-logging', module: 'commons-logging'
 		exclude group: 'io.grpc', module: 'grpc-xds'
 		exclude group: 'io.grpc', module: 'grpc-services'
-		exclude group: 'io.opencensus', module: 'opencensus-api'
-		exclude group: 'io.opencensus', module: 'opencensus-contrib-http-util'
 	}
 }
 

--- a/geulnamu_backend/src/main/java/com/geulnamu/repository/fcm/FcmQueryRepository.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/repository/fcm/FcmQueryRepository.java
@@ -3,12 +3,19 @@ package com.geulnamu.repository.fcm;
 import com.geulnamu.domain.fcm.FcmToken;
 import com.geulnamu.domain.member.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FcmQueryRepository extends JpaRepository<FcmToken, Long> {
     Optional<FcmToken> findByMemberAndDeviceType(Member member, String deviceType);
-    List<FcmToken> findByMemberIdIn(List<Long> memberIds);
-    Optional<FcmToken> findByMember(Member member);
+
+    @Query(value = "SELECT ft.token " +
+        "FROM fcm_tokens ft " +
+        "JOIN ft.member m " +
+        "WHERE m.id IN :memberIds " +
+        "AND m.pushEnabled = true")
+    List<String> findEnabledTokensByMemberIds(@Param("memberIds") List<Long> memberIds);
 }

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/fcm/FcmService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/fcm/FcmService.java
@@ -46,13 +46,8 @@ public class FcmService {
     }
 
     @Transactional(rollbackFor = Exception.class)
-    public FcmSendResult sendNotification(String title, String body, List<Long> memberId) {
-        List<String> tokens = fcmQueryRepository.findByMemberIdIn(memberId)
-            .stream()
-            .filter(token -> token.getMember().isPushEnabled())
-            .map(FcmToken::getToken)
-            .toList();
-
+    public FcmSendResult sendNotification(String title, String body, List<Long> memberIds) {
+        List<String> tokens = fcmQueryRepository.findEnabledTokensByMemberIds(memberIds);
         if(tokens.isEmpty()) {
             return new FcmSendResult(0, 0);
         }

--- a/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
+++ b/geulnamu_backend/src/main/java/com/geulnamu/service/meeting/MeetingService.java
@@ -81,8 +81,10 @@ public class MeetingService {
     )
     @Transactional(readOnly = true)
     public MeetingDetailResponse getMeeting(Long meetingId, Long memberId) {
-        Meeting meeting = findMeetingOrThrow(meetingId);
-        MeetingDetailResponse meetingDetailResponse = meetingQueryRepository.findMeeting(meeting.getId(), memberId);
+        MeetingDetailResponse meetingDetailResponse = meetingQueryRepository.findMeeting(meetingId, memberId);
+        if(meetingDetailResponse == null) {
+            throw new NotFoundDataException(DomainType.MEETING.getDescription());
+        }
         if(meetingDetailResponse.getDiscussionGroup() != null) {
             List<AttendanceIdAndNameResponse> groupMemberList = attendanceQueryRepository.findMyDiscussionMemberList(
                 meetingDetailResponse.getMeetingId(), meetingDetailResponse.getDiscussionGroup());


### PR DESCRIPTION
# 변경 내역
## 성능 개선
### JPA 관련
- 로직 중 N+1 관련 엔티티 관계 문제 개선
  - 엔티티 확인 후 불러오는 대신, 바로 엔티티의 값 불러오도록 쿼리 수정
## 의존성 관련 에러 수정
- 의존성이 제거되어서 사용되지 못하던 '앱 푸시' 기능, 의존성 추가하여 정상 동작하도록 수정